### PR TITLE
Secure Gemini auth and harden DB optimizer form handling

### DIFF
--- a/sitepulse_FR/modules/ai_insights.php
+++ b/sitepulse_FR/modules/ai_insights.php
@@ -183,11 +183,7 @@ function sitepulse_generate_ai_insight() {
         ], 400);
     }
 
-    $endpoint = add_query_arg(
-        'key',
-        $api_key,
-        'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent'
-    );
+    $endpoint = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent';
 
     $site_name        = wp_strip_all_tags(get_bloginfo('name'));
     $site_url         = esc_url_raw(home_url());
@@ -228,7 +224,8 @@ function sitepulse_generate_ai_insight() {
         $endpoint,
         [
             'headers' => [
-                'Content-Type' => 'application/json',
+                'Content-Type'  => 'application/json',
+                'x-goog-api-key' => $api_key,
             ],
             'body'    => wp_json_encode($request_body),
             'timeout' => 30,

--- a/sitepulse_FR/modules/database_optimizer.php
+++ b/sitepulse_FR/modules/database_optimizer.php
@@ -7,8 +7,13 @@ function sitepulse_database_optimizer_page() {
     }
 
     global $wpdb;
-    if (isset($_POST['db_cleanup_nonce']) && wp_verify_nonce($_POST['db_cleanup_nonce'], 'db_cleanup')) {
-        if (isset($_POST['clean_revisions'])) {
+    if (isset($_POST['db_cleanup_nonce'])) {
+        check_admin_referer('db_cleanup', 'db_cleanup_nonce');
+
+        $clean_revisions  = isset($_POST['clean_revisions']) && '1' === wp_unslash($_POST['clean_revisions']);
+        $clean_transients = isset($_POST['clean_transients']) && '1' === wp_unslash($_POST['clean_transients']);
+
+        if ($clean_revisions) {
             $batch_size = 500;
             $cleaned = 0;
             $remaining_meta = 0;
@@ -127,7 +132,7 @@ function sitepulse_database_optimizer_page() {
                 );
             }
         }
-        if (isset($_POST['clean_transients'])) {
+        if ($clean_transients) {
             $cleaned = null;
             $generic_success = false;
 


### PR DESCRIPTION
## Summary
- switch the Gemini API call to use an authentication header instead of leaking the key in the query string
- normalize nonce handling in the database optimizer by delegating to check_admin_referer
- sanitize the cleanup form inputs before evaluating the selected actions

## Testing
- php -l sitepulse_FR/modules/ai_insights.php
- php -l sitepulse_FR/modules/database_optimizer.php

------
https://chatgpt.com/codex/tasks/task_e_68d3c4e16510832e95d7709d98a32557