### PR TITLE
Ensure reset clears alert recipients option

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -448,6 +448,7 @@ function sitepulse_settings_page() {
                 SITEPULSE_OPTION_CPU_ALERT_THRESHOLD,
                 SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES,
                 SITEPULSE_OPTION_ALERT_INTERVAL,
+                SITEPULSE_OPTION_ALERT_RECIPIENTS,
                 SITEPULSE_PLUGIN_IMPACT_OPTION,
             ];
 


### PR DESCRIPTION
## Summary
- delete the alert recipients option when resetting the plugin so its stored list is cleared
- rely on the existing sitepulse_activate_site call to recreate default options with an empty recipients list

## Testing
- php -l sitepulse_FR/includes/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68d2bd86e49c832e92ad6d3815d53dcd