### PR TITLE
Ensure transient cleanup compares numeric timeouts

### DIFF
--- a/sitepulse_FR/modules/database_optimizer.php
+++ b/sitepulse_FR/modules/database_optimizer.php
@@ -351,8 +351,8 @@ function sitepulse_cleanup_transient_source($wpdb, $source, $current_time) {
     $expired_timeouts = [];
 
     do {
-        $sql = "SELECT {$key_column} FROM {$table} WHERE {$key_column} LIKE %s AND {$value_column} < %s";
-        $params = array($wpdb->esc_like($timeout_prefix) . '%', $current_time);
+        $sql = "SELECT {$key_column} FROM {$table} WHERE {$key_column} LIKE %s AND CAST({$value_column} AS UNSIGNED) < %d";
+        $params = array($wpdb->esc_like($timeout_prefix) . '%', (int) $current_time);
 
         if ($table === $wpdb->sitemeta && $site_id !== null) {
             $sql .= ' AND site_id = %d';


### PR DESCRIPTION
## Summary
- cast the transient cleanup query to compare numeric timeout values and pass the current time as an integer
- enhance the fallback transient cleanup test harness to log prepared statements and cover malformed timeouts and multisite clauses

## Testing
- php sitepulse_FR/tests/sitepulse_transient_fallback_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d59147dddc832ebe09530c8feacbd6