### PR TITLE
Include alert recipients option in reset cleanup

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -448,6 +448,7 @@ function sitepulse_settings_page() {
                 SITEPULSE_OPTION_CPU_ALERT_THRESHOLD,
                 SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES,
                 SITEPULSE_OPTION_ALERT_INTERVAL,
+                SITEPULSE_OPTION_ALERT_RECIPIENTS,
                 SITEPULSE_PLUGIN_IMPACT_OPTION,
             ];
 


### PR DESCRIPTION
## Summary
- ensure the SitePulse reset routine also deletes the alert recipients option so it is recreated with default values

## Testing
- not run (WordPress admin environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d2739b1120832eaa03a7a5e293f8c4