### PR TITLE
Fix cron timestamps display using wp_date

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -635,7 +635,7 @@ function sitepulse_debug_page() {
                                         foreach ($cron as $hook => $events) {
                                             if (strpos($hook, 'sitepulse') !== false) {
                                                 $has_sitepulse_cron = true;
-                                                $next_run = get_date_from_gmt(date('Y-m-d H:i:s', $timestamp));
+                                                $next_run = wp_date('Y-m-d H:i:s', $timestamp);
                                                 echo '<li><strong>' . esc_html($hook) . '</strong> - Prochaine exécution: ' . esc_html($next_run) . '</li>';
                                             }
                                         }


### PR DESCRIPTION
## Summary
- replace the cron schedule timestamp formatting to rely on wp_date so that WordPress' timezone is respected

## Testing
- php -l sitepulse_FR/includes/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68d181662894832eae936fc2b3aa987c