### PR TITLE
Normalise active module options before implode

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -678,7 +678,13 @@ function sitepulse_debug_page() {
                     <div class="postbox">
                         <h2 class="hndle"><span>Détails de l'Environnement</span></h2>
                         <div class="inside">
-                            <?php $active_modules_list = implode(', ', get_option(SITEPULSE_OPTION_ACTIVE_MODULES, [])); ?>
+                            <?php
+                            $active_modules_option = get_option(SITEPULSE_OPTION_ACTIVE_MODULES, []);
+                            $active_modules = array_values(array_filter(array_map('strval', (array) $active_modules_option), static function ($module) {
+                                return $module !== '';
+                            }));
+                            $active_modules_list = implode(', ', $active_modules);
+                            ?>
                             <ul>
                                 <li><strong>Version de SitePulse:</strong> <?php echo esc_html(SITEPULSE_VERSION); ?></li>
                                 <li><strong>Version de WordPress:</strong> <?php echo esc_html(get_bloginfo('version')); ?></li>

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -587,9 +587,12 @@ function sitepulse_load_modules() {
         'error_alerts'          => 'Error Alerts',
     ];
     
-    $active_modules = get_option(SITEPULSE_OPTION_ACTIVE_MODULES, []);
+    $active_modules_option = get_option(SITEPULSE_OPTION_ACTIVE_MODULES, []);
+    $active_modules = array_values(array_filter(array_map('strval', (array) $active_modules_option), static function ($module) {
+        return $module !== '';
+    }));
     sitepulse_log('Loading active modules: ' . implode(', ', $active_modules));
-    
+
     foreach ($active_modules as $module_key) {
         if (!array_key_exists($module_key, $modules)) {
             sitepulse_log("Module $module_key not found or invalid", 'WARNING');


### PR DESCRIPTION
## Summary
- normalise the active modules option before logging or iterating so non-array values cannot trigger fatal errors
- normalise the admin debug page module list before imploding to keep the page accessible even if the option is corrupted

## Testing
- php -l sitepulse_FR/sitepulse.php
- php -l sitepulse_FR/includes/admin-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68d3a5d44484832e83ce9eab6744b5ac