### PR TITLE
Handle unreadable module files gracefully

### DIFF
--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -104,14 +104,22 @@ function sitepulse_load_modules() {
     sitepulse_log('Loading active modules: ' . implode(', ', $active_modules));
     
     foreach ($active_modules as $module_key) {
-        if (array_key_exists($module_key, $modules) && file_exists(SITEPULSE_PATH . 'modules/' . $module_key . '.php')) {
-            try {
-                require_once SITEPULSE_PATH . 'modules/' . $module_key . '.php';
-            } catch (Exception $e) {
-                sitepulse_log("Error loading module $module_key: " . $e->getMessage(), 'ERROR');
-            }
-        } else {
+        if (!array_key_exists($module_key, $modules)) {
             sitepulse_log("Module $module_key not found or invalid", 'WARNING');
+            continue;
+        }
+
+        $module_path = SITEPULSE_PATH . 'modules/' . $module_key . '.php';
+
+        if (!is_readable($module_path)) {
+            sitepulse_log("Module file for $module_key is not readable: $module_path", 'ERROR');
+            continue;
+        }
+
+        $include_result = include_once $module_path;
+
+        if ($include_result === false) {
+            sitepulse_log("Failed to load module $module_key from $module_path", 'ERROR');
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the module loading try/catch with a readability check before including module files
- log missing modules, unreadable files, and failed includes via `sitepulse_log` instead of relying on exceptions

## Testing
- php -l sitepulse.php

------
https://chatgpt.com/codex/tasks/task_e_68c888d918e4832eb966e67a51383b41