### PR TITLE
Fix size_format output escaping

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -615,7 +615,7 @@ function sitepulse_debug_page() {
                                 <li><strong>Version de PHP:</strong> <?php echo esc_html(PHP_VERSION); ?></li>
                                 <li><strong>Modules Actifs:</strong> <?php echo $active_modules_list ? esc_html($active_modules_list) : esc_html('Aucun'); ?></li>
                                 <li><strong>WP Memory Limit:</strong> <?php echo esc_html(WP_MEMORY_LIMIT); ?></li>
-                                <li><strong>Pic d'utilisation mémoire:</strong> <?php echo esc_html(size_format(memory_get_peak_usage(true))); ?></li>
+                                <li><strong>Pic d'utilisation mémoire:</strong> <?php echo wp_kses_post(size_format(memory_get_peak_usage(true))); ?></li>
                             </ul>
                         </div>
                     </div>
@@ -651,7 +651,7 @@ function sitepulse_debug_page() {
             printf(
                 esc_html__('Seules les %1$d dernières lignes du journal (limitées à %2$s) sont chargées pour éviter toute surcharge mémoire.', 'sitepulse'),
                 (int) $log_max_lines,
-                esc_html(size_format($log_max_bytes))
+                wp_kses_post(size_format($log_max_bytes))
             );
             ?>
         </p>

--- a/sitepulse_FR/modules/plugin_impact_scanner.php
+++ b/sitepulse_FR/modules/plugin_impact_scanner.php
@@ -356,7 +356,7 @@ function sitepulse_plugin_impact_scanner_page() {
                     <tr>
                         <td><strong><?php echo esc_html($data['name']); ?></strong></td>
                         <td><?php echo $impact_output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
-                        <td><?php echo esc_html(size_format($data['disk_space'], 2)); ?></td>
+                        <td><?php echo wp_kses_post(size_format($data['disk_space'], 2)); ?></td>
                         <td>
                             <?php if ($weight !== null) : ?>
                                 <div class="impact-bar-bg">

--- a/sitepulse_FR/modules/resource_monitor.php
+++ b/sitepulse_FR/modules/resource_monitor.php
@@ -168,8 +168,8 @@ function sitepulse_resource_monitor_page() {
             <?php endforeach; ?>
         <?php endif; ?>
         <p><strong>Charge CPU (1/5/15 min):</strong> <?php echo esc_html($load_display); ?></p>
-        <p><strong>Mémoire:</strong> Utilisation <?php echo esc_html($memory_usage); ?> / Limite <?php echo esc_html($memory_limit); ?></p>
-        <p><strong>Disque:</strong> Espace Libre <?php echo esc_html($disk_free); ?> / Total <?php echo esc_html($disk_total); ?></p>
+        <p><strong>Mémoire:</strong> Utilisation <?php echo wp_kses_post($memory_usage); ?> / Limite <?php echo esc_html($memory_limit); ?></p>
+        <p><strong>Disque:</strong> Espace Libre <?php echo wp_kses_post($disk_free); ?> / Total <?php echo wp_kses_post($disk_total); ?></p>
     </div>
     <?php
 }


### PR DESCRIPTION
## Summary
- switch size_format outputs in the admin settings and plugin impact scanner to wp_kses_post so non-breaking spaces render correctly
- update the resource monitor metrics to use wp_kses_post for size_format values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf4125f9f8832e82b0455f68f552eb