### PR TITLE
Use WordPress timezone-aware timestamps in logging

### DIFF
--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -526,7 +526,13 @@ function sitepulse_log($message, $level = 'INFO') {
         }
     }
 
-    $timestamp  = date('Y-m-d H:i:s');
+    if (function_exists('wp_date')) {
+        $timestamp = wp_date('Y-m-d H:i:s');
+    } elseif (function_exists('current_time')) {
+        $timestamp = current_time('mysql');
+    } else {
+        $timestamp = date('Y-m-d H:i:s');
+    }
     $log_entry  = "[$timestamp] [$level] $message\n";
     $max_size   = 5 * 1024 * 1024; // 5 MB
 


### PR DESCRIPTION
## Summary
- switch SitePulse log timestamps to use WordPress timezone-aware helpers
- fall back to the PHP date function only when WordPress helpers are unavailable

## Testing
- php -l sitepulse_FR/sitepulse.php

------
https://chatgpt.com/codex/tasks/task_e_68cf38bfbf64832e924f3b93de73a39a