### PR TITLE
Ensure network activation handles all sites

### DIFF
--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -600,9 +600,18 @@ function sitepulse_deactivate_site() {
  */
 register_activation_hook(__FILE__, function($network_wide) {
     if (is_multisite() && $network_wide) {
-        $sites = get_sites(['fields' => 'ids']);
+        $site_ids = get_sites([
+            'fields' => 'ids',
+            'number' => 0,
+        ]);
 
-        foreach ($sites as $site_id) {
+        foreach ($site_ids as $site_id) {
+            $site_id = (int) $site_id;
+
+            if ($site_id <= 0) {
+                continue;
+            }
+
             switch_to_blog($site_id);
             sitepulse_activate_site();
             restore_current_blog();
@@ -621,9 +630,18 @@ register_activation_hook(__FILE__, function($network_wide) {
  */
 register_deactivation_hook(__FILE__, function($network_wide) {
     if (is_multisite() && $network_wide) {
-        $sites = get_sites(['fields' => 'ids']);
+        $site_ids = get_sites([
+            'fields' => 'ids',
+            'number' => 0,
+        ]);
 
-        foreach ($sites as $site_id) {
+        foreach ($site_ids as $site_id) {
+            $site_id = (int) $site_id;
+
+            if ($site_id <= 0) {
+                continue;
+            }
+
             switch_to_blog($site_id);
             sitepulse_deactivate_site();
             restore_current_blog();


### PR DESCRIPTION
## Summary
- request the full list of site IDs during network-wide activation and deactivation
- skip invalid IDs before switching blogs so every valid site runs the plugin hooks

## Testing
- php -l sitepulse.php

------
https://chatgpt.com/codex/tasks/task_e_68ce8f4685f0832ea0e79fbc3409b1e7