### PR TITLE
Store TTFB measurement and surface on dashboard

### DIFF
--- a/sitepulse_FR/modules/custom_dashboards.php
+++ b/sitepulse_FR/modules/custom_dashboards.php
@@ -44,10 +44,23 @@ function sitepulse_custom_dashboards_page() {
             <div class="sitepulse-card">
                 <?php
                 $results = get_transient(SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS);
-                $ttfb = (is_array($results) && isset($results['ttfb'])) ? $results['ttfb'] : 0;
-                $ttfb_status = $ttfb > 500 ? 'status-bad' : ($ttfb > 200 ? 'status-warn' : 'status-ok');
+                $ttfb = null;
+
+                if (is_array($results) && isset($results['ttfb']) && is_numeric($results['ttfb'])) {
+                    $ttfb = (float) $results['ttfb'];
+                }
+
+                $ttfb_status = 'status-ok';
+
+                if ($ttfb === null) {
+                    $ttfb_status = 'status-warn';
+                } elseif ($ttfb > 500) {
+                    $ttfb_status = 'status-bad';
+                } elseif ($ttfb > 200) {
+                    $ttfb_status = 'status-warn';
+                }
                 ?>
-                <?php $ttfb_display = $ttfb ? round($ttfb) . ' ' . esc_html__('ms', 'sitepulse') : esc_html__('N/A', 'sitepulse'); ?>
+                <?php $ttfb_display = $ttfb !== null ? round($ttfb) . ' ' . esc_html__('ms', 'sitepulse') : esc_html__('N/A', 'sitepulse'); ?>
                 <h2><span class="dashicons dashicons-performance"></span> <?php esc_html_e('Speed', 'sitepulse'); ?></h2>
                 <a href="<?php echo esc_url(admin_url('admin.php?page=sitepulse-speed')); ?>" class="button"><?php esc_html_e('Details', 'sitepulse'); ?></a>
                 <p><?php esc_html_e('Server Response (TTFB):', 'sitepulse'); ?> <span class="metric <?php echo esc_attr($ttfb_status); ?>"><?php echo esc_html($ttfb_display); ?></span></p>

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -136,6 +136,11 @@ function sitepulse_plugin_impact_tracker_persist() {
     }
 
     update_option(SITEPULSE_OPTION_LAST_LOAD_TIME, $request_duration_ms, false);
+    set_transient(
+        SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS,
+        ['ttfb' => $request_duration_ms],
+        MINUTE_IN_SECONDS * 10
+    );
 
     if (empty($sitepulse_plugin_impact_tracker_samples) || !is_array($sitepulse_plugin_impact_tracker_samples)) {
         return;


### PR DESCRIPTION
## Summary
- persist the measured request duration into the speed scan transient alongside the existing option update
- update the dashboard speed card to read numeric TTFB measurements from the transient and adjust status handling

## Testing
- php -l sitepulse_FR/sitepulse.php
- php -l sitepulse_FR/modules/custom_dashboards.php

------
https://chatgpt.com/codex/tasks/task_e_68cc4dd9f12c832e82898a24792bb947