### PR TITLE
Add cron scheduling for error alerts module

### DIFF
--- a/sitepulse_FR/includes/cron-hooks.php
+++ b/sitepulse_FR/includes/cron-hooks.php
@@ -2,6 +2,7 @@
 
 return [
     'uptime_tracker'    => 'sitepulse_uptime_tracker_cron',
+    'error_alerts'      => 'sitepulse_error_alerts_cron',
     'resource_monitor'  => 'sitepulse_resource_monitor_cron',
     'log_analyzer'      => 'sitepulse_log_analyzer_cron',
 ];


### PR DESCRIPTION
## Summary
- add a cron schedule registration and scheduler for the error alerts module so CPU and log checks run automatically
- consolidate the CPU load and debug log checks into dedicated functions executed by the cron hook
- register the new error alerts cron hook for cleanup by module and plugin deactivation

## Testing
- `php -l modules/error_alerts.php`
- `php -l includes/cron-hooks.php`


------
https://chatgpt.com/codex/tasks/task_e_68c9cfae3b08832e96196f61af94c08c