### PR TITLE
Handle debug log write failures

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -90,8 +90,14 @@ function sitepulse_settings_page() {
 
     if (isset($_POST['sitepulse_cleanup_nonce']) && wp_verify_nonce($_POST['sitepulse_cleanup_nonce'], 'sitepulse_cleanup')) {
         if (isset($_POST['sitepulse_clear_log']) && defined('SITEPULSE_DEBUG_LOG') && file_exists(SITEPULSE_DEBUG_LOG)) {
-            file_put_contents(SITEPULSE_DEBUG_LOG, '');
-            echo '<div class="notice notice-success is-dismissible"><p>Journal de débogage vidé.</p></div>';
+            $cleared = @file_put_contents(SITEPULSE_DEBUG_LOG, '');
+
+            if ($cleared === false) {
+                error_log(sprintf('SitePulse: unable to clear debug log file (%s).', SITEPULSE_DEBUG_LOG));
+                echo '<div class="notice notice-error is-dismissible"><p>Impossible de vider le journal de débogage. Vérifiez les permissions du fichier.</p></div>';
+            } else {
+                echo '<div class="notice notice-success is-dismissible"><p>Journal de débogage vidé.</p></div>';
+            }
         }
         if (isset($_POST['sitepulse_clear_data'])) {
             delete_option('sitepulse_uptime_log');

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -38,7 +38,11 @@ function sitepulse_log($message, $level = 'INFO') {
         @rename(SITEPULSE_DEBUG_LOG, $archive);
     }
 
-    file_put_contents(SITEPULSE_DEBUG_LOG, $log_entry, FILE_APPEND | LOCK_EX);
+    $result = @file_put_contents(SITEPULSE_DEBUG_LOG, $log_entry, FILE_APPEND | LOCK_EX);
+
+    if ($result === false) {
+        error_log(sprintf('SitePulse: unable to write to debug log file (%s).', SITEPULSE_DEBUG_LOG));
+    }
 }
 sitepulse_log('SitePulse loaded. Version: ' . SITEPULSE_VERSION);
 


### PR DESCRIPTION
## Summary
- log a PHP error when writing to the debug log fails so silent failures are avoided
- handle failures while clearing the debug log from the admin UI and display an error notice

## Testing
- php -l sitepulse_FR/sitepulse.php
- php -l sitepulse_FR/includes/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68c847da04bc832ea78be54f1af80fd0