### PR TITLE
Support custom WP_DEBUG_LOG paths

### DIFF
--- a/sitepulse_FR/modules/custom_dashboards.php
+++ b/sitepulse_FR/modules/custom_dashboards.php
@@ -101,19 +101,25 @@ function sitepulse_custom_dashboards_page() {
              <!-- Log Status Card -->
             <div class="sitepulse-card">
                 <?php
-                $log_file = WP_CONTENT_DIR . '/debug.log';
+                $log_file = function_exists('sitepulse_get_wp_debug_log_path') ? sitepulse_get_wp_debug_log_path() : null;
                 $log_status_class = 'status-ok';
                 $log_summary = esc_html__('Log is clean.', 'sitepulse');
 
-                if (!file_exists($log_file)) {
+                if ($log_file === null) {
                     $log_status_class = 'status-warn';
-                    $log_summary = esc_html__('Log file not found.', 'sitepulse');
+                    $log_summary = esc_html__('Debug log not configured.', 'sitepulse');
+                } elseif (!file_exists($log_file)) {
+                    $log_status_class = 'status-warn';
+                    $log_summary = sprintf(esc_html__('Log file not found (%s).', 'sitepulse'), esc_html($log_file));
+                } elseif (!is_readable($log_file)) {
+                    $log_status_class = 'status-warn';
+                    $log_summary = sprintf(esc_html__('Unable to read log file (%s).', 'sitepulse'), esc_html($log_file));
                 } else {
                     $recent_logs = sitepulse_get_recent_log_lines($log_file, 200, 131072);
 
                     if ($recent_logs === null) {
                         $log_status_class = 'status-warn';
-                        $log_summary = esc_html__('Unable to read log file.', 'sitepulse');
+                        $log_summary = sprintf(esc_html__('Unable to read log file (%s).', 'sitepulse'), esc_html($log_file));
                     } elseif (empty($recent_logs)) {
                         $log_summary = esc_html__('No recent log entries.', 'sitepulse');
                     } else {

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -41,6 +41,44 @@ define('SITEPULSE_NONCE_ACTION_CLEANUP', 'sitepulse_cleanup');
 define('SITEPULSE_NONCE_FIELD_CLEANUP', 'sitepulse_cleanup_nonce');
 define('SITEPULSE_ACTION_PLUGIN_IMPACT_REFRESH', 'sitepulse_plugin_impact_refresh');
 
+/**
+ * Retrieves the absolute path to the WordPress debug log file.
+ *
+ * @param bool $require_readable Optional. When true, only returns the path if the
+ *                               file exists and is readable. Default false.
+ *
+ * @return string|null Normalized file path when available, null otherwise.
+ */
+function sitepulse_get_wp_debug_log_path($require_readable = false) {
+    if (!defined('WP_DEBUG_LOG') || !WP_DEBUG_LOG) {
+        return null;
+    }
+
+    $path = null;
+
+    if (is_string(WP_DEBUG_LOG) && WP_DEBUG_LOG !== '') {
+        $path = WP_DEBUG_LOG;
+    } elseif (true === WP_DEBUG_LOG) {
+        $path = WP_CONTENT_DIR . '/debug.log';
+    }
+
+    if ($path === null) {
+        return null;
+    }
+
+    if (function_exists('wp_normalize_path')) {
+        $path = wp_normalize_path($path);
+    } else {
+        $path = str_replace('\\', '/', $path);
+    }
+
+    if ($require_readable && (!file_exists($path) || !is_readable($path))) {
+        return null;
+    }
+
+    return $path;
+}
+
 $debug_mode = get_option(SITEPULSE_OPTION_DEBUG_MODE, false);
 define('SITEPULSE_DEBUG', (bool) $debug_mode);
 


### PR DESCRIPTION
## Summary
- add a shared helper to resolve the active WP_DEBUG_LOG file location
- update the log analyzer, dashboard card, and alert module to rely on the helper and handle unreadable logs
- improve alert messaging so custom debug log paths are surfaced to users

## Testing
- php -l sitepulse_FR/sitepulse.php
- php -l sitepulse_FR/modules/log_analyzer.php
- php -l sitepulse_FR/modules/custom_dashboards.php
- php -l sitepulse_FR/modules/error_alerts.php

------
https://chatgpt.com/codex/tasks/task_e_68cf22a6543c832eaa9560266708821b