### PR TITLE
Aligner les hooks cron sur les modules

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -115,7 +115,11 @@ function sitepulse_settings_page() {
             delete_option('sitepulse_uptime_log');
             delete_transient('sitepulse_speed_scan_results');
             if (defined('SITEPULSE_DEBUG_LOG') && file_exists(SITEPULSE_DEBUG_LOG)) { unlink(SITEPULSE_DEBUG_LOG); }
-            $cron_hooks = ['log_analyzer_cron', 'resource_monitor_cron', 'speed_analyzer_cron', 'database_optimizer_cron', 'maintenance_advisor_cron', 'uptime_tracker_cron', 'ai_insights_cron'];
+            $cron_hooks = [
+                'sitepulse_uptime_tracker_cron',
+                'sitepulse_resource_monitor_cron',
+                'sitepulse_log_analyzer_cron',
+            ];
             foreach($cron_hooks as $hook) { wp_clear_scheduled_hook($hook); }
             echo '<div class="notice notice-success is-dismissible"><p>SitePulse a été réinitialisé.</p></div>';
         }

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -99,7 +99,11 @@ register_activation_hook(__FILE__, function() {
  * Deactivation hook. Cleans up scheduled tasks.
  */
 register_deactivation_hook(__FILE__, function() {
-    $cron_hooks = ['sitepulse_cleanup_cron', 'log_analyzer_cron', 'resource_monitor_cron', 'speed_analyzer_cron', 'database_optimizer_cron', 'maintenance_advisor_cron', 'uptime_tracker_cron', 'ai_insights_cron'];
+    $cron_hooks = [
+        'sitepulse_uptime_tracker_cron',
+        'sitepulse_resource_monitor_cron',
+        'sitepulse_log_analyzer_cron',
+    ];
     foreach($cron_hooks as $hook) {
         wp_clear_scheduled_hook($hook);
     }

--- a/sitepulse_FR/uninstall.php
+++ b/sitepulse_FR/uninstall.php
@@ -25,14 +25,6 @@ $transients = [
 ];
 
 $cron_hooks = [
-    'sitepulse_cleanup_cron',
-    'log_analyzer_cron',
-    'resource_monitor_cron',
-    'speed_analyzer_cron',
-    'database_optimizer_cron',
-    'maintenance_advisor_cron',
-    'uptime_tracker_cron',
-    'ai_insights_cron',
     'sitepulse_uptime_tracker_cron',
     'sitepulse_resource_monitor_cron',
     'sitepulse_log_analyzer_cron',


### PR DESCRIPTION
## Summary
- aligne la liste des hooks WP-Cron nettoyés à la désactivation sur les identifiants réellement programmés par les modules
- applique la même liste lors de la réinitialisation dans l’administration et dans le script de désinstallation pour éviter les entrées orphelines

## Testing
- php -l sitepulse.php
- php -l includes/admin-settings.php
- php -l uninstall.php

------
https://chatgpt.com/codex/tasks/task_e_68c85cfa5544832eb75624ef54442fb1