### PR TITLE
Remove rewrite flush on activation

### DIFF
--- a/sitepulse_FR/readme.txt
+++ b/sitepulse_FR/readme.txt
@@ -33,6 +33,7 @@ Toggle modules in the admin panel to keep it lightweight. Includes debug mode an
 
 = 1.0 =
 * Initial release with all core modules.
+* Removed the call to `flush_rewrite_rules()` on activation to avoid an unnecessary and costly permalink flush.
 
 == Upgrade Notice ==
 

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -88,7 +88,6 @@ register_activation_hook(__FILE__, function() {
     add_option('sitepulse_active_modules', ['custom_dashboards']);
     add_option('sitepulse_debug_mode', false);
     add_option('sitepulse_gemini_api_key', '');
-    flush_rewrite_rules();
 });
 
 /**


### PR DESCRIPTION
## Summary
- remove the unnecessary `flush_rewrite_rules()` call from the activation hook
- document the change and its rationale in the changelog

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c847d43cb8832ebefce8fb3ef22a3c