### PR TITLE
Allow uptime checker to treat redirects as up

### DIFF
--- a/sitepulse_FR/modules/uptime_tracker.php
+++ b/sitepulse_FR/modules/uptime_tracker.php
@@ -47,7 +47,8 @@ function sitepulse_uptime_tracker_page() {
 function sitepulse_run_uptime_check() {
     $response = wp_remote_get(home_url(), ['timeout' => 10]);
     $response_code = wp_remote_retrieve_response_code($response);
-    $is_up = !is_wp_error($response) && $response_code >= 200 && $response_code < 300;
+    // Considère les réponses HTTP dans la plage 2xx ou 3xx comme un site "up"
+    $is_up = !is_wp_error($response) && $response_code >= 200 && $response_code < 400;
     $log = get_option(SITEPULSE_OPTION_UPTIME_LOG, []);
     $log[] = (int)$is_up;
     if (count($log) > 30) { array_shift($log); }


### PR DESCRIPTION
## Summary
- treat HTTP 3xx responses as successful uptime checks so redirects do not trigger downtime alerts
- document the broader success range directly in the uptime check implementation

## Testing
- php -l sitepulse_FR/modules/uptime_tracker.php

------
https://chatgpt.com/codex/tasks/task_e_68cfef27b6c4832e8d54ac2f865f1c3c