### PR TITLE
Include alert interval option in reset cleanup

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -447,6 +447,7 @@ function sitepulse_settings_page() {
                 SITEPULSE_OPTION_LAST_LOAD_TIME,
                 SITEPULSE_OPTION_CPU_ALERT_THRESHOLD,
                 SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES,
+                SITEPULSE_OPTION_ALERT_INTERVAL,
                 SITEPULSE_PLUGIN_IMPACT_OPTION,
             ];
 


### PR DESCRIPTION
## Summary
- ensure the reset process deletes the alert interval option so it is recreated with the default value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d26d037630832eaf0a963b2994b0fc