### PR TITLE
Ensure transient cleanup uses numeric comparison

### DIFF
--- a/sitepulse_FR/modules/database_optimizer.php
+++ b/sitepulse_FR/modules/database_optimizer.php
@@ -364,7 +364,7 @@ function sitepulse_cleanup_transient_source($wpdb, $source, $current_time) {
 
         $prepared = $wpdb->prepare($sql, $params);
 
-        if ($prepared === false) {
+        if ($prepared === false || !is_string($prepared)) {
             break;
         }
 


### PR DESCRIPTION
## Summary
- ensure transient cleanup bails when `$wpdb->prepare()` fails to return a SQL string
- extend the fake `$wpdb` used in tests to build prepared SQL strings and log them for assertions
- verify both single-site and multisite cleanup queries cast timeout values numerically and produce the expected prepared SQL

## Testing
- php sitepulse_FR/tests/sitepulse_transient_fallback_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d5ad0b1bc0832e9343a6912e522ff6