### PR TITLE
Align plugin impact timestamps with site timezone

### DIFF
--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -105,7 +105,7 @@ function sitepulse_plugin_impact_tracker_persist() {
 
     $option_key = SITEPULSE_PLUGIN_IMPACT_OPTION;
     $existing = get_option($option_key, []);
-    $now = time();
+    $now = current_time('timestamp');
 
     if (!is_array($existing)) {
         $existing = [];


### PR DESCRIPTION
## Summary
- use `current_time( 'timestamp' )` when persisting plugin impact data so stored timestamps share WordPress' clock base
- normalize stored timestamps before formatting them in the admin page to keep displayed datetimes accurate in non-UTC timezones

## Testing
- php -l sitepulse_FR/sitepulse.php
- php -l sitepulse_FR/modules/plugin_impact_scanner.php

------
https://chatgpt.com/codex/tasks/task_e_68cb1644fb94832e9a48dac1a97dacf6