### PR TITLE
Improve loader integrity and fatal error detection

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -719,16 +719,23 @@ function sitepulse_debug_page() {
                         <div class="inside">
                            <ul>
                                 <?php 
-                                $crons = _get_cron_array();
+                                $crons = get_option('cron');
                                 $has_sitepulse_cron = false;
-                                if (!empty($crons)) {
+
+                                if (is_array($crons)) {
                                     foreach ($crons as $timestamp => $cron) {
+                                        if (!is_numeric($timestamp) || !is_array($cron)) {
+                                            continue;
+                                        }
+
                                         foreach ($cron as $hook => $events) {
-                                            if (strpos($hook, 'sitepulse') !== false) {
-                                                $has_sitepulse_cron = true;
-                                                $next_run = wp_date('Y-m-d H:i:s', $timestamp);
-                                                echo '<li><strong>' . esc_html($hook) . '</strong> - Prochaine exécution: ' . esc_html($next_run) . '</li>';
+                                            if (strpos((string) $hook, 'sitepulse') === false) {
+                                                continue;
                                             }
+
+                                            $has_sitepulse_cron = true;
+                                            $next_run = wp_date('Y-m-d H:i:s', (int) $timestamp);
+                                            echo '<li><strong>' . esc_html($hook) . '</strong> - Prochaine exécution: ' . esc_html($next_run) . '</li>';
                                         }
                                     }
                                 }

--- a/sitepulse_FR/modules/error_alerts.php
+++ b/sitepulse_FR/modules/error_alerts.php
@@ -425,7 +425,15 @@ function sitepulse_error_alerts_check_debug_log() {
     }
 
     foreach ($recent_log_lines as $log_line) {
-        if (stripos($log_line, 'PHP Fatal error') !== false) {
+        $has_fatal_error = false;
+
+        if (function_exists('sitepulse_log_line_contains_fatal_error')) {
+            $has_fatal_error = sitepulse_log_line_contains_fatal_error($log_line);
+        } elseif (stripos($log_line, 'PHP Fatal error') !== false) {
+            $has_fatal_error = true;
+        }
+
+        if ($has_fatal_error) {
             sitepulse_error_alert_send(
                 'php_fatal',
                 'Alerte SitePulse: Erreur Fatale Détectée',

--- a/sitepulse_FR/modules/log_analyzer.php
+++ b/sitepulse_FR/modules/log_analyzer.php
@@ -59,7 +59,7 @@ function sitepulse_log_analyzer_page() {
 
                 foreach ($recent_log_lines as $line) {
                     if (empty(trim($line))) continue;
-                    if (stripos($line, 'PHP Fatal error') !== false) { $categorized['fatal_errors'][] = $line; }
+                    if ((function_exists('sitepulse_log_line_contains_fatal_error') && sitepulse_log_line_contains_fatal_error($line)) || stripos($line, 'PHP Fatal error') !== false) { $categorized['fatal_errors'][] = $line; }
                     elseif (stripos($line, 'PHP Parse error') !== false || stripos($line, 'PHP Error') !== false) { $categorized['errors'][] = $line; }
                     elseif (stripos($line, 'PHP Warning') !== false) { $categorized['warnings'][] = $line; }
                     elseif (stripos($line, 'PHP Notice') !== false || stripos($line, 'PHP Deprecated') !== false) { $categorized['notices'][] = $line; }


### PR DESCRIPTION
## Summary
- switch MU loader signature management to SHA-256 with timing-safe comparisons
- add shared helper to detect additional fatal log signatures and reuse it in alerts/analyzer
- replace use of private `_get_cron_array()` with public cron option access for debug page

## Testing
- php -l sitepulse_FR/sitepulse.php
- php -l sitepulse_FR/includes/admin-settings.php
- php -l sitepulse_FR/modules/log_analyzer.php
- php -l sitepulse_FR/modules/error_alerts.php

------
https://chatgpt.com/codex/tasks/task_e_68d435fc8d7c832e93457065c10c9cf2