### PR TITLE
Add interactive dashboard visuals and reorderable widgets

### DIFF
--- a/sitepulse_FR/modules/js/sitepulse-dashboard-charts.js
+++ b/sitepulse_FR/modules/js/sitepulse-dashboard-charts.js
@@ -1,0 +1,278 @@
+(function (window, document) {
+    'use strict';
+
+    function mergeOptions(base, overrides) {
+        var result = Array.isArray(base) ? base.slice() : Object.assign({}, base || {});
+
+        if (!overrides || typeof overrides !== 'object') {
+            return result;
+        }
+
+        Object.keys(overrides).forEach(function (key) {
+            var value = overrides[key];
+
+            if (value && typeof value === 'object' && !Array.isArray(value)) {
+                result[key] = mergeOptions(base ? base[key] : undefined, value);
+            } else {
+                result[key] = value;
+            }
+        });
+
+        return result;
+    }
+
+    function normalizeDatasets(datasets) {
+        if (!Array.isArray(datasets)) {
+            return [];
+        }
+
+        return datasets.map(function (dataset) {
+            var normalized = {
+                data: Array.isArray(dataset.data) ? dataset.data : [],
+                backgroundColor: Array.isArray(dataset.backgroundColor) ? dataset.backgroundColor : [],
+            };
+
+            if (typeof dataset.borderWidth === 'number') {
+                normalized.borderWidth = dataset.borderWidth;
+            } else {
+                normalized.borderWidth = 0;
+            }
+
+            if (typeof dataset.borderRadius !== 'undefined') {
+                normalized.borderRadius = dataset.borderRadius;
+            }
+
+            if (typeof dataset.hoverOffset === 'number') {
+                normalized.hoverOffset = dataset.hoverOffset;
+            } else {
+                normalized.hoverOffset = 6;
+            }
+
+            return normalized;
+        });
+    }
+
+    function showFallback(canvas, message) {
+        if (!canvas) {
+            return;
+        }
+
+        var container = canvas.parentElement;
+        if (!container) {
+            return;
+        }
+
+        container.removeChild(canvas);
+        var placeholder = document.createElement('p');
+        placeholder.className = 'sitepulse-chart-empty';
+        placeholder.textContent = message;
+        container.appendChild(placeholder);
+    }
+
+    function formatValue(value, unit, fractionDigits) {
+        if (typeof value !== 'number' || !isFinite(value)) {
+            value = 0;
+        }
+
+        var options = {};
+        if (typeof fractionDigits === 'number') {
+            options.minimumFractionDigits = fractionDigits;
+            options.maximumFractionDigits = fractionDigits;
+        } else {
+            options.maximumFractionDigits = 2;
+        }
+
+        var formatted = value.toLocaleString(undefined, options);
+        if (unit) {
+            if (unit === '%') {
+                return formatted + unit;
+            }
+            return formatted + ' ' + unit;
+        }
+
+        return formatted;
+    }
+
+    function createChart(canvasId, chartConfig, overrides, strings) {
+        var canvas = document.getElementById(canvasId);
+        if (!canvas) {
+            return null;
+        }
+
+        if (!chartConfig || chartConfig.empty || !Array.isArray(chartConfig.datasets) || chartConfig.datasets.length === 0) {
+            showFallback(canvas, strings && strings.noData ? strings.noData : 'No data');
+            return null;
+        }
+
+        var data = {
+            labels: Array.isArray(chartConfig.labels) ? chartConfig.labels : [],
+            datasets: normalizeDatasets(chartConfig.datasets),
+        };
+
+        var baseOptions = {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: {
+                    display: true,
+                    position: 'bottom',
+                },
+                tooltip: {},
+            },
+        };
+
+        var options = mergeOptions(baseOptions, overrides || {});
+
+        return new Chart(canvas, {
+            type: chartConfig.type || 'doughnut',
+            data: data,
+            options: options,
+        });
+    }
+
+    function init() {
+        if (typeof Chart === 'undefined') {
+            return;
+        }
+
+        var config = window.SitePulseDashboardData || {};
+        var charts = config.charts || {};
+        var strings = config.strings || {};
+
+        if (charts.speed) {
+            createChart(
+                'sitepulse-speed-chart',
+                charts.speed,
+                {
+                    cutout: '65%',
+                    plugins: {
+                        legend: {
+                            display: false,
+                        },
+                        tooltip: {
+                            callbacks: {
+                                label: function (context) {
+                                    var label = context.label || strings.speedTooltipLabel || '';
+                                    var raw = typeof context.raw === 'number' ? context.raw : 0;
+                                    var unit = charts.speed.unit || 'ms';
+                                    return label + ': ' + formatValue(raw, unit, 0);
+                                },
+                            },
+                        },
+                    },
+                },
+                strings
+            );
+        } else {
+            showFallback(document.getElementById('sitepulse-speed-chart'), strings.noData || 'No data');
+        }
+
+        if (charts.uptime) {
+            createChart(
+                'sitepulse-uptime-chart',
+                charts.uptime,
+                {
+                    plugins: {
+                        legend: {
+                            display: false,
+                        },
+                        tooltip: {
+                            callbacks: {
+                                label: function (context) {
+                                    var isUp = typeof context.raw === 'number' && context.raw >= 100;
+                                    var label = isUp ? strings.uptimeTooltipUp : strings.uptimeTooltipDown;
+                                    return (label || '') + ': ' + formatValue(context.raw, charts.uptime.unit || '%', 0);
+                                },
+                            },
+                        },
+                    },
+                    scales: {
+                        y: {
+                            beginAtZero: true,
+                            max: 100,
+                            ticks: {
+                                callback: function (value) {
+                                    return value + '%';
+                                },
+                            },
+                            title: {
+                                display: !!strings.uptimeAxisLabel,
+                                text: strings.uptimeAxisLabel || '',
+                            },
+                        },
+                        x: {
+                            ticks: {
+                                maxRotation: 0,
+                                autoSkip: true,
+                                maxTicksLimit: 8,
+                            },
+                        },
+                    },
+                },
+                strings
+            );
+        } else {
+            showFallback(document.getElementById('sitepulse-uptime-chart'), strings.noData || 'No data');
+        }
+
+        if (charts.database) {
+            createChart(
+                'sitepulse-database-chart',
+                charts.database,
+                {
+                    cutout: '65%',
+                    plugins: {
+                        legend: {
+                            position: 'bottom',
+                        },
+                        tooltip: {
+                            callbacks: {
+                                label: function (context) {
+                                    var label = context.label || strings.revisionsTooltip || '';
+                                    var raw = typeof context.raw === 'number' ? context.raw : 0;
+                                    return label + ': ' + formatValue(raw, null, 0);
+                                },
+                            },
+                        },
+                    },
+                },
+                strings
+            );
+        } else {
+            showFallback(document.getElementById('sitepulse-database-chart'), strings.noData || 'No data');
+        }
+
+        if (charts.logs) {
+            createChart(
+                'sitepulse-log-chart',
+                charts.logs,
+                {
+                    cutout: '60%',
+                    plugins: {
+                        legend: {
+                            position: 'bottom',
+                        },
+                        tooltip: {
+                            callbacks: {
+                                label: function (context) {
+                                    var label = context.label || strings.logEventsLabel || '';
+                                    var raw = typeof context.raw === 'number' ? context.raw : 0;
+                                    return label + ': ' + formatValue(raw, null, 0);
+                                },
+                            },
+                        },
+                    },
+                },
+                strings
+            );
+        } else {
+            showFallback(document.getElementById('sitepulse-log-chart'), strings.noData || 'No data');
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})(window, document);

--- a/sitepulse_FR/modules/js/sitepulse-dashboard-layout.js
+++ b/sitepulse_FR/modules/js/sitepulse-dashboard-layout.js
@@ -1,0 +1,130 @@
+(function () {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    const settings = window.SitePulseDashboardLayout || {};
+    const container = document.getElementById('sitepulse-dashboard-grid');
+
+    if (!container || typeof Sortable === 'undefined') {
+        return;
+    }
+
+    const speak = (message, politeness = 'polite') => {
+        if (!message) {
+            return;
+        }
+
+        if (window.wp && wp.a11y && typeof wp.a11y.speak === 'function') {
+            wp.a11y.speak(message, politeness);
+        }
+    };
+
+    let isSaving = false;
+
+    const saveOrder = () => {
+        if (!settings.ajaxUrl || !settings.nonce || isSaving) {
+            return;
+        }
+
+        const order = Array.from(container.querySelectorAll('[data-widget]'))
+            .map((card) => card.getAttribute('data-widget'))
+            .filter(Boolean);
+
+        if (!order.length) {
+            return;
+        }
+
+        isSaving = true;
+        container.classList.add('is-saving');
+
+        const payload = new URLSearchParams();
+        payload.set('action', 'sitepulse_save_dashboard_order');
+        payload.set('nonce', settings.nonce);
+        payload.set('order', JSON.stringify(order));
+
+        fetch(settings.ajaxUrl, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            },
+            body: payload.toString(),
+        })
+            .then((response) => response.json())
+            .then((data) => {
+                if (data && data.success) {
+                    speak(settings.strings && settings.strings.saved);
+                } else {
+                    speak(settings.strings && settings.strings.error, 'assertive');
+                }
+            })
+            .catch(() => {
+                speak(settings.strings && settings.strings.error, 'assertive');
+            })
+            .finally(() => {
+                isSaving = false;
+                container.classList.remove('is-saving');
+            });
+    };
+
+    Sortable.create(container, {
+        animation: 150,
+        handle: '.sitepulse-card-handle',
+        dragClass: 'sitepulse-card-dragging',
+        ghostClass: 'sitepulse-card-ghost',
+        onEnd: saveOrder,
+    });
+
+    container.addEventListener('keydown', (event) => {
+        const handle = event.target.closest('.sitepulse-card-handle');
+
+        if (!handle) {
+            return;
+        }
+
+        const card = handle.closest('[data-widget]');
+
+        if (!card) {
+            return;
+        }
+
+        const keys = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'];
+
+        if (!keys.includes(event.key)) {
+            return;
+        }
+
+        event.preventDefault();
+
+        const cards = Array.from(container.querySelectorAll('[data-widget]'));
+        const index = cards.indexOf(card);
+
+        if (index === -1) {
+            return;
+        }
+
+        let newIndex = index;
+
+        if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+            newIndex = Math.max(0, index - 1);
+        } else if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+            newIndex = Math.min(cards.length - 1, index + 1);
+        }
+
+        if (newIndex === index) {
+            return;
+        }
+
+        const reference = cards[newIndex];
+
+        if (newIndex < index) {
+            container.insertBefore(card, reference);
+        } else {
+            container.insertBefore(card, reference.nextElementSibling);
+        }
+
+        handle.focus();
+        saveOrder();
+    });
+})();


### PR DESCRIPTION
## Summary
- register Chart.js and a custom dashboard script so the admin page can load interactive charts
- compute structured datasets for speed, uptime, database and log metrics and expose them to JavaScript
- refresh the dashboard layout with chart containers, updated copy and metric summaries
- add a dedicated JavaScript module that renders doughnut and bar charts with fallbacks for missing data
- enable drag-and-drop widget ordering with persisted preferences per admin user

## Testing
- php -l sitepulse_FR/modules/custom_dashboards.php

------
https://chatgpt.com/codex/tasks/task_e_68d3e664e08c832e88d4145758b46af1