### PR TITLE
Add translations for dashboard and AI modules

### DIFF
--- a/sitepulse_FR/languages/sitepulse.pot
+++ b/sitepulse_FR/languages/sitepulse.pot
@@ -1,0 +1,181 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: SitePulse 1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-05-23 00:00+0000\n"
+"PO-Revision-Date: 2024-05-23 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Manual\n"
+"X-Domain: sitepulse\n"
+
+#: modules/custom_dashboards.php:39
+msgid "SitePulse Dashboard"
+msgstr ""
+
+#: modules/custom_dashboards.php:40
+msgid "A real-time overview of your site's performance and health."
+msgstr ""
+
+#: modules/custom_dashboards.php:50
+msgid "ms"
+msgstr ""
+
+#: modules/custom_dashboards.php:50
+msgid "N/A"
+msgstr ""
+
+#: modules/custom_dashboards.php:51
+msgid "Speed"
+msgstr ""
+
+#: modules/custom_dashboards.php:52 modules/custom_dashboards.php:67
+msgid "Details"
+msgstr ""
+
+#: modules/custom_dashboards.php:53
+msgid "Server Response (TTFB):"
+msgstr ""
+
+#: modules/custom_dashboards.php:54
+msgid "Time to First Byte measures how quickly your server responds. Under 200ms is excellent."
+msgstr ""
+
+#: modules/custom_dashboards.php:66
+msgid "Uptime"
+msgstr ""
+
+#: modules/custom_dashboards.php:68
+msgid "Last 30 Checks:"
+msgstr ""
+
+#: modules/custom_dashboards.php:69
+msgid "Represents your site's availability over the last 30 hours."
+msgstr ""
+
+#: modules/custom_dashboards.php:78
+msgid "Database Health"
+msgstr ""
+
+#: modules/custom_dashboards.php:79
+msgid "Optimize"
+msgstr ""
+
+#: modules/custom_dashboards.php:80
+msgid "Post Revisions:"
+msgstr ""
+
+#: modules/custom_dashboards.php:81
+msgid "Excessive revisions can slow down your database. It's safe to clean them."
+msgstr ""
+
+#: modules/custom_dashboards.php:89
+msgid "Log is clean."
+msgstr ""
+
+#: modules/custom_dashboards.php:93
+msgid "Log file not found."
+msgstr ""
+
+#: modules/custom_dashboards.php:99
+msgid "Unable to read log file."
+msgstr ""
+
+#: modules/custom_dashboards.php:101
+msgid "No recent log entries."
+msgstr ""
+
+#: modules/custom_dashboards.php:107
+msgid "Fatal Errors found!"
+msgstr ""
+
+#: modules/custom_dashboards.php:110
+msgid "Warnings present."
+msgstr ""
+
+#: modules/custom_dashboards.php:115
+msgid "Error Log"
+msgstr ""
+
+#: modules/custom_dashboards.php:116
+msgid "Analyze"
+msgstr ""
+
+#: modules/custom_dashboards.php:117
+msgid "Status:"
+msgstr ""
+
+#: modules/custom_dashboards.php:118
+msgid "Checks for critical errors in your WordPress debug log."
+msgstr ""
+
+#: modules/ai_insights.php:6 modules/ai_insights.php:7
+msgid "AI Insights"
+msgstr ""
+
+#: modules/ai_insights.php:15
+msgid "Vous n'avez pas les permissions nécessaires pour accéder à cette page."
+msgstr ""
+
+#: modules/ai_insights.php:29
+msgid "Veuillez entrer votre clé API Google Gemini dans les réglages de SitePulse."
+msgstr ""
+
+#: modules/ai_insights.php:41
+msgid "Tu es un expert en optimisation de sites WordPress."
+msgstr ""
+
+#. translators: %1$s: Site name, %2$s: Site URL
+#: modules/ai_insights.php:44
+msgid "Analyse les performances du site \"%1$s\" disponible à l'adresse %2$s."
+msgstr ""
+
+#: modules/ai_insights.php:48
+msgid "Fournis trois recommandations concrètes pour améliorer la vitesse, le référencement et la conversion. Réponds en français."
+msgstr ""
+
+#. translators: %s: site description
+#: modules/ai_insights.php:53
+msgid "Description du site : %s."
+msgstr ""
+
+#. translators: %s: error message
+#: modules/ai_insights.php:81 modules/ai_insights.php:126
+msgid "Erreur lors de la génération de l’analyse IA : %s"
+msgstr ""
+
+#: modules/ai_insights.php:106
+msgid "La réponse de Gemini ne contient aucun texte exploitable."
+msgstr ""
+
+#: modules/ai_insights.php:109
+msgid "Structure de réponse inattendue reçue depuis Gemini."
+msgstr ""
+
+#: modules/ai_insights.php:122
+msgid "HTTP %d"
+msgstr ""
+
+#: modules/ai_insights.php:135
+msgid "Analyses par IA"
+msgstr ""
+
+#: modules/ai_insights.php:136
+msgid "Obtenez des recommandations personnalisées pour votre site en analysant ses données de performance avec l'IA Gemini de Google."
+msgstr ""
+
+#: modules/ai_insights.php:138
+msgid "Veuillez <a href=\"%s\">entrer votre clé API Google Gemini</a> pour utiliser cette fonctionnalité."
+msgstr ""
+
+#: modules/ai_insights.php:142
+msgid "Générer une Analyse"
+msgstr ""
+
+#: modules/ai_insights.php:149
+msgid "Votre Recommandation par IA"
+msgstr ""

