### PR TITLE
Update alert interval hook signature

### DIFF
--- a/sitepulse_FR/modules/error_alerts.php
+++ b/sitepulse_FR/modules/error_alerts.php
@@ -346,11 +346,12 @@ function sitepulse_error_alerts_check_debug_log() {
 /**
  * Handles rescheduling when the alert interval option is updated.
  *
- * @param mixed $old_value Previous value.
- * @param mixed $value     New value.
+ * @param mixed      $old_value Previous value.
+ * @param mixed      $value     New value.
+ * @param string|int $option    Option name. Unused.
  * @return void
  */
-function sitepulse_error_alerts_on_interval_update($old_value, $value) {
+function sitepulse_error_alerts_on_interval_update($old_value, $value, $option = null) {
     global $sitepulse_error_alerts_cron_hook, $sitepulse_error_alerts_schedule;
 
     if (empty($sitepulse_error_alerts_cron_hook)) {


### PR DESCRIPTION
## Summary
- allow sitepulse_error_alerts_on_interval_update to receive the option parameter expected by WordPress
- document the unused option parameter in the callback docblock

## Testing
- php -l sitepulse_FR/modules/error_alerts.php

------
https://chatgpt.com/codex/tasks/task_e_68d27cc67f40832e8d6ae13adb4fe39d