### PR TITLE
Add plugin impact option to uninstall cleanup

### DIFF
--- a/sitepulse_FR/uninstall.php
+++ b/sitepulse_FR/uninstall.php
@@ -19,6 +19,7 @@ $options = [
     'sitepulse_last_load_time',
     'sitepulse_cpu_alert_threshold',
     'sitepulse_alert_cooldown_minutes',
+    defined('SITEPULSE_PLUGIN_IMPACT_OPTION') ? SITEPULSE_PLUGIN_IMPACT_OPTION : 'sitepulse_plugin_impact_stats',
 ];
 
 $transients = [


### PR DESCRIPTION
## Summary
- ensure the plugin impact stats option is removed during uninstall by adding it to the options cleanup list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cad6a09400832ebd6b02534b7f13cb