### PR TITLE
Return cached AI insight when available

### DIFF
--- a/sitepulse_FR/modules/ai_insights.php
+++ b/sitepulse_FR/modules/ai_insights.php
@@ -102,6 +102,30 @@ function sitepulse_generate_ai_insight() {
         ], 403);
     }
 
+    $cached_insight = get_transient(SITEPULSE_TRANSIENT_AI_INSIGHT);
+
+    if (is_array($cached_insight) && isset($cached_insight['text'])) {
+        $cached_text = sanitize_textarea_field($cached_insight['text']);
+
+        if ('' !== $cached_text) {
+            $payload = ['text' => $cached_text];
+
+            if (isset($cached_insight['timestamp'])) {
+                $payload['timestamp'] = (int) $cached_insight['timestamp'];
+            }
+
+            wp_send_json_success($payload);
+        }
+    } elseif (is_string($cached_insight) && '' !== $cached_insight) {
+        $cached_text = sanitize_textarea_field($cached_insight);
+
+        if ('' !== $cached_text) {
+            wp_send_json_success([
+                'text' => $cached_text,
+            ]);
+        }
+    }
+
     $api_key = trim((string) get_option(SITEPULSE_OPTION_GEMINI_API_KEY));
 
     if ('' === $api_key) {


### PR DESCRIPTION
## Summary
- return cached AI insight data when a sanitized transient is available before calling Gemini

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce69eb99a4832ea22d369238a2e9b8