### PR TITLE
Add Markdown README

### DIFF
--- a/sitepulse_FR/README.md
+++ b/sitepulse_FR/README.md
@@ -1,0 +1,50 @@
+# Sitepulse - JLG
+
+**Contributors:** jeromelegousse  
+**Tags:** performance, monitoring, speed, database, server
+
+Monitors your WordPress site's speed, database, maintenance, server, and errors with modular, toggleable tools.
+
+## Description
+
+Sitepulse - JLG takes the pulse of your WordPress site, offering modules for:
+
+- Speed analysis (load times, TTFB)
+- Database optimization (clean bloat, suggest indexes)
+- Server monitoring (CPU, memory, uptime)
+- Error logging and alerts
+- Plugin impact analysis
+- Maintenance checks and AI insights
+- Custom dashboards and multisite support
+
+Toggle modules in the admin panel to keep it lightweight. Includes debug mode and cleanup options.
+
+## Installation
+
+1. Upload `sitepulse-jlg.zip` to your `/wp-content/plugins/` directory.
+2. Activate the plugin through the 'Plugins' menu in WordPress.
+3. Visit 'SitePulse' in your admin menu to configure the modules.
+
+## WordPress Compatibility
+
+- Requires at least: 5.0
+- Tested up to: 6.6
+- Stable tag: 1.0
+
+## License
+
+GPLv2 or later  
+[http://www.gnu.org/licenses/gpl-2.0.html](http://www.gnu.org/licenses/gpl-2.0.html)
+
+## Changelog
+
+### 1.0
+
+- Initial release with all core modules.
+
+## Upgrade Notice
+
+### 1.0
+
+- First version—full pulse-monitoring suite!
+


### PR DESCRIPTION
## Summary
- add Markdown-formatted README with compatibility, license, and changelog sections
- keep existing `readme.txt` for WordPress.org compatibility

## Testing
- `npm test` *(fails: Could not read package.json)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c744e2bb64832ea4b14a24b33a7cc8