### PR TITLE
Document optional option parameter for interval update callback

### DIFF
--- a/sitepulse_FR/modules/error_alerts.php
+++ b/sitepulse_FR/modules/error_alerts.php
@@ -346,9 +346,9 @@ function sitepulse_error_alerts_check_debug_log() {
 /**
  * Handles rescheduling when the alert interval option is updated.
  *
- * @param mixed      $old_value Previous value.
- * @param mixed      $value     New value.
- * @param string|int $option    Option name. Unused.
+ * @param mixed            $old_value Previous value.
+ * @param mixed            $value     New value.
+ * @param string|int|null  $option    Option name. Unused.
  * @return void
  */
 function sitepulse_error_alerts_on_interval_update($old_value, $value, $option = null) {


### PR DESCRIPTION
## Summary
- document the optional option parameter in the interval update callback docblock to reflect the three-argument signature

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d283394f18832e823d559585288a55