### PR TITLE
Améliore la pertinence des alertes et du tableau de bord

### DIFF
--- a/sitepulse_FR/README.md
+++ b/sitepulse_FR/README.md
@@ -9,7 +9,7 @@ Monitors your WordPress site's speed, database, maintenance, server, and errors 
 
 Sitepulse - JLG takes the pulse of your WordPress site, offering modules for:
 
-- Speed analysis (load times, TTFB)
+- Speed analysis (load times, server processing time)
 - Database optimization (clean bloat, suggest indexes)
 - Server monitoring (CPU, memory, uptime)
 - Error logging and alerts

--- a/sitepulse_FR/languages/sitepulse.pot
+++ b/sitepulse_FR/languages/sitepulse.pot
@@ -38,11 +38,11 @@ msgid "Details"
 msgstr ""
 
 #: modules/custom_dashboards.php:53
-msgid "Server Response (TTFB):"
+msgid "Server PHP Processing:"
 msgstr ""
 
 #: modules/custom_dashboards.php:54
-msgid "Time to First Byte measures how quickly your server responds. Under 200ms is excellent."
+msgid "Measures the backend execution time captured at shutdown. Under 200ms indicates an excellent PHP response."
 msgstr ""
 
 #: modules/custom_dashboards.php:66

--- a/sitepulse_FR/modules/custom_dashboards.php
+++ b/sitepulse_FR/modules/custom_dashboards.php
@@ -44,31 +44,35 @@ function sitepulse_custom_dashboards_page() {
             <div class="sitepulse-card">
                 <?php
                 $results = get_transient(SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS);
-                $ttfb = null;
+                $processing_time = null;
 
                 if (is_array($results)) {
-                    if (isset($results['ttfb']) && is_numeric($results['ttfb'])) {
-                        $ttfb = (float) $results['ttfb'];
+                    if (isset($results['server_processing_ms']) && is_numeric($results['server_processing_ms'])) {
+                        $processing_time = (float) $results['server_processing_ms'];
+                    } elseif (isset($results['ttfb']) && is_numeric($results['ttfb'])) {
+                        $processing_time = (float) $results['ttfb'];
+                    } elseif (isset($results['data']['server_processing_ms']) && is_numeric($results['data']['server_processing_ms'])) {
+                        $processing_time = (float) $results['data']['server_processing_ms'];
                     } elseif (isset($results['data']['ttfb']) && is_numeric($results['data']['ttfb'])) {
-                        $ttfb = (float) $results['data']['ttfb'];
+                        $processing_time = (float) $results['data']['ttfb'];
                     }
                 }
 
-                $ttfb_status = 'status-ok';
+                $processing_status = 'status-ok';
 
-                if ($ttfb === null) {
-                    $ttfb_status = 'status-warn';
-                } elseif ($ttfb > 500) {
-                    $ttfb_status = 'status-bad';
-                } elseif ($ttfb > 200) {
-                    $ttfb_status = 'status-warn';
+                if ($processing_time === null) {
+                    $processing_status = 'status-warn';
+                } elseif ($processing_time > 500) {
+                    $processing_status = 'status-bad';
+                } elseif ($processing_time > 200) {
+                    $processing_status = 'status-warn';
                 }
                 ?>
-                <?php $ttfb_display = $ttfb !== null ? round($ttfb) . ' ' . esc_html__('ms', 'sitepulse') : esc_html__('N/A', 'sitepulse'); ?>
+                <?php $processing_display = $processing_time !== null ? round($processing_time) . ' ' . esc_html__('ms', 'sitepulse') : esc_html__('N/A', 'sitepulse'); ?>
                 <h2><span class="dashicons dashicons-performance"></span> <?php esc_html_e('Speed', 'sitepulse'); ?></h2>
                 <a href="<?php echo esc_url(admin_url('admin.php?page=sitepulse-speed')); ?>" class="button"><?php esc_html_e('Details', 'sitepulse'); ?></a>
-                <p><?php esc_html_e('Server Response (TTFB):', 'sitepulse'); ?> <span class="metric <?php echo esc_attr($ttfb_status); ?>"><?php echo esc_html($ttfb_display); ?></span></p>
-                <p class="description"><?php esc_html_e('Time to First Byte measures how quickly your server responds. Under 200ms is excellent.', 'sitepulse'); ?></p>
+                <p><?php esc_html_e('Server PHP Processing:', 'sitepulse'); ?> <span class="metric <?php echo esc_attr($processing_status); ?>"><?php echo esc_html($processing_display); ?></span></p>
+                <p class="description"><?php esc_html_e('Measures the backend execution time captured at shutdown. Under 200ms indicates an excellent PHP response.', 'sitepulse'); ?></p>
             </div>
 
             <!-- Uptime Card -->

--- a/sitepulse_FR/readme.txt
+++ b/sitepulse_FR/readme.txt
@@ -14,7 +14,7 @@ Monitors your WordPress site's speed, database, maintenance, server, and errors 
 
 Sitepulse - JLG takes the pulse of your WordPress site, offering modules for:
 
-* Speed analysis (load times, TTFB)
+* Speed analysis (load times, server processing time)
 * Database optimization (clean bloat, suggest indexes)
 * Server monitoring (CPU, memory, uptime)
 * Error logging and alerts

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -248,8 +248,9 @@ function sitepulse_plugin_impact_tracker_persist() {
         set_transient(
             SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS,
             [
-                'ttfb'      => $request_duration_ms,
-                'timestamp' => $current_timestamp,
+                'server_processing_ms' => $request_duration_ms,
+                'ttfb'                 => $request_duration_ms, // Back-compat for earlier dashboard versions.
+                'timestamp'            => $current_timestamp,
             ],
             MINUTE_IN_SECONDS * 10
         );


### PR DESCRIPTION
## Summary
- tient compte du nombre de cœurs CPU pour normaliser l’alerte de charge et expose des filtres pour personnaliser la détection
- renomme la mesure de vitesse en « Server PHP Processing » et stocke une clé dédiée tout en conservant la compatibilité
- accélère le nettoyage des révisions en supprimant en masse via SQL tout en gérant le cache et la métadonnée résiduelle

## Testing
- php -l sitepulse_FR/modules/error_alerts.php
- php -l sitepulse_FR/sitepulse.php
- php -l sitepulse_FR/modules/custom_dashboards.php
- php -l sitepulse_FR/modules/database_optimizer.php


------
https://chatgpt.com/codex/tasks/task_e_68d3be116590832e831f121a7bc4a450