### PR TITLE
Add configurable alert interval for error monitoring

### DIFF
--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -25,6 +25,7 @@ define('SITEPULSE_OPTION_UPTIME_LOG', 'sitepulse_uptime_log');
 define('SITEPULSE_OPTION_LAST_LOAD_TIME', 'sitepulse_last_load_time');
 define('SITEPULSE_OPTION_CPU_ALERT_THRESHOLD', 'sitepulse_cpu_alert_threshold');
 define('SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES', 'sitepulse_alert_cooldown_minutes');
+define('SITEPULSE_OPTION_ALERT_INTERVAL', 'sitepulse_alert_interval');
 
 define('SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS', 'sitepulse_speed_scan_results');
 define('SITEPULSE_TRANSIENT_AI_INSIGHT', 'sitepulse_ai_insight');
@@ -577,6 +578,7 @@ function sitepulse_activate_site() {
     add_option(SITEPULSE_OPTION_GEMINI_API_KEY, '');
     add_option(SITEPULSE_OPTION_CPU_ALERT_THRESHOLD, 5);
     add_option(SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES, 60);
+    add_option(SITEPULSE_OPTION_ALERT_INTERVAL, 5);
 }
 
 /**

--- a/sitepulse_FR/uninstall.php
+++ b/sitepulse_FR/uninstall.php
@@ -19,6 +19,7 @@ $sitepulse_constants = [
     'SITEPULSE_OPTION_LAST_LOAD_TIME'             => 'sitepulse_last_load_time',
     'SITEPULSE_OPTION_CPU_ALERT_THRESHOLD'        => 'sitepulse_cpu_alert_threshold',
     'SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES'     => 'sitepulse_alert_cooldown_minutes',
+    'SITEPULSE_OPTION_ALERT_INTERVAL'             => 'sitepulse_alert_interval',
     'SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS'      => 'sitepulse_speed_scan_results',
     'SITEPULSE_TRANSIENT_AI_INSIGHT'              => 'sitepulse_ai_insight',
     'SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX' => 'sitepulse_error_alert_',
@@ -49,6 +50,7 @@ $options = [
     SITEPULSE_OPTION_LAST_LOAD_TIME,
     SITEPULSE_OPTION_CPU_ALERT_THRESHOLD,
     SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES,
+    SITEPULSE_OPTION_ALERT_INTERVAL,
     SITEPULSE_PLUGIN_IMPACT_OPTION,
 ];
 


### PR DESCRIPTION
## Summary
- define the new `SITEPULSE_OPTION_ALERT_INTERVAL` option and register it with sanitization and defaults
- expose a frequency selector in the alert settings to choose 5/10/15/30 minute cron intervals
- update the error alert module to honor the option, validate the interval, and reschedule cron events when it changes

## Testing
- php -l sitepulse_FR/sitepulse.php
- php -l sitepulse_FR/includes/admin-settings.php
- php -l sitepulse_FR/modules/error_alerts.php
- php -l sitepulse_FR/uninstall.php

------
https://chatgpt.com/codex/tasks/task_e_68cdbd610900832e86ff84278bdd224c