### PR TITLE
Ensure debug mode checkbox posts explicit off value

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -332,6 +332,7 @@ function sitepulse_settings_page() {
                 <tr>
                     <th scope="row"><label for="sitepulse_debug_mode">Activer le Mode Debug</label></th>
                     <td>
+                        <input type="hidden" name="sitepulse_debug_mode" value="0">
                         <input type="checkbox" id="sitepulse_debug_mode" name="sitepulse_debug_mode" value="1" <?php checked(get_option('sitepulse_debug_mode')); ?>>
                         <p class="description">Active la journalisation détaillée et le tableau de bord de débogage. À n'utiliser que pour le dépannage.</p>
                     </td>


### PR DESCRIPTION
## Summary
- add a hidden field for the debug mode checkbox to force submission of a 0 value when unchecked

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cac03351c0832eaa6fe960d6fd431d