--- a/sitepulse_FR/modules/ai_insights.php
+++ b/sitepulse_FR/modules/ai_insights.php
@@ -1,6 +1,15 @@
 <?php
 if (!defined('ABSPATH')) exit;
-add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'AI Insights', 'AI Insights', 'manage_options', 'sitepulse-ai', 'sitepulse_ai_insights_page'); });
+add_action('admin_menu', function() {
+    add_submenu_page(
+        'sitepulse-dashboard',
+        __('AI Insights', 'sitepulse'),
+        __('AI Insights', 'sitepulse'),
+        'manage_options',
+        'sitepulse-ai',
+        'sitepulse_ai_insights_page'
+    );
+});
 function sitepulse_ai_insights_page() {
     if (!current_user_can('manage_options')) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
@@ -15,7 +24,10 @@ function sitepulse_ai_insights_page() {
     $error_notice = '';
     if (isset($_POST['get_ai_insight']) && check_admin_referer('sitepulse_get_ai_insight')) {
         if (empty($api_key)) {
-            echo '<div class="notice notice-error"><p>Veuillez entrer votre clé API Google Gemini dans les réglages de SitePulse.</p></div>';
+            printf(
+                '<div class="notice notice-error"><p>%s</p></div>',
+                esc_html__('Veuillez entrer votre clé API Google Gemini dans les réglages de SitePulse.', 'sitepulse')
+            );
         } else {
             $endpoint = add_query_arg(
                 'key',
@@ -120,21 +132,21 @@ function sitepulse_ai_insights_page() {
     }
     ?>
     <div class="wrap">
-        <h1><span class="dashicons-before dashicons-superhero"></span> Analyses par IA</h1>
-        <p>Obtenez des recommandations personnalisées pour votre site en analysant ses données de performance avec l'IA Gemini de Google.</p>
+        <h1><span class="dashicons-before dashicons-superhero"></span> <?php esc_html_e('Analyses par IA', 'sitepulse'); ?></h1>
+        <p><?php esc_html_e("Obtenez des recommandations personnalisées pour votre site en analysant ses données de performance avec l'IA Gemini de Google.", 'sitepulse'); ?></p>
         <?php if (empty($api_key)): ?>
-            <div class="notice notice-warning"><p>Veuillez <a href="<?php echo esc_url(admin_url('admin.php?page=sitepulse-settings')); ?>">entrer votre clé API Google Gemini</a> pour utiliser cette fonctionnalité.</p></div>
+            <div class="notice notice-warning"><p><?php echo wp_kses_post(sprintf(__('Veuillez <a href="%s">entrer votre clé API Google Gemini</a> pour utiliser cette fonctionnalité.', 'sitepulse'), esc_url(admin_url('admin.php?page=sitepulse-settings')))); ?></p></div>
         <?php else: ?>
             <form method="post" action="">
                 <?php wp_nonce_field('sitepulse_get_ai_insight'); ?>
-                <button type="submit" name="get_ai_insight" class="button button-primary">Générer une Analyse</button>
+                <button type="submit" name="get_ai_insight" class="button button-primary"><?php esc_html_e('Générer une Analyse', 'sitepulse'); ?></button>
             </form>
         <?php endif; ?>
         <?php if (!empty($error_notice)): ?>
             <div class="notice notice-error"><p><?php echo esc_html($error_notice); ?></p></div>
         <?php endif; ?>
         <?php if ($insight_result): ?>
-            <div id="ai-insight-response" style="background: #fff; border: 1px solid #ccc; padding: 15px; margin-top: 20px;"><h2>Votre Recommandation par IA</h2><p><?php echo nl2br(esc_html($insight_result)); ?></p></div>
+            <div id="ai-insight-response" style="background: #fff; border: 1px solid #ccc; padding: 15px; margin-top: 20px;"><h2><?php esc_html_e('Votre Recommandation par IA', 'sitepulse'); ?></h2><p><?php echo nl2br(esc_html($insight_result)); ?></p></div>
         <?php endif; ?>
     </div>
     <?php

--- a/sitepulse_FR/modules/custom_dashboards.php
+++ b/sitepulse_FR/modules/custom_dashboards.php
@@ -36,8 +36,8 @@ function sitepulse_custom_dashboards_page() {
         .sitepulse-card a.button { float: right; margin-top: -45px; }
     </style>
     <div class="wrap">
-        <h1><span class="dashicons-before dashicons-dashboard"></span> SitePulse Dashboard</h1>
-        <p>A real-time overview of your site's performance and health.</p>
+        <h1><span class="dashicons-before dashicons-dashboard"></span> <?php esc_html_e('SitePulse Dashboard', 'sitepulse'); ?></h1>
+        <p><?php esc_html_e("A real-time overview of your site's performance and health.", 'sitepulse'); ?></p>
 
         <div class="sitepulse-grid">
             <!-- Speed Card -->
@@ -47,11 +47,11 @@ function sitepulse_custom_dashboards_page() {
                 $ttfb = (is_array($results) && isset($results['ttfb'])) ? $results['ttfb'] : 0;
                 $ttfb_status = $ttfb > 500 ? 'status-bad' : ($ttfb > 200 ? 'status-warn' : 'status-ok');
                 ?>
-                <?php $ttfb_display = $ttfb ? round($ttfb) . ' ms' : 'N/A'; ?>
-                <h2><span class="dashicons dashicons-performance"></span> Speed</h2>
-                <a href="<?php echo esc_url(admin_url('admin.php?page=sitepulse-speed')); ?>" class="button">Details</a>
-                <p>Server Response (TTFB): <span class="metric <?php echo esc_attr($ttfb_status); ?>"><?php echo esc_html($ttfb_display); ?></span></p>
-                <p class="description">Time to First Byte measures how quickly your server responds. Under 200ms is excellent.</p>
+                <?php $ttfb_display = $ttfb ? round($ttfb) . ' ' . __('ms', 'sitepulse') : __('N/A', 'sitepulse'); ?>
+                <h2><span class="dashicons dashicons-performance"></span> <?php esc_html_e('Speed', 'sitepulse'); ?></h2>
+                <a href="<?php echo esc_url(admin_url('admin.php?page=sitepulse-speed')); ?>" class="button"><?php esc_html_e('Details', 'sitepulse'); ?></a>
+                <p><?php esc_html_e('Server Response (TTFB):', 'sitepulse'); ?> <span class="metric <?php echo esc_attr($ttfb_status); ?>"><?php echo esc_html($ttfb_display); ?></span></p>
+                <p class="description"><?php esc_html_e('Time to First Byte measures how quickly your server responds. Under 200ms is excellent.', 'sitepulse'); ?></p>
             </div>
 
             <!-- Uptime Card -->
@@ -63,10 +63,10 @@ function sitepulse_custom_dashboards_page() {
                 $uptime_percentage = $total_checks > 0 ? ($up_checks / $total_checks) * 100 : 100;
                 $uptime_status = $uptime_percentage < 99 ? 'status-bad' : ($uptime_percentage < 100 ? 'status-warn' : 'status-ok');
                 ?>
-                <h2><span class="dashicons dashicons-chart-bar"></span> Uptime</h2>
-                 <a href="<?php echo esc_url(admin_url('admin.php?page=sitepulse-uptime')); ?>" class="button">Details</a>
-                <p>Last 30 Checks: <span class="metric <?php echo esc_attr($uptime_status); ?>"><?php echo esc_html(round($uptime_percentage, 2)); ?>%</span></p>
-                 <p class="description">Represents your site's availability over the last 30 hours.</p>
+                <h2><span class="dashicons dashicons-chart-bar"></span> <?php esc_html_e('Uptime', 'sitepulse'); ?></h2>
+                 <a href="<?php echo esc_url(admin_url('admin.php?page=sitepulse-uptime')); ?>" class="button"><?php esc_html_e('Details', 'sitepulse'); ?></a>
+                <p><?php esc_html_e('Last 30 Checks:', 'sitepulse'); ?> <span class="metric <?php echo esc_attr($uptime_status); ?>"><?php echo esc_html(round($uptime_percentage, 2)); ?>%</span></p>
+                 <p class="description"><?php esc_html_e("Represents your site's availability over the last 30 hours.", 'sitepulse'); ?></p>
             </div>
 
             <!-- Database Card -->
@@ -75,10 +75,10 @@ function sitepulse_custom_dashboards_page() {
                 $revisions = $wpdb->get_var("SELECT COUNT(*) FROM $wpdb->posts WHERE post_type = 'revision'");
                 $db_status = $revisions > 100 ? 'status-bad' : ($revisions > 50 ? 'status-warn' : 'status-ok');
                 ?>
-                <h2><span class="dashicons dashicons-database"></span> Database Health</h2>
-                <a href="<?php echo esc_url(admin_url('admin.php?page=sitepulse-db')); ?>" class="button">Optimize</a>
-                <p>Post Revisions: <span class="metric <?php echo esc_attr($db_status); ?>"><?php echo esc_html((int)$revisions); ?></span></p>
-                <p class="description">Excessive revisions can slow down your database. It's safe to clean them.</p>
+                <h2><span class="dashicons dashicons-database"></span> <?php esc_html_e('Database Health', 'sitepulse'); ?></h2>
+                <a href="<?php echo esc_url(admin_url('admin.php?page=sitepulse-db')); ?>" class="button"><?php esc_html_e('Optimize', 'sitepulse'); ?></a>
+                <p><?php esc_html_e('Post Revisions:', 'sitepulse'); ?> <span class="metric <?php echo esc_attr($db_status); ?>"><?php echo esc_html((int)$revisions); ?></span></p>
+                <p class="description"><?php esc_html_e("Excessive revisions can slow down your database. It's safe to clean them.", 'sitepulse'); ?></p>
             </div>
 
              <!-- Log Status Card -->
@@ -86,36 +86,36 @@ function sitepulse_custom_dashboards_page() {
                 <?php
                 $log_file = WP_CONTENT_DIR . '/debug.log';
                 $log_status_class = 'status-ok';
-                $log_summary = 'Log is clean.';
+                $log_summary = __('Log is clean.', 'sitepulse');
 
                 if (!file_exists($log_file)) {
                     $log_status_class = 'status-warn';
-                    $log_summary = 'Log file not found.';
+                    $log_summary = __('Log file not found.', 'sitepulse');
                 } else {
                     $recent_logs = sitepulse_get_recent_log_lines($log_file, 200, 131072);
 
                     if ($recent_logs === null) {
                         $log_status_class = 'status-warn';
-                        $log_summary = 'Unable to read log file.';
+                        $log_summary = __('Unable to read log file.', 'sitepulse');
                     } elseif (empty($recent_logs)) {
-                        $log_summary = 'No recent log entries.';
+                        $log_summary = __('No recent log entries.', 'sitepulse');
                     } else {
                         $log_content = implode("\n", $recent_logs);
 
                         if (stripos($log_content, 'PHP Fatal error') !== false) {
                             $log_status_class = 'status-bad';
-                            $log_summary = 'Fatal Errors found!';
+                            $log_summary = __('Fatal Errors found!', 'sitepulse');
                         } elseif (stripos($log_content, 'PHP Warning') !== false) {
                             $log_status_class = 'status-warn';
-                            $log_summary = 'Warnings present.';
+                            $log_summary = __('Warnings present.', 'sitepulse');
                         }
                     }
                 }
                 ?>
-                <h2><span class="dashicons dashicons-hammer"></span> Error Log</h2>
-                <a href="<?php echo esc_url(admin_url('admin.php?page=sitepulse-logs')); ?>" class="button">Analyze</a>
-                <p>Status: <span class="metric <?php echo esc_attr($log_status_class); ?>"><?php echo esc_html($log_summary); ?></span></p>
-                <p class="description">Checks for critical errors in your WordPress debug log.</p>
+                <h2><span class="dashicons dashicons-hammer"></span> <?php esc_html_e('Error Log', 'sitepulse'); ?></h2>
+                <a href="<?php echo esc_url(admin_url('admin.php?page=sitepulse-logs')); ?>" class="button"><?php esc_html_e('Analyze', 'sitepulse'); ?></a>
+                <p><?php esc_html_e('Status:', 'sitepulse'); ?> <span class="metric <?php echo esc_attr($log_status_class); ?>"><?php echo esc_html($log_summary); ?></span></p>
+                <p class="description"><?php esc_html_e('Checks for critical errors in your WordPress debug log.', 'sitepulse'); ?></p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- wrap all dashboard UI strings in translation functions scoped to the sitepulse text domain
- internationalize the AI Insights admin interface, including notices and buttons
- add a sitepulse.pot template capturing the plugin strings for translators

## Testing
- php -l sitepulse_FR/modules/custom_dashboards.php
- php -l sitepulse_FR/modules/ai_insights.php

------
https://chatgpt.com/codex/tasks/task_e_68cb27726988832e80985a1c031afcf7