### PR TITLE
Add guards to skip impact tracking for background requests

### DIFF
--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -121,6 +121,17 @@ function sitepulse_plugin_impact_tracker_on_plugin_loaded($plugin_file) {
 function sitepulse_plugin_impact_tracker_persist() {
     global $sitepulse_plugin_impact_tracker_samples, $sitepulse_plugin_impact_tracker_force_persist;
 
+    if ((function_exists('wp_doing_cron') && wp_doing_cron())
+        || (function_exists('wp_doing_ajax') && wp_doing_ajax())
+        || (defined('REST_REQUEST') && REST_REQUEST)
+    ) {
+        return;
+    }
+
+    if (function_exists('is_admin') && is_admin() && !apply_filters('sitepulse_track_admin_requests', false)) {
+        return;
+    }
+
     $request_start = null;
 
     if (isset($GLOBALS['timestart']) && is_numeric($GLOBALS['timestart'])) {


### PR DESCRIPTION
## Summary
- skip persisting request metrics when running in cron, AJAX, or REST contexts
- avoid tracking admin requests by default while adding a filter to opt-in

## Testing
- php -l sitepulse_FR/sitepulse.php

------
https://chatgpt.com/codex/tasks/task_e_68cc6da661e8832e8def6189b36732ac