### PR TITLE
Allow forcing AI insight refresh

### DIFF
--- a/sitepulse_FR/modules/ai_insights.php
+++ b/sitepulse_FR/modules/ai_insights.php
@@ -78,6 +78,10 @@ function sitepulse_ai_insights_page() {
         <?php else : ?>
             <div class="sitepulse-ai-insight-actions">
                 <button type="button" id="sitepulse-ai-generate" class="button button-primary"><?php esc_html_e('Générer une Analyse', 'sitepulse'); ?></button>
+                <label for="sitepulse-ai-force-refresh" class="sitepulse-ai-force-refresh">
+                    <input type="checkbox" id="sitepulse-ai-force-refresh" />
+                    <?php esc_html_e('Forcer une nouvelle analyse', 'sitepulse'); ?>
+                </label>
                 <span class="spinner" id="sitepulse-ai-spinner" style="float: none; margin-top: 0;"></span>
             </div>
         <?php endif; ?>

--- a/sitepulse_FR/modules/js/sitepulse-ai-insights.js
+++ b/sitepulse_FR/modules/js/sitepulse-ai-insights.js
@@ -91,6 +91,7 @@
         var $statusEl = $resultContainer.find('.sitepulse-ai-insight-status');
         var $resultText = $resultContainer.find('.sitepulse-ai-insight-text');
         var $timestampEl = $resultContainer.find('.sitepulse-ai-insight-timestamp');
+        var $forceRefreshToggle = $('#sitepulse-ai-force-refresh');
         var lastResultData = null;
 
         $errorContainer.hide();
@@ -116,11 +117,18 @@
             $resultContainer.show();
             setStatus($statusEl, sitepulseAIInsights.strings.statusGenerating);
 
-            $.post(sitepulseAIInsights.ajaxUrl, {
+            var requestData = {
                 action: 'sitepulse_generate_ai_insight',
-                nonce: sitepulseAIInsights.nonce,
-                force_refresh: true
-            }).done(function (response) {
+                nonce: sitepulseAIInsights.nonce
+            };
+
+            var forceRefresh = $forceRefreshToggle.length > 0 && $forceRefreshToggle.is(':checked');
+
+            if (forceRefresh) {
+                requestData.force_refresh = true;
+            }
+
+            $.post(sitepulseAIInsights.ajaxUrl, requestData).done(function (response) {
                 if (response && response.success && response.data) {
                     lastResultData = renderResult($resultContainer, $resultText, $timestampEl, $statusEl, response.data);
                 } else if (response && response.data && response.data.message) {


### PR DESCRIPTION
## Summary
- add a checkbox in the AI Insights admin UI to explicitly request a fresh analysis
- update the AJAX request to only send force_refresh when the checkbox is enabled and keep cache status messaging

## Testing
- php -l sitepulse_FR/modules/ai_insights.php

------
https://chatgpt.com/codex/tasks/task_e_68d1c9b12440832e8e4cc2514f167f75