### PR TITLE
Fix multisite cache purge and transient cleanup safeguards

### DIFF
--- a/sitepulse_FR/modules/database_optimizer.php
+++ b/sitepulse_FR/modules/database_optimizer.php
@@ -33,6 +33,8 @@ function sitepulse_database_optimizer_page() {
                 $previous_cache_invalidation = wp_suspend_cache_invalidation(true);
             }
 
+            $revision_ids = [];
+
             do {
                 $sql = $wpdb->prepare(
                     "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'revision' AND ID > %d ORDER BY ID ASC LIMIT %d",
@@ -345,6 +347,8 @@ function sitepulse_cleanup_transient_source($wpdb, $source, $current_time) {
     }
 
     $purged = 0;
+
+    $expired_timeouts = [];
 
     do {
         $sql = "SELECT {$key_column} FROM {$table} WHERE {$key_column} LIKE %s AND {$value_column} < %s";

--- a/sitepulse_FR/modules/plugin_impact_scanner.php
+++ b/sitepulse_FR/modules/plugin_impact_scanner.php
@@ -66,7 +66,13 @@ function sitepulse_plugin_impact_clear_dir_cache_on_upgrade($upgrader, $hook_ext
         sitepulse_clear_dir_size_cache($plugin_dir_path);
 
         if (is_multisite()) {
-            $site_ids = function_exists('get_sites') ? get_sites(['fields' => 'ids']) : [];
+            $site_ids = function_exists('get_sites')
+                ? get_sites([
+                    'fields' => 'ids',
+                    'number' => 0,
+                    'no_found_rows' => true,
+                ])
+                : [];
 
             if (!empty($site_ids) && defined('SITEPULSE_TRANSIENT_PLUGIN_DIR_SIZE_PREFIX')) {
                 $transient_key = SITEPULSE_TRANSIENT_PLUGIN_DIR_SIZE_PREFIX . md5($plugin_dir_path);


### PR DESCRIPTION
## Summary
- ensure the plugin impact cache purge iterates over every site in multisite networks by requesting all site IDs
- prevent undefined variable notices in database and transient cleanup loops by initializing the batch arrays before the do/while structures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d50a68a64c832eab862d164ee96054