### PR TITLE
Handle debug log deletion failure in reset flow

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -443,10 +443,12 @@ function sitepulse_settings_page() {
                 $log_deleted = false;
 
                 if (function_exists('wp_delete_file')) {
-                    $log_deleted = wp_delete_file(SITEPULSE_DEBUG_LOG);
+                    $delete_result = wp_delete_file(SITEPULSE_DEBUG_LOG);
 
-                    if (function_exists('is_wp_error') && is_wp_error($log_deleted)) {
+                    if (function_exists('is_wp_error') && is_wp_error($delete_result)) {
                         $log_deleted = false;
+                    } else {
+                        $log_deleted = (bool) $delete_result;
                     }
                 } else {
                     $log_deleted = @unlink(SITEPULSE_DEBUG_LOG);


### PR DESCRIPTION
## Summary
- ensure the reset-all routine handles debug log removal failures gracefully
- rely on wp_delete_file when available and treat WP_Error responses as failures
- keep the success notice gated on all operations, logging and surfacing an error when the log file cannot be deleted

## Testing
- php -l sitepulse_FR/includes/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68cee6498490832eb6b970bcef6ec56d