### PR TITLE
Adjust reset button layout with confirmation spacing

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -310,7 +310,10 @@ function sitepulse_settings_page() {
                 </tr>
                 <tr>
                     <th scope="row"><label>Réinitialiser le plugin</label></th>
-                    <td><input type="submit" name="sitepulse_reset_all" value="Tout réinitialiser" class="button button-danger" onclick="return confirm('Êtes-vous sûr ?');"><p class="description">Réinitialise SitePulse à son état d'installation initial.</p></td>
+                    <td>
+                        <input type="submit" name="sitepulse_reset_all" value="Tout réinitialiser" class="button button-danger" onclick="return confirm('Êtes-vous sûr ?');">
+                        <p class="description">Réinitialise SitePulse à son état d'installation initial.</p>
+                    </td>
                 </tr>
             </table>
         </form>


### PR DESCRIPTION
## Summary
- reformat the reset button markup in the settings page table for improved readability
- ensure the reset button keeps the `onclick` confirmation handler with a space after the class attribute

## Testing
- php -l includes/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68c9b330dc38832e8f03615ba8dd4fec