### PR TITLE
Handle unreadable directories in size calculator

### DIFF
--- a/sitepulse_FR/modules/plugin_impact_scanner.php
+++ b/sitepulse_FR/modules/plugin_impact_scanner.php
@@ -356,9 +356,28 @@ function sitepulse_get_dir_size_recursive($dir) {
         return $size;
     }
 
-    $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS));
+    try {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS)
+        );
+    } catch (\UnexpectedValueException | \RuntimeException $e) {
+        if (function_exists('sitepulse_log')) {
+            sitepulse_log(
+                sprintf(
+                    'Failed to scan directory "%s": %s',
+                    $dir,
+                    $e->getMessage()
+                )
+            );
+        }
+
+        return 0;
+    }
 
     foreach ($iterator as $file) {
+        if (!$file->isReadable()) {
+            continue;
+        }
         $size += $file->getSize();
     }
 


### PR DESCRIPTION
## Summary
- wrap RecursiveDirectoryIterator creation in a try/catch to handle unreadable directories
- log failures via sitepulse_log when available and return zero on error
- skip unreadable files while aggregating plugin directory sizes

## Testing
- php -l modules/plugin_impact_scanner.php

------
https://chatgpt.com/codex/tasks/task_e_68ca8405b4ec832ead437743f6244d2f