### PR TITLE
Handle missing timestart in speed analyzer

### DIFF
--- a/sitepulse_FR/modules/speed_analyzer.php
+++ b/sitepulse_FR/modules/speed_analyzer.php
@@ -28,7 +28,8 @@ function sitepulse_speed_analyzer_page() {
 
     // 1. Page Generation Time (Backend processing)
     // **FIX:** Replaced timer_stop() with a direct microtime calculation to prevent non-numeric value warnings in specific environments.
-    $page_generation_time = (microtime(true) - $GLOBALS['timestart']) * 1000; // in milliseconds
+    $timestart = isset($GLOBALS['timestart']) ? $GLOBALS['timestart'] : microtime(true);
+    $page_generation_time = (microtime(true) - $timestart) * 1000; // in milliseconds
 
     // 2. Database Query Time & Count
     $db_query_total_time = 0;


### PR DESCRIPTION
## Summary
- add a fallback when the WordPress $timestart global is not populated before computing the page generation time
- use the fallback variable in the microtime calculation to avoid PHP notices on the Speed page

## Testing
- php -l modules/speed_analyzer.php

------
https://chatgpt.com/codex/tasks/task_e_68c945ff37a0832e8dcfe5d1f1a4b1c6