### PR TITLE
Handle missing speed scan data

### DIFF
--- a/sitepulse_FR/modules/custom_dashboards.php
+++ b/sitepulse_FR/modules/custom_dashboards.php
@@ -43,7 +43,8 @@ function custom_dashboards_page() {
             <!-- Speed Card -->
             <div class="sitepulse-card">
                 <?php
-                $ttfb = get_transient('sitepulse_speed_scan_results')['ttfb'] ?? 0;
+                $results = get_transient('sitepulse_speed_scan_results');
+                $ttfb = (is_array($results) && isset($results['ttfb'])) ? $results['ttfb'] : 0;
                 $ttfb_status = $ttfb > 500 ? 'status-bad' : ($ttfb > 200 ? 'status-warn' : 'status-ok');
                 ?>
                 <?php $ttfb_display = $ttfb ? round($ttfb) . ' ms' : 'N/A'; ?>


### PR DESCRIPTION
## Summary
- store the SitePulse speed scan transient before using its data
- guard access to the TTFB metric and display a fallback when results are unavailable

## Testing
- php -l modules/custom_dashboards.php

------
https://chatgpt.com/codex/tasks/task_e_68c8786a7144832e85180908e6cb85bf