### PR TITLE
Add capability checks to admin pages

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -81,6 +81,10 @@ function sitepulse_sanitize_modules($input) {
  * Renders the settings page.
  */
 function sitepulse_settings_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
+    }
+
     $modules = [
         'log_analyzer' => 'Log Analyzer', 'resource_monitor' => 'Resource Monitor', 'plugin_impact_scanner' => 'Plugin Impact Scanner',
         'speed_analyzer' => 'Speed Analyzer', 'database_optimizer' => 'Database Optimizer', 'maintenance_advisor' => 'Maintenance Advisor',
@@ -172,6 +176,10 @@ function sitepulse_settings_page() {
  * Renders the debug page.
  */
 function sitepulse_debug_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
+    }
+
     ?>
     <div class="wrap">
         <h1><span class="dashicons-before dashicons-bug"></span> Debug Dashboard</h1>

--- a/sitepulse_FR/modules/ai_insights.php
+++ b/sitepulse_FR/modules/ai_insights.php
@@ -2,6 +2,10 @@
 if (!defined('ABSPATH')) exit;
 add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'AI Insights', 'AI Insights', 'manage_options', 'sitepulse-ai', 'ai_insights_page'); });
 function ai_insights_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
+    }
+
     $api_key = get_option('sitepulse_gemini_api_key');
     $insight_result = get_transient('sitepulse_ai_insight');
     if (isset($_POST['get_ai_insight']) && check_admin_referer('sitepulse_get_ai_insight')) {

--- a/sitepulse_FR/modules/custom_dashboards.php
+++ b/sitepulse_FR/modules/custom_dashboards.php
@@ -19,6 +19,10 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly.
  * to prevent conflicts and duplicate menus.
  */
 function custom_dashboards_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
+    }
+
     global $wpdb;
     ?>
     <style>

--- a/sitepulse_FR/modules/database_optimizer.php
+++ b/sitepulse_FR/modules/database_optimizer.php
@@ -2,6 +2,10 @@
 if (!defined('ABSPATH')) exit;
 add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Database Optimizer', 'Database', 'manage_options', 'sitepulse-db', 'database_optimizer_page'); });
 function database_optimizer_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
+    }
+
     global $wpdb;
     if (isset($_POST['db_cleanup_nonce']) && wp_verify_nonce($_POST['db_cleanup_nonce'], 'db_cleanup')) {
         if (isset($_POST['clean_revisions'])) {

--- a/sitepulse_FR/modules/log_analyzer.php
+++ b/sitepulse_FR/modules/log_analyzer.php
@@ -17,6 +17,10 @@ add_action('admin_menu', function() {
  * Renders the Log Analyzer page with improved logic and explanations.
  */
 function sitepulse_log_analyzer_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
+    }
+
     $log_file = WP_CONTENT_DIR . '/debug.log';
     $log_file_exists = file_exists($log_file) && is_readable($log_file);
     $debug_log_enabled = defined('WP_DEBUG_LOG') && WP_DEBUG_LOG;

--- a/sitepulse_FR/modules/maintenance_advisor.php
+++ b/sitepulse_FR/modules/maintenance_advisor.php
@@ -2,6 +2,10 @@
 if (!defined('ABSPATH')) exit;
 add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Maintenance Advisor', 'Maintenance', 'manage_options', 'sitepulse-maintenance', 'maintenance_advisor_page'); });
 function maintenance_advisor_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
+    }
+
     require_once ABSPATH . 'wp-admin/includes/update.php';
     $core_updates = get_core_updates();
     $plugin_updates = get_plugin_updates();

--- a/sitepulse_FR/modules/plugin_impact_scanner.php
+++ b/sitepulse_FR/modules/plugin_impact_scanner.php
@@ -2,6 +2,10 @@
 if (!defined('ABSPATH')) exit;
 add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Plugin Impact Scanner', 'Plugin Impact', 'manage_options', 'sitepulse-plugins', 'plugin_impact_scanner_page'); });
 function plugin_impact_scanner_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
+    }
+
     if (!function_exists('get_plugins')) { require_once ABSPATH . 'wp-admin/includes/plugin.php'; }
     $all_plugins = get_plugins();
     $active_plugin_files = get_option('active_plugins');

--- a/sitepulse_FR/modules/resource_monitor.php
+++ b/sitepulse_FR/modules/resource_monitor.php
@@ -2,6 +2,10 @@
 if (!defined('ABSPATH')) exit;
 add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Resource Monitor', 'Resources', 'manage_options', 'sitepulse-resources', 'resource_monitor_page'); });
 function resource_monitor_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
+    }
+
     if (function_exists('sys_getloadavg')) { $load = sys_getloadavg(); } else { $load = ['N/A', 'N/A', 'N/A']; }
     ?>
     <div class="wrap">

--- a/sitepulse_FR/modules/speed_analyzer.php
+++ b/sitepulse_FR/modules/speed_analyzer.php
@@ -18,6 +18,10 @@ add_action('admin_menu', function() {
  * The analysis is now based on internal WordPress timers for better reliability.
  */
 function sitepulse_speed_analyzer_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
+    }
+
     global $wpdb;
 
     // --- Server Performance Metrics ---

--- a/sitepulse_FR/modules/uptime_tracker.php
+++ b/sitepulse_FR/modules/uptime_tracker.php
@@ -4,6 +4,10 @@ add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'U
 add_action('init', function() { if (!wp_next_scheduled('sitepulse_uptime_tracker_cron')) { wp_schedule_event(time(), 'hourly', 'sitepulse_uptime_tracker_cron'); } });
 add_action('sitepulse_uptime_tracker_cron', 'sitepulse_run_uptime_check');
 function uptime_tracker_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
+    }
+
     $uptime_log = get_option('sitepulse_uptime_log', []);
     $total_checks = count($uptime_log);
     $up_checks = count(array_filter($uptime_log));


### PR DESCRIPTION
## Summary
- add manage_options capability checks to every SitePulse admin page function and stop execution with wp_die when capability checks fail

## Testing
- php -l includes/admin-settings.php modules/ai_insights.php modules/custom_dashboards.php modules/database_optimizer.php modules/log_analyzer.php modules/maintenance_advisor.php modules/plugin_impact_scanner.php modules/resource_monitor.php modules/speed_analyzer.php modules/uptime_tracker.php

------
https://chatgpt.com/codex/tasks/task_e_68c847d17aa4832ea9e83190c72a6f4d