### PR TITLE
Align cron hook identifiers across plugin

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -149,12 +149,10 @@ function sitepulse_settings_page() {
             delete_option('sitepulse_uptime_log');
             delete_transient('sitepulse_speed_scan_results');
             if (defined('SITEPULSE_DEBUG_LOG') && file_exists(SITEPULSE_DEBUG_LOG)) { unlink(SITEPULSE_DEBUG_LOG); }
-            $cron_hooks = [
-                'sitepulse_uptime_tracker_cron',
-                'sitepulse_resource_monitor_cron',
-                'sitepulse_log_analyzer_cron',
-            ];
-            foreach($cron_hooks as $hook) { wp_clear_scheduled_hook($hook); }
+            $cron_hooks = function_exists('sitepulse_get_cron_hooks') ? sitepulse_get_cron_hooks() : [];
+            foreach ($cron_hooks as $hook) {
+                wp_clear_scheduled_hook($hook);
+            }
             echo '<div class="notice notice-success is-dismissible"><p>SitePulse a été réinitialisé.</p></div>';
         }
     }

--- a/sitepulse_FR/includes/cron-hooks.php
+++ b/sitepulse_FR/includes/cron-hooks.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'uptime_tracker'    => 'sitepulse_uptime_tracker_cron',
+    'resource_monitor'  => 'sitepulse_resource_monitor_cron',
+    'log_analyzer'      => 'sitepulse_log_analyzer_cron',
+];

--- a/sitepulse_FR/modules/uptime_tracker.php
+++ b/sitepulse_FR/modules/uptime_tracker.php
@@ -1,8 +1,18 @@
 <?php
 if (!defined('ABSPATH')) exit;
+
+$sitepulse_uptime_cron_hook = function_exists('sitepulse_get_cron_hook') ? sitepulse_get_cron_hook('uptime_tracker') : 'sitepulse_uptime_tracker_cron';
+
 add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Uptime Tracker', 'Uptime', 'manage_options', 'sitepulse-uptime', 'uptime_tracker_page'); });
-add_action('init', function() { if (!wp_next_scheduled('sitepulse_uptime_tracker_cron')) { wp_schedule_event(time(), 'hourly', 'sitepulse_uptime_tracker_cron'); } });
-add_action('sitepulse_uptime_tracker_cron', 'sitepulse_run_uptime_check');
+
+if (!empty($sitepulse_uptime_cron_hook)) {
+    add_action('init', function() use ($sitepulse_uptime_cron_hook) {
+        if (!wp_next_scheduled($sitepulse_uptime_cron_hook)) {
+            wp_schedule_event(time(), 'hourly', $sitepulse_uptime_cron_hook);
+        }
+    });
+    add_action($sitepulse_uptime_cron_hook, 'sitepulse_run_uptime_check');
+}
 function uptime_tracker_page() {
     if (!current_user_can('manage_options')) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -20,6 +20,38 @@ define('SITEPULSE_DEBUG', (bool) $debug_mode);
 define('SITEPULSE_DEBUG_LOG', WP_CONTENT_DIR . '/sitepulse-debug.log');
 
 /**
+ * Returns the list of cron hook identifiers used across SitePulse modules.
+ *
+ * @return array<string, string> Associative array of module keys to cron hook names.
+ */
+function sitepulse_get_cron_hooks() {
+    static $cron_hooks = null;
+
+    if ($cron_hooks === null) {
+        $cron_hooks = require SITEPULSE_PATH . 'includes/cron-hooks.php';
+
+        if (!is_array($cron_hooks)) {
+            $cron_hooks = [];
+        }
+    }
+
+    return $cron_hooks;
+}
+
+/**
+ * Retrieves the cron hook name for a specific module.
+ *
+ * @param string $module_key Identifier of the module (e.g. uptime_tracker).
+ *
+ * @return string|null The cron hook name or null if none exists.
+ */
+function sitepulse_get_cron_hook($module_key) {
+    $cron_hooks = sitepulse_get_cron_hooks();
+
+    return isset($cron_hooks[$module_key]) ? $cron_hooks[$module_key] : null;
+}
+
+/**
  * Logging function for debugging purposes.
  *
  * @param string $message The message to log.
@@ -101,12 +133,7 @@ register_activation_hook(__FILE__, function() {
  * Deactivation hook. Cleans up scheduled tasks.
  */
 register_deactivation_hook(__FILE__, function() {
-    $cron_hooks = [
-        'sitepulse_uptime_tracker_cron',
-        'sitepulse_resource_monitor_cron',
-        'sitepulse_log_analyzer_cron',
-    ];
-    foreach($cron_hooks as $hook) {
+    foreach (sitepulse_get_cron_hooks() as $hook) {
         wp_clear_scheduled_hook($hook);
     }
 });

--- a/sitepulse_FR/uninstall.php
+++ b/sitepulse_FR/uninstall.php
@@ -28,11 +28,10 @@ $transients = [
     'sitepulse_error_alert_php_fatal_lock',
 ];
 
-$cron_hooks = [
-    'sitepulse_uptime_tracker_cron',
-    'sitepulse_resource_monitor_cron',
-    'sitepulse_log_analyzer_cron',
-];
+$cron_hooks = require __DIR__ . '/includes/cron-hooks.php';
+if (!is_array($cron_hooks)) {
+    $cron_hooks = [];
+}
 
 /**
  * Removes plugin data for a single site.


### PR DESCRIPTION
## Summary
- centralize SitePulse cron hook identifiers in a shared include and helper accessors
- update module scheduling, admin reset, and uninstall cleanup to use the shared cron hook list
- guard module cron handlers behind the shared identifiers to keep scheduled and cleared hooks aligned

## Testing
- php -l sitepulse.php
- php -l includes/admin-settings.php
- php -l modules/error_alerts.php
- php -l modules/uptime_tracker.php
- php -l uninstall.php
- php -l includes/cron-hooks.php

------
https://chatgpt.com/codex/tasks/task_e_68c864e6c53c832e89f8fb6e06043692