### PR TITLE
Prefix module page callbacks with sitepulse_

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -18,7 +18,7 @@ function sitepulse_admin_menu() {
         'Sitepulse - JLG',
         'manage_options',
         'sitepulse-dashboard',
-        'custom_dashboards_page',
+        'sitepulse_custom_dashboards_page',
         'dashicons-chart-area',
         30
     );

--- a/sitepulse_FR/modules/ai_insights.php
+++ b/sitepulse_FR/modules/ai_insights.php
@@ -1,7 +1,7 @@
 <?php
 if (!defined('ABSPATH')) exit;
-add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'AI Insights', 'AI Insights', 'manage_options', 'sitepulse-ai', 'ai_insights_page'); });
-function ai_insights_page() {
+add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'AI Insights', 'AI Insights', 'manage_options', 'sitepulse-ai', 'sitepulse_ai_insights_page'); });
+function sitepulse_ai_insights_page() {
     if (!current_user_can('manage_options')) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }

--- a/sitepulse_FR/modules/custom_dashboards.php
+++ b/sitepulse_FR/modules/custom_dashboards.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly.
  * Note: The menu registration for this page is now handled in 'admin-settings.php'
  * to prevent conflicts and duplicate menus.
  */
-function custom_dashboards_page() {
+function sitepulse_custom_dashboards_page() {
     if (!current_user_can('manage_options')) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }

--- a/sitepulse_FR/modules/database_optimizer.php
+++ b/sitepulse_FR/modules/database_optimizer.php
@@ -1,7 +1,7 @@
 <?php
 if (!defined('ABSPATH')) exit;
-add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Database Optimizer', 'Database', 'manage_options', 'sitepulse-db', 'database_optimizer_page'); });
-function database_optimizer_page() {
+add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Database Optimizer', 'Database', 'manage_options', 'sitepulse-db', 'sitepulse_database_optimizer_page'); });
+function sitepulse_database_optimizer_page() {
     if (!current_user_can('manage_options')) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }

--- a/sitepulse_FR/modules/maintenance_advisor.php
+++ b/sitepulse_FR/modules/maintenance_advisor.php
@@ -1,7 +1,7 @@
 <?php
 if (!defined('ABSPATH')) exit;
-add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Maintenance Advisor', 'Maintenance', 'manage_options', 'sitepulse-maintenance', 'maintenance_advisor_page'); });
-function maintenance_advisor_page() {
+add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Maintenance Advisor', 'Maintenance', 'manage_options', 'sitepulse-maintenance', 'sitepulse_maintenance_advisor_page'); });
+function sitepulse_maintenance_advisor_page() {
     if (!current_user_can('manage_options')) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }

--- a/sitepulse_FR/modules/plugin_impact_scanner.php
+++ b/sitepulse_FR/modules/plugin_impact_scanner.php
@@ -1,7 +1,7 @@
 <?php
 if (!defined('ABSPATH')) exit;
-add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Plugin Impact Scanner', 'Plugin Impact', 'manage_options', 'sitepulse-plugins', 'plugin_impact_scanner_page'); });
-function plugin_impact_scanner_page() {
+add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Plugin Impact Scanner', 'Plugin Impact', 'manage_options', 'sitepulse-plugins', 'sitepulse_plugin_impact_scanner_page'); });
+function sitepulse_plugin_impact_scanner_page() {
     if (!current_user_can('manage_options')) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }

--- a/sitepulse_FR/modules/resource_monitor.php
+++ b/sitepulse_FR/modules/resource_monitor.php
@@ -1,7 +1,7 @@
 <?php
 if (!defined('ABSPATH')) exit;
-add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Resource Monitor', 'Resources', 'manage_options', 'sitepulse-resources', 'resource_monitor_page'); });
-function resource_monitor_page() {
+add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Resource Monitor', 'Resources', 'manage_options', 'sitepulse-resources', 'sitepulse_resource_monitor_page'); });
+function sitepulse_resource_monitor_page() {
     if (!current_user_can('manage_options')) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }

--- a/sitepulse_FR/modules/uptime_tracker.php
+++ b/sitepulse_FR/modules/uptime_tracker.php
@@ -3,7 +3,7 @@ if (!defined('ABSPATH')) exit;
 
 $sitepulse_uptime_cron_hook = function_exists('sitepulse_get_cron_hook') ? sitepulse_get_cron_hook('uptime_tracker') : 'sitepulse_uptime_tracker_cron';
 
-add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Uptime Tracker', 'Uptime', 'manage_options', 'sitepulse-uptime', 'uptime_tracker_page'); });
+add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Uptime Tracker', 'Uptime', 'manage_options', 'sitepulse-uptime', 'sitepulse_uptime_tracker_page'); });
 
 if (!empty($sitepulse_uptime_cron_hook)) {
     add_action('init', function() use ($sitepulse_uptime_cron_hook) {
@@ -13,7 +13,7 @@ if (!empty($sitepulse_uptime_cron_hook)) {
     });
     add_action($sitepulse_uptime_cron_hook, 'sitepulse_run_uptime_check');
 }
-function uptime_tracker_page() {
+function sitepulse_uptime_tracker_page() {
     if (!current_user_can('manage_options')) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }


### PR DESCRIPTION
## Summary
- prefix each module's global admin page callback with `sitepulse_`
- update menu and submenu registrations to reference the renamed callbacks

## Testing
- for file in modules/maintenance_advisor.php modules/resource_monitor.php modules/database_optimizer.php modules/plugin_impact_scanner.php modules/custom_dashboards.php modules/uptime_tracker.php modules/ai_insights.php includes/admin-settings.php; do php -l $file; done

------
https://chatgpt.com/codex/tasks/task_e_68c91c8fd14c832e96210038c79975c7