### PR TITLE
Handle debug log deletion failures

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -440,8 +440,14 @@ function sitepulse_settings_page() {
             }
 
             if (defined('SITEPULSE_DEBUG_LOG') && file_exists(SITEPULSE_DEBUG_LOG)) {
+                $log_deleted = false;
+
                 if (function_exists('wp_delete_file')) {
                     $log_deleted = wp_delete_file(SITEPULSE_DEBUG_LOG);
+
+                    if (function_exists('is_wp_error') && is_wp_error($log_deleted)) {
+                        $log_deleted = false;
+                    }
                 } else {
                     $log_deleted = @unlink(SITEPULSE_DEBUG_LOG);
                 }


### PR DESCRIPTION
## Summary
- guard debug log removal during full reset by using tolerant deletion and logging failures

## Testing
- php -l includes/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68cea9161bf0832e8e90741c9d1e3b59