### PR TITLE
Ensure SitePulse debug checkbox posts explicit values

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -274,6 +274,8 @@ function sitepulse_settings_page() {
         'uptime_tracker' => 'Uptime Tracker', 'ai_insights' => 'AI-Powered Insights', 'custom_dashboards' => 'Custom Dashboards', 'error_alerts' => 'Error Alerts',
     ];
     $active_modules = get_option('sitepulse_active_modules', []);
+    $debug_mode_option = get_option('sitepulse_debug_mode');
+    $is_debug_mode_enabled = rest_sanitize_boolean($debug_mode_option);
 
     if (isset($_POST['sitepulse_cleanup_nonce']) && wp_verify_nonce($_POST['sitepulse_cleanup_nonce'], 'sitepulse_cleanup')) {
         if (isset($_POST['sitepulse_clear_log']) && defined('SITEPULSE_DEBUG_LOG') && file_exists(SITEPULSE_DEBUG_LOG)) {
@@ -333,7 +335,7 @@ function sitepulse_settings_page() {
                     <th scope="row"><label for="sitepulse_debug_mode">Activer le Mode Debug</label></th>
                     <td>
                         <input type="hidden" name="sitepulse_debug_mode" value="0">
-                        <input type="checkbox" id="sitepulse_debug_mode" name="sitepulse_debug_mode" value="1" <?php checked(get_option('sitepulse_debug_mode'), '1'); ?>>
+                        <input type="checkbox" id="sitepulse_debug_mode" name="sitepulse_debug_mode" value="1" <?php checked($is_debug_mode_enabled); ?>>
                         <p class="description">Active la journalisation détaillée et le tableau de bord de débogage. À n'utiliser que pour le dépannage.</p>
                     </td>
                 </tr>


### PR DESCRIPTION
## Summary
- sanitize the saved debug mode option before rendering the settings form
- keep the hidden field that posts a zero when the checkbox is unchecked and rely on the sanitized flag for the checkbox state

## Testing
- php -l sitepulse_FR/includes/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68caf62066c4832e8834a289425b2796