### PR TITLE
Refactor option and transient keys into constants

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -27,7 +27,7 @@ function sitepulse_render_dashboard_page() {
         return;
     }
 
-    $active_modules = (array) get_option('sitepulse_active_modules', []);
+    $active_modules = (array) get_option(SITEPULSE_OPTION_ACTIVE_MODULES, []);
     $is_dashboard_enabled = in_array('custom_dashboards', $active_modules, true);
     $settings_url = admin_url('admin.php?page=sitepulse-settings');
 
@@ -86,19 +86,19 @@ add_action('admin_menu', 'sitepulse_admin_menu');
  * Registers the settings fields.
  */
 function sitepulse_register_settings() {
-    register_setting('sitepulse_settings', 'sitepulse_active_modules', [
+    register_setting('sitepulse_settings', SITEPULSE_OPTION_ACTIVE_MODULES, [
         'type' => 'array', 'sanitize_callback' => 'sitepulse_sanitize_modules', 'default' => []
     ]);
-    register_setting('sitepulse_settings', 'sitepulse_debug_mode', [
+    register_setting('sitepulse_settings', SITEPULSE_OPTION_DEBUG_MODE, [
         'type' => 'boolean', 'sanitize_callback' => 'rest_sanitize_boolean', 'default' => false
     ]);
-    register_setting('sitepulse_settings', 'sitepulse_gemini_api_key', [
+    register_setting('sitepulse_settings', SITEPULSE_OPTION_GEMINI_API_KEY, [
         'type' => 'string', 'sanitize_callback' => 'sanitize_text_field', 'default' => ''
     ]);
-    register_setting('sitepulse_settings', 'sitepulse_cpu_alert_threshold', [
+    register_setting('sitepulse_settings', SITEPULSE_OPTION_CPU_ALERT_THRESHOLD, [
         'type' => 'number', 'sanitize_callback' => 'sitepulse_sanitize_cpu_threshold', 'default' => 5
     ]);
-    register_setting('sitepulse_settings', 'sitepulse_alert_cooldown_minutes', [
+    register_setting('sitepulse_settings', SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES, [
         'type' => 'integer', 'sanitize_callback' => 'sitepulse_sanitize_cooldown_minutes', 'default' => 60
     ]);
 }
@@ -273,8 +273,8 @@ function sitepulse_settings_page() {
         'speed_analyzer' => 'Speed Analyzer', 'database_optimizer' => 'Database Optimizer', 'maintenance_advisor' => 'Maintenance Advisor',
         'uptime_tracker' => 'Uptime Tracker', 'ai_insights' => 'AI-Powered Insights', 'custom_dashboards' => 'Custom Dashboards', 'error_alerts' => 'Error Alerts',
     ];
-    $active_modules = get_option('sitepulse_active_modules', []);
-    $debug_mode_option = get_option('sitepulse_debug_mode');
+    $active_modules = get_option(SITEPULSE_OPTION_ACTIVE_MODULES, []);
+    $debug_mode_option = get_option(SITEPULSE_OPTION_DEBUG_MODE);
     $is_debug_mode_enabled = rest_sanitize_boolean($debug_mode_option);
 
     if (isset($_POST['sitepulse_cleanup_nonce']) && wp_verify_nonce($_POST['sitepulse_cleanup_nonce'], 'sitepulse_cleanup')) {
@@ -289,8 +289,8 @@ function sitepulse_settings_page() {
             }
         }
         if (isset($_POST['sitepulse_clear_data'])) {
-            delete_option('sitepulse_uptime_log');
-            delete_transient('sitepulse_speed_scan_results');
+            delete_option(SITEPULSE_OPTION_UPTIME_LOG);
+            delete_transient(SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS);
             echo '<div class="notice notice-success is-dismissible"><p>Données stockées effacées.</p></div>';
         }
         if (isset($_POST['sitepulse_reset_all'])) {
@@ -299,13 +299,13 @@ function sitepulse_settings_page() {
                 : 'sitepulse_plugin_impact_stats';
 
             $options_to_delete = [
-                'sitepulse_active_modules',
-                'sitepulse_debug_mode',
-                'sitepulse_gemini_api_key',
-                'sitepulse_uptime_log',
-                'sitepulse_last_load_time',
-                'sitepulse_cpu_alert_threshold',
-                'sitepulse_alert_cooldown_minutes',
+                SITEPULSE_OPTION_ACTIVE_MODULES,
+                SITEPULSE_OPTION_DEBUG_MODE,
+                SITEPULSE_OPTION_GEMINI_API_KEY,
+                SITEPULSE_OPTION_UPTIME_LOG,
+                SITEPULSE_OPTION_LAST_LOAD_TIME,
+                SITEPULSE_OPTION_CPU_ALERT_THRESHOLD,
+                SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES,
                 $plugin_impact_option,
             ];
 
@@ -314,10 +314,10 @@ function sitepulse_settings_page() {
             }
 
             $transients_to_delete = [
-                'sitepulse_speed_scan_results',
-                'sitepulse_ai_insight',
-                'sitepulse_error_alert_cpu_lock',
-                'sitepulse_error_alert_php_fatal_lock',
+                SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS,
+                SITEPULSE_TRANSIENT_AI_INSIGHT,
+                SITEPULSE_TRANSIENT_ERROR_ALERT_CPU_LOCK,
+                SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK,
             ];
 
             foreach ($transients_to_delete as $transient_key) {
@@ -343,9 +343,9 @@ function sitepulse_settings_page() {
             <h2>Paramètres de l'API</h2>
             <table class="form-table">
                 <tr valign="top">
-                    <th scope="row"><label for="sitepulse_gemini_api_key">Clé API Google Gemini</label></th>
+                    <th scope="row"><label for="<?php echo esc_attr(SITEPULSE_OPTION_GEMINI_API_KEY); ?>">Clé API Google Gemini</label></th>
                     <td>
-                        <input type="password" id="sitepulse_gemini_api_key" name="sitepulse_gemini_api_key" value="<?php echo esc_attr(get_option('sitepulse_gemini_api_key')); ?>" class="regular-text" />
+                        <input type="password" id="<?php echo esc_attr(SITEPULSE_OPTION_GEMINI_API_KEY); ?>" name="<?php echo esc_attr(SITEPULSE_OPTION_GEMINI_API_KEY); ?>" value="<?php echo esc_attr(get_option(SITEPULSE_OPTION_GEMINI_API_KEY)); ?>" class="regular-text" />
                         <p class="description">Entrez votre clé API pour activer les analyses par IA. Obtenez une clé sur <a href="https://aistudio.google.com/app/apikey" target="_blank">Google AI Studio</a>.</p>
                     </td>
                 </tr>
@@ -356,14 +356,14 @@ function sitepulse_settings_page() {
                 <?php foreach ($modules as $key => $name): ?>
                 <tr>
                     <th scope="row"><label for="<?php echo esc_attr($key); ?>"><?php echo esc_html($name); ?></label></th>
-                    <td><input type="checkbox" id="<?php echo esc_attr($key); ?>" name="sitepulse_active_modules[]" value="<?php echo esc_attr($key); ?>" <?php checked(in_array($key, $active_modules, true)); ?>></td>
+                    <td><input type="checkbox" id="<?php echo esc_attr($key); ?>" name="<?php echo esc_attr(SITEPULSE_OPTION_ACTIVE_MODULES); ?>[]" value="<?php echo esc_attr($key); ?>" <?php checked(in_array($key, $active_modules, true)); ?>></td>
                 </tr>
                 <?php endforeach; ?>
                 <tr>
-                    <th scope="row"><label for="sitepulse_debug_mode">Activer le Mode Debug</label></th>
+                    <th scope="row"><label for="<?php echo esc_attr(SITEPULSE_OPTION_DEBUG_MODE); ?>">Activer le Mode Debug</label></th>
                     <td>
-                        <input type="hidden" name="sitepulse_debug_mode" value="0">
-                        <input type="checkbox" id="sitepulse_debug_mode" name="sitepulse_debug_mode" value="1" <?php checked($is_debug_mode_enabled); ?>>
+                        <input type="hidden" name="<?php echo esc_attr(SITEPULSE_OPTION_DEBUG_MODE); ?>" value="0">
+                        <input type="checkbox" id="<?php echo esc_attr(SITEPULSE_OPTION_DEBUG_MODE); ?>" name="<?php echo esc_attr(SITEPULSE_OPTION_DEBUG_MODE); ?>" value="1" <?php checked($is_debug_mode_enabled); ?>>
                         <p class="description">Active la journalisation détaillée et le tableau de bord de débogage. À n'utiliser que pour le dépannage.</p>
                     </td>
                 </tr>
@@ -371,16 +371,16 @@ function sitepulse_settings_page() {
             <h2>Alertes</h2>
             <table class="form-table">
                 <tr>
-                    <th scope="row"><label for="sitepulse_cpu_alert_threshold">Seuil d'alerte de charge CPU</label></th>
+                    <th scope="row"><label for="<?php echo esc_attr(SITEPULSE_OPTION_CPU_ALERT_THRESHOLD); ?>">Seuil d'alerte de charge CPU</label></th>
                     <td>
-                        <input type="number" step="0.1" min="0" id="sitepulse_cpu_alert_threshold" name="sitepulse_cpu_alert_threshold" value="<?php echo esc_attr(get_option('sitepulse_cpu_alert_threshold', 5)); ?>" class="small-text">
+                        <input type="number" step="0.1" min="0" id="<?php echo esc_attr(SITEPULSE_OPTION_CPU_ALERT_THRESHOLD); ?>" name="<?php echo esc_attr(SITEPULSE_OPTION_CPU_ALERT_THRESHOLD); ?>" value="<?php echo esc_attr(get_option(SITEPULSE_OPTION_CPU_ALERT_THRESHOLD, 5)); ?>" class="small-text">
                         <p class="description">Une alerte e-mail est envoyée lorsque la charge moyenne sur 1 minute dépasse ce seuil.</p>
                     </td>
                 </tr>
                 <tr>
-                    <th scope="row"><label for="sitepulse_alert_cooldown_minutes">Fenêtre anti-spam (minutes)</label></th>
+                    <th scope="row"><label for="<?php echo esc_attr(SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES); ?>">Fenêtre anti-spam (minutes)</label></th>
                     <td>
-                        <input type="number" min="1" id="sitepulse_alert_cooldown_minutes" name="sitepulse_alert_cooldown_minutes" value="<?php echo esc_attr(get_option('sitepulse_alert_cooldown_minutes', 60)); ?>" class="small-text">
+                        <input type="number" min="1" id="<?php echo esc_attr(SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES); ?>" name="<?php echo esc_attr(SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES); ?>" value="<?php echo esc_attr(get_option(SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES, 60)); ?>" class="small-text">
                         <p class="description">Empêche l'envoi de plusieurs e-mails identiques pendant la durée spécifiée.</p>
                     </td>
                 </tr>
@@ -435,7 +435,7 @@ function sitepulse_debug_page() {
                     <div class="postbox">
                         <h2 class="hndle"><span>Détails de l'Environnement</span></h2>
                         <div class="inside">
-                            <?php $active_modules_list = implode(', ', get_option('sitepulse_active_modules', [])); ?>
+                            <?php $active_modules_list = implode(', ', get_option(SITEPULSE_OPTION_ACTIVE_MODULES, [])); ?>
                             <ul>
                                 <li><strong>Version de SitePulse:</strong> <?php echo esc_html(SITEPULSE_VERSION); ?></li>
                                 <li><strong>Version de WordPress:</strong> <?php echo esc_html(get_bloginfo('version')); ?></li>

--- a/sitepulse_FR/includes/integrations.php
+++ b/sitepulse_FR/includes/integrations.php
@@ -14,8 +14,8 @@ add_action('plugins_loaded', function () {
             public function name() { return 'SitePulse'; }
 
             public function process() {
-                $this->data['load_time'] = get_option('sitepulse_last_load_time', 'N/A');
-                $this->data['uptime'] = get_option('sitepulse_uptime_log', []);
+                $this->data['load_time'] = get_option(SITEPULSE_OPTION_LAST_LOAD_TIME, 'N/A');
+                $this->data['uptime'] = get_option(SITEPULSE_OPTION_UPTIME_LOG, []);
             }
         }
     }

--- a/sitepulse_FR/modules/ai_insights.php
+++ b/sitepulse_FR/modules/ai_insights.php
@@ -6,8 +6,8 @@ function sitepulse_ai_insights_page() {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }
 
-    $api_key = get_option('sitepulse_gemini_api_key');
-    $stored_insight = get_transient('sitepulse_ai_insight');
+    $api_key = get_option(SITEPULSE_OPTION_GEMINI_API_KEY);
+    $stored_insight = get_transient(SITEPULSE_TRANSIENT_AI_INSIGHT);
     $insight_result = '';
     if (is_string($stored_insight) && '' !== $stored_insight) {
         $insight_result = sanitize_textarea_field($stored_insight);
@@ -88,7 +88,7 @@ function sitepulse_ai_insights_page() {
                         $generated_text = trim($generated_text);
                         if ('' !== $generated_text) {
                             $generated_text = sanitize_textarea_field($generated_text);
-                            set_transient('sitepulse_ai_insight', $generated_text, HOUR_IN_SECONDS);
+                            set_transient(SITEPULSE_TRANSIENT_AI_INSIGHT, $generated_text, HOUR_IN_SECONDS);
                             $insight_result = $generated_text;
                         } else {
                             $error_notice = __('La réponse de Gemini ne contient aucun texte exploitable.', 'sitepulse');

--- a/sitepulse_FR/modules/custom_dashboards.php
+++ b/sitepulse_FR/modules/custom_dashboards.php
@@ -43,7 +43,7 @@ function sitepulse_custom_dashboards_page() {
             <!-- Speed Card -->
             <div class="sitepulse-card">
                 <?php
-                $results = get_transient('sitepulse_speed_scan_results');
+                $results = get_transient(SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS);
                 $ttfb = (is_array($results) && isset($results['ttfb'])) ? $results['ttfb'] : 0;
                 $ttfb_status = $ttfb > 500 ? 'status-bad' : ($ttfb > 200 ? 'status-warn' : 'status-ok');
                 ?>
@@ -57,7 +57,7 @@ function sitepulse_custom_dashboards_page() {
             <!-- Uptime Card -->
             <div class="sitepulse-card">
                  <?php
-                $uptime_log = get_option('sitepulse_uptime_log', []);
+                $uptime_log = get_option(SITEPULSE_OPTION_UPTIME_LOG, []);
                 $total_checks = count($uptime_log);
                 $up_checks = count(array_filter($uptime_log));
                 $uptime_percentage = $total_checks > 0 ? ($up_checks / $total_checks) * 100 : 100;

--- a/sitepulse_FR/modules/error_alerts.php
+++ b/sitepulse_FR/modules/error_alerts.php
@@ -12,7 +12,7 @@ $sitepulse_error_alerts_schedule   = 'sitepulse_error_alerts_five_minutes';
  * @return float
  */
 function sitepulse_error_alert_get_cpu_threshold() {
-    $threshold = get_option('sitepulse_cpu_alert_threshold', 5);
+    $threshold = get_option(SITEPULSE_OPTION_CPU_ALERT_THRESHOLD, 5);
     if (!is_numeric($threshold)) {
         $threshold = 5;
     }
@@ -31,7 +31,7 @@ function sitepulse_error_alert_get_cpu_threshold() {
  * @return int
  */
 function sitepulse_error_alert_get_cooldown() {
-    $cooldown_minutes = get_option('sitepulse_alert_cooldown_minutes', 60);
+    $cooldown_minutes = get_option(SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES, 60);
     if (!is_numeric($cooldown_minutes)) {
         $cooldown_minutes = 60;
     }
@@ -55,7 +55,7 @@ function sitepulse_error_alert_get_cooldown() {
  * @return bool True if the e-mail was dispatched, false otherwise.
  */
 function sitepulse_error_alert_send($type, $subject, $message) {
-    $lock_key = 'sitepulse_error_alert_' . sanitize_key($type) . '_lock';
+    $lock_key = SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX . sanitize_key($type) . SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_SUFFIX;
 
     if (false !== get_transient($lock_key)) {
         if (function_exists('sitepulse_log')) {

--- a/sitepulse_FR/modules/uptime_tracker.php
+++ b/sitepulse_FR/modules/uptime_tracker.php
@@ -18,7 +18,7 @@ function sitepulse_uptime_tracker_page() {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }
 
-    $uptime_log = get_option('sitepulse_uptime_log', []);
+    $uptime_log = get_option(SITEPULSE_OPTION_UPTIME_LOG, []);
     $total_checks = count($uptime_log);
     $up_checks = count(array_filter($uptime_log));
     $uptime_percentage = $total_checks > 0 ? ($up_checks / $total_checks) * 100 : 100;
@@ -48,10 +48,10 @@ function sitepulse_run_uptime_check() {
     $response = wp_remote_get(home_url(), ['timeout' => 10]);
     $response_code = wp_remote_retrieve_response_code($response);
     $is_up = !is_wp_error($response) && $response_code >= 200 && $response_code < 300;
-    $log = get_option('sitepulse_uptime_log', []);
+    $log = get_option(SITEPULSE_OPTION_UPTIME_LOG, []);
     $log[] = (int)$is_up;
     if (count($log) > 30) { array_shift($log); }
-    update_option('sitepulse_uptime_log', $log);
+    update_option(SITEPULSE_OPTION_UPTIME_LOG, $log);
     if (!$is_up) { sitepulse_log('Uptime check: Down', 'ALERT'); } 
     else { sitepulse_log('Uptime check: Up'); }
 }

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -17,7 +17,23 @@ if (!defined('ABSPATH')) exit;
 define('SITEPULSE_VERSION', '1.0');
 define('SITEPULSE_PATH', plugin_dir_path(__FILE__));
 define('SITEPULSE_URL', plugin_dir_url(__FILE__));
-$debug_mode = get_option('sitepulse_debug_mode', false);
+
+define('SITEPULSE_OPTION_ACTIVE_MODULES', 'sitepulse_active_modules');
+define('SITEPULSE_OPTION_DEBUG_MODE', 'sitepulse_debug_mode');
+define('SITEPULSE_OPTION_GEMINI_API_KEY', 'sitepulse_gemini_api_key');
+define('SITEPULSE_OPTION_UPTIME_LOG', 'sitepulse_uptime_log');
+define('SITEPULSE_OPTION_LAST_LOAD_TIME', 'sitepulse_last_load_time');
+define('SITEPULSE_OPTION_CPU_ALERT_THRESHOLD', 'sitepulse_cpu_alert_threshold');
+define('SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES', 'sitepulse_alert_cooldown_minutes');
+
+define('SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS', 'sitepulse_speed_scan_results');
+define('SITEPULSE_TRANSIENT_AI_INSIGHT', 'sitepulse_ai_insight');
+define('SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX', 'sitepulse_error_alert_');
+define('SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_SUFFIX', '_lock');
+define('SITEPULSE_TRANSIENT_ERROR_ALERT_CPU_LOCK', SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX . 'cpu' . SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_SUFFIX);
+define('SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK', SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX . 'php_fatal' . SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_SUFFIX);
+
+$debug_mode = get_option(SITEPULSE_OPTION_DEBUG_MODE, false);
 define('SITEPULSE_DEBUG', (bool) $debug_mode);
 
 add_action('plugins_loaded', 'sitepulse_load_textdomain');
@@ -275,7 +291,7 @@ function sitepulse_handle_module_changes($old_value, $value, $option = null) {
     }
 }
 
-add_action('update_option_sitepulse_active_modules', 'sitepulse_handle_module_changes', 10, 3);
+add_action('update_option_' . SITEPULSE_OPTION_ACTIVE_MODULES, 'sitepulse_handle_module_changes', 10, 3);
 
 /**
  * Schedules an admin notice to report SitePulse debug errors.
@@ -425,7 +441,7 @@ function sitepulse_load_modules() {
         'error_alerts'          => 'Error Alerts',
     ];
     
-    $active_modules = get_option('sitepulse_active_modules', []);
+    $active_modules = get_option(SITEPULSE_OPTION_ACTIVE_MODULES, []);
     sitepulse_log('Loading active modules: ' . implode(', ', $active_modules));
     
     foreach ($active_modules as $module_key) {
@@ -455,11 +471,11 @@ add_action('plugins_loaded', 'sitepulse_load_modules');
  */
 register_activation_hook(__FILE__, function() {
     // **FIX:** Activate the dashboard by default to prevent fatal errors on first load.
-    add_option('sitepulse_active_modules', ['custom_dashboards']);
-    add_option('sitepulse_debug_mode', false);
-    add_option('sitepulse_gemini_api_key', '');
-    add_option('sitepulse_cpu_alert_threshold', 5);
-    add_option('sitepulse_alert_cooldown_minutes', 60);
+    add_option(SITEPULSE_OPTION_ACTIVE_MODULES, ['custom_dashboards']);
+    add_option(SITEPULSE_OPTION_DEBUG_MODE, false);
+    add_option(SITEPULSE_OPTION_GEMINI_API_KEY, '');
+    add_option(SITEPULSE_OPTION_CPU_ALERT_THRESHOLD, 5);
+    add_option(SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES, 60);
 });
 
 /**

--- a/sitepulse_FR/uninstall.php
+++ b/sitepulse_FR/uninstall.php
@@ -11,22 +11,50 @@ if (!defined('WP_UNINSTALL_PLUGIN')) {
     exit;
 }
 
+$sitepulse_constants = [
+    'SITEPULSE_OPTION_ACTIVE_MODULES'             => 'sitepulse_active_modules',
+    'SITEPULSE_OPTION_DEBUG_MODE'                 => 'sitepulse_debug_mode',
+    'SITEPULSE_OPTION_GEMINI_API_KEY'             => 'sitepulse_gemini_api_key',
+    'SITEPULSE_OPTION_UPTIME_LOG'                 => 'sitepulse_uptime_log',
+    'SITEPULSE_OPTION_LAST_LOAD_TIME'             => 'sitepulse_last_load_time',
+    'SITEPULSE_OPTION_CPU_ALERT_THRESHOLD'        => 'sitepulse_cpu_alert_threshold',
+    'SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES'     => 'sitepulse_alert_cooldown_minutes',
+    'SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS'      => 'sitepulse_speed_scan_results',
+    'SITEPULSE_TRANSIENT_AI_INSIGHT'              => 'sitepulse_ai_insight',
+    'SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX' => 'sitepulse_error_alert_',
+    'SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_SUFFIX' => '_lock',
+];
+
+foreach ($sitepulse_constants as $constant => $value) {
+    if (!defined($constant)) {
+        define($constant, $value);
+    }
+}
+
+if (!defined('SITEPULSE_TRANSIENT_ERROR_ALERT_CPU_LOCK')) {
+    define('SITEPULSE_TRANSIENT_ERROR_ALERT_CPU_LOCK', SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX . 'cpu' . SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_SUFFIX);
+}
+
+if (!defined('SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK')) {
+    define('SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK', SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX . 'php_fatal' . SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_SUFFIX);
+}
+
 $options = [
-    'sitepulse_active_modules',
-    'sitepulse_debug_mode',
-    'sitepulse_gemini_api_key',
-    'sitepulse_uptime_log',
-    'sitepulse_last_load_time',
-    'sitepulse_cpu_alert_threshold',
-    'sitepulse_alert_cooldown_minutes',
+    SITEPULSE_OPTION_ACTIVE_MODULES,
+    SITEPULSE_OPTION_DEBUG_MODE,
+    SITEPULSE_OPTION_GEMINI_API_KEY,
+    SITEPULSE_OPTION_UPTIME_LOG,
+    SITEPULSE_OPTION_LAST_LOAD_TIME,
+    SITEPULSE_OPTION_CPU_ALERT_THRESHOLD,
+    SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES,
     defined('SITEPULSE_PLUGIN_IMPACT_OPTION') ? SITEPULSE_PLUGIN_IMPACT_OPTION : 'sitepulse_plugin_impact_stats',
 ];
 
 $transients = [
-    'sitepulse_speed_scan_results',
-    'sitepulse_ai_insight',
-    'sitepulse_error_alert_cpu_lock',
-    'sitepulse_error_alert_php_fatal_lock',
+    SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS,
+    SITEPULSE_TRANSIENT_AI_INSIGHT,
+    SITEPULSE_TRANSIENT_ERROR_ALERT_CPU_LOCK,
+    SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK,
 ];
 
 $cron_hooks = require __DIR__ . '/includes/cron-hooks.php';


### PR DESCRIPTION
## Summary
- define reusable constants for SitePulse option and transient keys in the plugin bootstrap file
- update admin settings, modules, and integrations to rely on the constants when reading or clearing stored data
- ensure the uninstall routine and reset tools clean up using the same constant-backed keys to prevent drift

## Testing
- php -l sitepulse_FR/sitepulse.php sitepulse_FR/includes/admin-settings.php sitepulse_FR/includes/integrations.php sitepulse_FR/modules/ai_insights.php sitepulse_FR/modules/custom_dashboards.php sitepulse_FR/modules/error_alerts.php sitepulse_FR/modules/uptime_tracker.php sitepulse_FR/uninstall.php

------
https://chatgpt.com/codex/tasks/task_e_68cb275f88a4832e98bbbb875ed30bb5