### PR TITLE
Measure and display real plugin load times

### DIFF
--- a/sitepulse_FR/modules/plugin_impact_scanner.php
+++ b/sitepulse_FR/modules/plugin_impact_scanner.php
@@ -1,36 +1,286 @@
 <?php
-if (!defined('ABSPATH')) exit;
-add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Plugin Impact Scanner', 'Plugin Impact', 'manage_options', 'sitepulse-plugins', 'plugin_impact_scanner_page'); });
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+add_action(
+    'admin_menu',
+    function () {
+        add_submenu_page(
+            'sitepulse-dashboard',
+            'Plugin Impact Scanner',
+            'Plugin Impact',
+            'manage_options',
+            'sitepulse-plugins',
+            'plugin_impact_scanner_page'
+        );
+    }
+);
+
 function plugin_impact_scanner_page() {
     if (!current_user_can('manage_options')) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }
 
-    if (!function_exists('get_plugins')) { require_once ABSPATH . 'wp-admin/includes/plugin.php'; }
-    $all_plugins = get_plugins();
-    $active_plugin_files = get_option('active_plugins');
-    $impacts = []; $total_impact = 0;
-    foreach ($active_plugin_files as $plugin_file) {
-        $impact_ms = rand(5, 150);
-        $impacts[$plugin_file] = [ 'name' => $all_plugins[$plugin_file]['Name'], 'impact' => $impact_ms, 'disk_space' => sitepulse_get_dir_size_recursive(WP_PLUGIN_DIR . '/' . dirname($plugin_file)) ];
-        $total_impact += $impact_ms;
+    if (!function_exists('get_plugins')) {
+        require_once ABSPATH . 'wp-admin/includes/plugin.php';
     }
-    uasort($impacts, function($a, $b) { return $b['impact'] <=> $a['impact']; });
+
+    $all_plugins = get_plugins();
+    $active_plugin_files = get_option('active_plugins', []);
+
+    if (!is_array($active_plugin_files)) {
+        $active_plugin_files = [];
+    }
+
+    $measurements = sitepulse_plugin_impact_get_measurements();
+
+    if (!empty($_POST['sitepulse_plugin_impact_refresh'])) {
+        check_admin_referer('sitepulse_plugin_impact_refresh');
+
+        if (function_exists('sitepulse_plugin_impact_force_next_persist')) {
+            sitepulse_plugin_impact_force_next_persist(true);
+        } else {
+            $option_key = defined('SITEPULSE_PLUGIN_IMPACT_OPTION') ? SITEPULSE_PLUGIN_IMPACT_OPTION : 'sitepulse_plugin_impact_stats';
+            delete_option($option_key);
+        }
+
+        add_settings_error(
+            'sitepulse_plugin_impact',
+            'sitepulse_plugin_impact_refreshed',
+            esc_html__("Une nouvelle série de mesures sera enregistrée à la fin de cette requête.", 'sitepulse'),
+            'updated'
+        );
+    }
+
+    $samples = isset($measurements['samples']) && is_array($measurements['samples']) ? $measurements['samples'] : [];
+    $default_interval = defined('SITEPULSE_PLUGIN_IMPACT_REFRESH_INTERVAL') ? SITEPULSE_PLUGIN_IMPACT_REFRESH_INTERVAL : 15 * MINUTE_IN_SECONDS;
+    $last_updated = isset($measurements['last_updated']) ? (int) $measurements['last_updated'] : 0;
+    $interval = isset($measurements['interval']) ? max(1, (int) $measurements['interval']) : $default_interval;
+
+    $current_time = current_time('timestamp');
+    $next_refresh = $last_updated > 0 ? $last_updated + $interval : 0;
+
+    $impacts = [];
+    $total_impact = 0.0;
+    $measured_count = 0;
+
+    foreach ($active_plugin_files as $plugin_file) {
+        $plugin_name = isset($all_plugins[$plugin_file]['Name']) ? $all_plugins[$plugin_file]['Name'] : $plugin_file;
+
+        $impact_data = [
+            'file'          => $plugin_file,
+            'name'          => $plugin_name,
+            'impact'        => null,
+            'last_ms'       => null,
+            'samples'       => 0,
+            'last_recorded' => null,
+            'disk_space'    => sitepulse_get_dir_size_recursive(WP_PLUGIN_DIR . '/' . dirname($plugin_file)),
+        ];
+
+        if (isset($samples[$plugin_file]) && is_array($samples[$plugin_file])) {
+            $sample = $samples[$plugin_file];
+
+            if (isset($sample['avg_ms'])) {
+                $impact_data['impact'] = max(0.0, (float) $sample['avg_ms']);
+            }
+
+            if (isset($sample['last_ms'])) {
+                $impact_data['last_ms'] = max(0.0, (float) $sample['last_ms']);
+            }
+
+            if (isset($sample['samples'])) {
+                $impact_data['samples'] = max(0, (int) $sample['samples']);
+            }
+
+            if (isset($sample['last_recorded'])) {
+                $impact_data['last_recorded'] = (int) $sample['last_recorded'];
+            }
+        }
+
+        if ($impact_data['impact'] !== null) {
+            $total_impact += $impact_data['impact'];
+            $measured_count++;
+        }
+
+        $impacts[$plugin_file] = $impact_data;
+    }
+
+    uasort(
+        $impacts,
+        function ($a, $b) {
+            $a_measured = $a['impact'] !== null;
+            $b_measured = $b['impact'] !== null;
+
+            if ($a_measured && $b_measured) {
+                if ($a['impact'] === $b['impact']) {
+                    return strcasecmp($a['name'], $b['name']);
+                }
+
+                return $b['impact'] <=> $a['impact'];
+            }
+
+            if ($a_measured) {
+                return -1;
+            }
+
+            if ($b_measured) {
+                return 1;
+            }
+
+            return strcasecmp($a['name'], $b['name']);
+        }
+    );
+
+    $total_plugins = count($impacts);
+
+    $coverage_text = sprintf(
+        /* translators: 1: measured plugins count, 2: total active plugins count. */
+        __('Plugins chronométrés : %1$d sur %2$d.', 'sitepulse'),
+        (int) $measured_count,
+        (int) $total_plugins
+    );
+
+    if ($last_updated > 0) {
+        $formatted_date = function_exists('wp_date')
+            ? wp_date(get_option('date_format') . ' ' . get_option('time_format'), $last_updated)
+            : date_i18n(get_option('date_format') . ' ' . get_option('time_format'), $last_updated);
+
+        $relative_date = sprintf(
+            /* translators: %s: human time diff. */
+            __('il y a %s', 'sitepulse'),
+            human_time_diff($last_updated, $current_time)
+        );
+
+        $last_updated_text = sprintf(
+            /* translators: 1: formatted datetime, 2: human readable diff. */
+            __('Dernière actualisation : %1$s (%2$s).', 'sitepulse'),
+            $formatted_date,
+            $relative_date
+        );
+    } else {
+        $last_updated_text = __('Dernière actualisation : aucune donnée collectée pour le moment.', 'sitepulse');
+    }
+
+    if ($next_refresh > $current_time) {
+        $refresh_text = sprintf(
+            __('Prochain échantillonnage automatique possible dans %s.', 'sitepulse'),
+            human_time_diff($current_time, $next_refresh)
+        );
+    } else {
+        $refresh_text = __('Les mesures seront mises à jour à la fin du prochain chargement de page.', 'sitepulse');
+    }
+
+    $interval_text = sprintf(
+        __('Intervalle de rafraîchissement : %s maximum.', 'sitepulse'),
+        sitepulse_plugin_impact_format_interval($interval)
+    );
     ?>
-    <style> .impact-bar-bg { background: #eee; border-radius: 3px; overflow: hidden; width: 100%; } .impact-bar { height: 18px; border-radius: 3px; background-color: #FFC107; text-align: right; color: white; padding-right: 5px; white-space: nowrap; font-size: 12px; line-height: 18px; } </style>
+    <style>
+        .impact-bar-bg { background: #eee; border-radius: 3px; overflow: hidden; width: 100%; }
+        .impact-bar { height: 18px; border-radius: 3px; background-color: #FFC107; text-align: right; color: white; padding-right: 5px; white-space: nowrap; font-size: 12px; line-height: 18px; }
+        .sitepulse-impact-meta { margin-bottom: 1em; }
+        .sitepulse-impact-meta p { margin: 0.2em 0; }
+        .sitepulse-impact-limitations { list-style: disc; margin-left: 1.5em; }
+    </style>
     <div class="wrap">
-        <h1><span class="dashicons-before dashicons-filter"></span> Analyseur d'Impact des Plugins</h1>
-        <p>Cet outil fournit une <strong>simulation</strong> de la contribution de chaque plugin actif au temps de chargement et à l'utilisation des ressources.</p>
+        <h1><span class="dashicons-before dashicons-filter"></span> <?php esc_html_e("Analyseur d'Impact des Plugins", 'sitepulse'); ?></h1>
+
+        <?php settings_errors('sitepulse_plugin_impact'); ?>
+
+        <p><?php esc_html_e('Les temps affichés ci-dessous proviennent du chronométrage réel du chargement de chaque plugin actif.', 'sitepulse'); ?></p>
+
+        <div class="notice notice-info sitepulse-impact-meta">
+            <p><?php echo esc_html($last_updated_text); ?></p>
+            <p><?php echo esc_html($interval_text); ?></p>
+            <p><?php echo esc_html($refresh_text); ?></p>
+            <p><?php echo esc_html($coverage_text); ?></p>
+        </div>
+
+        <p><?php esc_html_e('Limitations connues :', 'sitepulse'); ?></p>
+        <ul class="sitepulse-impact-limitations">
+            <li><?php esc_html_e('les mesures correspondent au temps écoulé entre le chargement de deux plugins consécutifs via le hook « plugin_loaded » ; elles reflètent donc l’impact relatif sur la phase de bootstrap.', 'sitepulse'); ?></li>
+            <li><?php esc_html_e('les plugins chargés avant SitePulse ne peuvent pas être chronométrés directement et apparaissent comme « non mesurés » tant que leur ordre de chargement n’est pas modifié.', 'sitepulse'); ?></li>
+            <li><?php esc_html_e('les valeurs sont moyennées pour lisser les variations ponctuelles ; les caches d’opcode peuvent réduire artificiellement certaines durées.', 'sitepulse'); ?></li>
+        </ul>
+
+        <form method="post" class="sitepulse-impact-refresh">
+            <?php wp_nonce_field('sitepulse_plugin_impact_refresh'); ?>
+            <?php submit_button(__('Forcer un nouvel échantillon maintenant', 'sitepulse'), 'secondary', 'sitepulse_plugin_impact_refresh', false); ?>
+        </form>
+
         <table class="wp-list-table widefat striped">
-            <thead><tr><th scope="col" style="width: 25%;">Plugin</th><th scope="col">Impact (Simulé)</th><th scope="col">Espace Disque</th><th scope="col" style="width: 35%;">Poids Relatif</th></tr></thead>
+            <thead>
+                <tr>
+                    <th scope="col" style="width: 25%;"><?php esc_html_e('Plugin', 'sitepulse'); ?></th>
+                    <th scope="col"><?php esc_html_e('Durée mesurée', 'sitepulse'); ?></th>
+                    <th scope="col"><?php esc_html_e('Espace disque', 'sitepulse'); ?></th>
+                    <th scope="col" style="width: 35%;"><?php esc_html_e('Poids relatif', 'sitepulse'); ?></th>
+                </tr>
+            </thead>
             <tbody>
-                <?php if (empty($impacts)): ?><tr><td colspan="4">Aucun plugin actif à scanner.</td></tr><?php else: ?>
-                    <?php foreach ($impacts as $data): $weight = $total_impact > 0 ? ($data['impact'] / $total_impact) * 100 : 0; $weight_color = $weight > 20 ? '#F44336' : ($weight > 10 ? '#FFC107' : '#4CAF50'); ?>
+                <?php if (empty($impacts)) : ?>
+                    <tr><td colspan="4"><?php esc_html_e('Aucun plugin actif à analyser.', 'sitepulse'); ?></td></tr>
+                <?php else : ?>
+                    <?php foreach ($impacts as $data) :
+                        $weight = ($total_impact > 0 && $data['impact'] !== null) ? ($data['impact'] / $total_impact) * 100 : null;
+                        $weight_color = '#4CAF50';
+
+                        if (is_numeric($weight)) {
+                            if ($weight > 20) {
+                                $weight_color = '#F44336';
+                            } elseif ($weight > 10) {
+                                $weight_color = '#FFC107';
+                            }
+                        }
+
+                        $impact_lines = [];
+
+                        if ($data['impact'] !== null) {
+                            $impact_lines[] = sprintf(
+                                /* translators: %s: duration in milliseconds */
+                                __('Moyenne glissante : %s ms', 'sitepulse'),
+                                number_format_i18n($data['impact'], 2)
+                            );
+
+                            $last_value = $data['last_ms'] !== null ? $data['last_ms'] : $data['impact'];
+                            $impact_lines[] = sprintf(
+                                __('Dernière mesure : %s ms', 'sitepulse'),
+                                number_format_i18n($last_value, 2)
+                            );
+
+                            if ($data['last_recorded']) {
+                                $impact_lines[] = sprintf(
+                                    __('Enregistré il y a %s', 'sitepulse'),
+                                    human_time_diff($data['last_recorded'], $current_time)
+                                );
+                            }
+
+                            $impact_lines[] = sprintf(
+                                __('Nombre d’échantillons : %d', 'sitepulse'),
+                                max(1, (int) $data['samples'])
+                            );
+                        } else {
+                            $impact_lines[] = __('Non mesuré pour le moment.', 'sitepulse');
+                        }
+
+                        $impact_output = implode('<br />', array_map('esc_html', $impact_lines));
+                    ?>
                     <tr>
                         <td><strong><?php echo esc_html($data['name']); ?></strong></td>
-                        <td><?php echo esc_html($data['impact']); ?> ms</td>
+                        <td><?php echo $impact_output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
                         <td><?php echo esc_html(size_format($data['disk_space'], 2)); ?></td>
-                        <td><div class="impact-bar-bg"><div class="impact-bar" style="width: <?php echo esc_attr($weight); ?>%; background-color: <?php echo esc_attr($weight_color); ?>;"><?php echo esc_html(round($weight, 1)); ?>%</div></div></td>
+                        <td>
+                            <?php if ($weight !== null) : ?>
+                                <div class="impact-bar-bg">
+                                    <div class="impact-bar" style="width: <?php echo esc_attr(min(100, $weight)); ?>%; background-color: <?php echo esc_attr($weight_color); ?>;">
+                                        <?php echo esc_html(number_format_i18n($weight, 1)); ?>%
+                                    </div>
+                                </div>
+                            <?php else : ?>
+                                <em><?php esc_html_e('n/d', 'sitepulse'); ?></em>
+                            <?php endif; ?>
+                        </td>
                     </tr>
                     <?php endforeach; ?>
                 <?php endif; ?>
@@ -39,10 +289,78 @@ function plugin_impact_scanner_page() {
     </div>
     <?php
 }
+
+function sitepulse_plugin_impact_get_measurements() {
+    $option_key = defined('SITEPULSE_PLUGIN_IMPACT_OPTION') ? SITEPULSE_PLUGIN_IMPACT_OPTION : 'sitepulse_plugin_impact_stats';
+    $data = get_option($option_key, []);
+
+    if (!is_array($data)) {
+        $data = [];
+    }
+
+    $default_interval = defined('SITEPULSE_PLUGIN_IMPACT_REFRESH_INTERVAL') ? SITEPULSE_PLUGIN_IMPACT_REFRESH_INTERVAL : 15 * MINUTE_IN_SECONDS;
+
+    return [
+        'last_updated' => isset($data['last_updated']) ? (int) $data['last_updated'] : 0,
+        'interval'     => isset($data['interval']) ? max(1, (int) $data['interval']) : $default_interval,
+        'samples'      => isset($data['samples']) && is_array($data['samples']) ? $data['samples'] : [],
+    ];
+}
+
+function sitepulse_plugin_impact_format_interval($seconds) {
+    $seconds = (int) $seconds;
+
+    if ($seconds <= 0) {
+        return __('immédiatement', 'sitepulse');
+    }
+
+    if ($seconds < MINUTE_IN_SECONDS) {
+        $value = max(1, $seconds);
+
+        return sprintf(
+            _n('%s seconde', '%s secondes', $value, 'sitepulse'),
+            number_format_i18n($value)
+        );
+    }
+
+    if ($seconds < HOUR_IN_SECONDS) {
+        $minutes = max(1, (int) round($seconds / MINUTE_IN_SECONDS));
+
+        return sprintf(
+            _n('%s minute', '%s minutes', $minutes, 'sitepulse'),
+            number_format_i18n($minutes)
+        );
+    }
+
+    if ($seconds < DAY_IN_SECONDS) {
+        $hours = max(1, (int) round($seconds / HOUR_IN_SECONDS));
+
+        return sprintf(
+            _n('%s heure', '%s heures', $hours, 'sitepulse'),
+            number_format_i18n($hours)
+        );
+    }
+
+    $days = max(1, (int) round($seconds / DAY_IN_SECONDS));
+
+    return sprintf(
+        _n('%s jour', '%s jours', $days, 'sitepulse'),
+        number_format_i18n($days)
+    );
+}
+
 function sitepulse_get_dir_size_recursive($dir) {
     $size = 0;
-    if (!is_dir($dir)) return $size;
+
+    if (!is_dir($dir)) {
+        return $size;
+    }
+
     $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS));
-    foreach ($iterator as $file) { $size += $file->getSize(); }
+
+    foreach ($iterator as $file) {
+        $size += $file->getSize();
+    }
+
     return $size;
 }


### PR DESCRIPTION
## Summary
- instrument plugin loading to capture elapsed time per plugin and persist rolling averages
- update the plugin impact admin page to show measured durations, refresh controls and documented limitations

## Testing
- php -l sitepulse_FR/sitepulse.php
- php -l sitepulse_FR/modules/plugin_impact_scanner.php

------
https://chatgpt.com/codex/tasks/task_e_68c88f93964c832ea47feb59eed097bf