### PR TITLE
Load plugin translations

### DIFF
--- a/sitepulse_FR/languages/.gitkeep
+++ b/sitepulse_FR/languages/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder to ensure the languages directory is tracked by git.

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -7,6 +7,8 @@
  * Author: Jérôme Le Gousse
  * License: GPL-2.0+
  * Uninstall: uninstall.php
+ * Text Domain: sitepulse
+ * Domain Path: /languages
  */
 
 if (!defined('ABSPATH')) exit;
@@ -17,6 +19,12 @@ define('SITEPULSE_PATH', plugin_dir_path(__FILE__));
 define('SITEPULSE_URL', plugin_dir_url(__FILE__));
 $debug_mode = get_option('sitepulse_debug_mode', false);
 define('SITEPULSE_DEBUG', (bool) $debug_mode);
+
+add_action('plugins_loaded', 'sitepulse_load_textdomain');
+
+function sitepulse_load_textdomain() {
+    load_plugin_textdomain('sitepulse', false, dirname(plugin_basename(__FILE__)) . '/languages');
+}
 
 if (!function_exists('wp_mkdir_p')) {
     require_once ABSPATH . 'wp-admin/includes/file.php';


### PR DESCRIPTION
## Summary
- add missing plugin headers for the text domain metadata
- load the Sitepulse textdomain during the plugins_loaded hook
- add an empty languages directory so translation files can be packaged

## Testing
- php -l sitepulse_FR/sitepulse.php

------
https://chatgpt.com/codex/tasks/task_e_68cb019fa148832e9739c825d4835bc6