### PR TITLE
Optimize speed scan persistence with timestamp

### DIFF
--- a/sitepulse_FR/modules/custom_dashboards.php
+++ b/sitepulse_FR/modules/custom_dashboards.php
@@ -46,8 +46,12 @@ function sitepulse_custom_dashboards_page() {
                 $results = get_transient(SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS);
                 $ttfb = null;
 
-                if (is_array($results) && isset($results['ttfb']) && is_numeric($results['ttfb'])) {
-                    $ttfb = (float) $results['ttfb'];
+                if (is_array($results)) {
+                    if (isset($results['ttfb']) && is_numeric($results['ttfb'])) {
+                        $ttfb = (float) $results['ttfb'];
+                    } elseif (isset($results['data']['ttfb']) && is_numeric($results['data']['ttfb'])) {
+                        $ttfb = (float) $results['data']['ttfb'];
+                    }
                 }
 
                 $ttfb_status = 'status-ok';


### PR DESCRIPTION
## Summary
- add timestamp metadata to speed scan transient and skip redundant option writes when a fresh measurement already exists
- keep existing measurement schema compatible by including the TTFB value and adjusting the dashboard reader to tolerate nested data

## Testing
- php -l sitepulse_FR/sitepulse.php
- php -l sitepulse_FR/modules/custom_dashboards.php

------
https://chatgpt.com/codex/tasks/task_e_68cda8e56c2c832e8f7623fe45c25542