### PR TITLE
Use strict module sanitization for admin settings

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -75,7 +75,7 @@ function sitepulse_sanitize_modules($input) {
     $sanitized = [];
     if (is_array($input)) {
         foreach ($input as $key) {
-            if (in_array($key, $valid_keys)) {
+            if (in_array($key, $valid_keys, true)) {
                 $sanitized[] = $key;
             }
         }


### PR DESCRIPTION
## Summary
- enforce strict key comparison when sanitizing admin module selections

## Testing
- php -r "define('ABSPATH', __DIR__); function add_action(){} include 'WP-Sitepulse/sitepulse_FR/includes/admin-settings.php'; var_export(sitepulse_sanitize_modules(['log_analyzer','invalid',123,'error_alerts', '0']));"


------
https://chatgpt.com/codex/tasks/task_e_68c945f94fc4832e9f3e6b031692fabd