### PR TITLE
Delay Query Monitor integration registration

### DIFF
--- a/sitepulse_FR/includes/integrations.php
+++ b/sitepulse_FR/includes/integrations.php
@@ -2,18 +2,28 @@
 if (!defined('ABSPATH')) exit;
 
 // Query Monitor integration
-if (class_exists('QueryMonitor')) {
-    class SitePulse_QM_Collector extends QM_Collector {
-        public $id = 'sitepulse';
-        public function name() { return 'SitePulse'; }
-        public function process() {
-            $this->data['load_time'] = get_option('sitepulse_last_load_time', 'N/A');
-            $this->data['uptime'] = get_option('sitepulse_uptime_log', []);
+add_action('plugins_loaded', function () {
+    if (!class_exists('QM_Collector')) {
+        return;
+    }
+
+    if (!class_exists('SitePulse_QM_Collector', false)) {
+        class SitePulse_QM_Collector extends QM_Collector {
+            public $id = 'sitepulse';
+
+            public function name() { return 'SitePulse'; }
+
+            public function process() {
+                $this->data['load_time'] = get_option('sitepulse_last_load_time', 'N/A');
+                $this->data['uptime'] = get_option('sitepulse_uptime_log', []);
+            }
         }
     }
-    add_filter('qm/collectors', function($collectors) {
+
+    add_filter('qm/collectors', function ($collectors) {
         $collectors['sitepulse'] = new SitePulse_QM_Collector();
         return $collectors;
     });
+
     sitepulse_log('Integrated with Query Monitor');
-}
+}, 100);


### PR DESCRIPTION
## Summary
- wrap Query Monitor collector registration in a late `plugins_loaded` callback
- guard the collector definition with a `QM_Collector` class check to avoid premature loading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb186227c4832e892419e20ca829be