### PR TITLE
Add guards against non-representative impact tracking requests

### DIFF
--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -134,6 +134,10 @@ function sitepulse_plugin_impact_tracker_persist() {
         $non_representative_context = true;
     } elseif (defined('REST_REQUEST') && REST_REQUEST) {
         $non_representative_context = true;
+    } elseif (defined('WP_CLI') && WP_CLI) {
+        $non_representative_context = true;
+    } elseif (defined('XMLRPC_REQUEST') && XMLRPC_REQUEST) {
+        $non_representative_context = true;
     }
 
     $should_measure_request = apply_filters(


### PR DESCRIPTION
## Summary
- broaden the persistence guard to skip CLI and XML-RPC requests when measuring plugin impact
- retain the public-request filter so administrators can customize which requests are measured

## Testing
- php -l sitepulse_FR/sitepulse.php

------
https://chatgpt.com/codex/tasks/task_e_68cc6e40d7cc832eb6e4b6ef0efa262d