### PR TITLE
Reinitialize dashboard module after full reset

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -481,6 +481,10 @@ function sitepulse_settings_page() {
             foreach ($cron_hooks as $hook) {
                 wp_clear_scheduled_hook($hook);
             }
+            if ($reset_success && function_exists('sitepulse_activate_site')) {
+                sitepulse_activate_site();
+            }
+
             if ($reset_success) {
                 echo '<div class="notice notice-success is-dismissible"><p>SitePulse a été réinitialisé.</p></div>';
             } elseif ($log_deletion_failed) {


### PR DESCRIPTION
## Summary
- re-run site activation logic after a full reset to restore default modules before showing the success notice

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d05f850d9c832e86d0b699f34c4ee2