### PR TITLE
Resolve plugin dir size paths via realpath

### DIFF
--- a/sitepulse_FR/modules/plugin_impact_scanner.php
+++ b/sitepulse_FR/modules/plugin_impact_scanner.php
@@ -454,13 +454,25 @@ function sitepulse_get_dir_size_with_cache($dir) {
 function sitepulse_get_dir_size_recursive($dir) {
     $size = 0;
 
-    if (!is_dir($dir)) {
+    $dir = (string) $dir;
+    $resolved_dir = $dir;
+
+    if (function_exists('realpath')) {
+        $realpath = realpath($dir);
+
+        if ($realpath !== false) {
+            // Resolve the directory to follow symlinks where possible.
+            $resolved_dir = $realpath;
+        }
+    }
+
+    if (!is_dir($resolved_dir)) {
         return $size;
     }
 
     try {
         $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS)
+            new RecursiveDirectoryIterator($resolved_dir, FilesystemIterator::SKIP_DOTS)
         );
 
         foreach ($iterator as $file) {


### PR DESCRIPTION
## Summary
- resolve plugin directories with `realpath()` before scanning to better handle symlinks

## Testing
- php -l sitepulse_FR/modules/plugin_impact_scanner.php

------
https://chatgpt.com/codex/tasks/task_e_68cc4df2de9c832eb2afcc89a200c11b