### PR TITLE
Localize error alert emails

### DIFF
--- a/sitepulse_FR/languages/sitepulse-fr_FR.po
+++ b/sitepulse_FR/languages/sitepulse-fr_FR.po
@@ -1,0 +1,34 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: SitePulse 1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-06-02 00:00+0000\n"
+"PO-Revision-Date: 2024-06-02 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: French\n"
+"Language: fr_FR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Manual\n"
+"X-Domain: sitepulse\n"
+
+#: modules/error_alerts.php:370
+#, php-format
+msgid "SitePulse Alert: High Server Load on %s"
+msgstr "Alerte SitePulse : charge serveur élevée sur %s"
+
+#: modules/error_alerts.php:383
+#, php-format
+msgid "Current server load on %1$s: %2$s (detected cores: %3$d, load per core: %4$s, threshold per core: %5$s)"
+msgstr "Charge serveur actuelle sur %1$s : %2$s (cœurs détectés : %3$d, charge par cœur : %4$s, seuil par cœur : %5$s)"
+
+#: modules/error_alerts.php:408
+#, php-format
+msgid "SitePulse Alert: Fatal Error Detected on %s"
+msgstr "Alerte SitePulse : erreur fatale détectée sur %s"
+
+#: modules/error_alerts.php:414
+#, php-format
+msgid "Review %1$s for error details affecting %2$s."
+msgstr "Consultez %1$s pour les détails des erreurs affectant %2$s."

--- a/sitepulse_FR/languages/sitepulse.pot
+++ b/sitepulse_FR/languages/sitepulse.pot
@@ -13,6 +13,26 @@ msgstr ""
 "X-Generator: Manual\n"
 "X-Domain: sitepulse\n"
 
+#: modules/error_alerts.php:370
+#, php-format
+msgid "SitePulse Alert: High Server Load on %s"
+msgstr ""
+
+#: modules/error_alerts.php:383
+#, php-format
+msgid "Current server load on %1$s: %2$s (detected cores: %3$d, load per core: %4$s, threshold per core: %5$s)"
+msgstr ""
+
+#: modules/error_alerts.php:408
+#, php-format
+msgid "SitePulse Alert: Fatal Error Detected on %s"
+msgstr ""
+
+#: modules/error_alerts.php:414
+#, php-format
+msgid "Review %1$s for error details affecting %2$s."
+msgstr ""
+
 #: modules/custom_dashboards.php:39
 msgid "SitePulse Dashboard"
 msgstr ""

--- a/sitepulse_FR/modules/error_alerts.php
+++ b/sitepulse_FR/modules/error_alerts.php
@@ -363,14 +363,32 @@ function sitepulse_error_alerts_check_cpu_load() {
     $normalized_load = (float) $load[0] / $core_count;
 
     if ($normalized_load > $threshold) {
+        $site_name = get_bloginfo('name');
+
+        /* translators: %s: Site title. */
+        $subject = sprintf(
+            __('SitePulse Alert: High Server Load on %s', 'sitepulse'),
+            $site_name
+        );
+
+        /*
+         * translators:
+         * %1$s: Site title.
+         * %2$s: Current server load.
+         * %3$d: Detected CPU cores.
+         * %4$s: Load per core.
+         * %5$s: Threshold per core.
+         */
         $message = sprintf(
-            'Charge serveur actuelle : %1$s (cœurs détectés : %2$d, charge par cœur : %3$s, seuil par cœur : %4$s)',
+            esc_html__('Current server load on %1$s: %2$s (detected cores: %3$d, load per core: %4$s, threshold per core: %5$s)', 'sitepulse'),
+            $site_name,
             number_format_i18n((float) $load[0], 2),
             $core_count,
             number_format_i18n($normalized_load, 2),
             number_format_i18n($threshold, 2)
         );
-        sitepulse_error_alert_send('cpu', 'Alerte SitePulse: Charge Serveur Élevée', $message);
+
+        sitepulse_error_alert_send('cpu', $subject, $message);
     }
 }
 
@@ -505,11 +523,22 @@ function sitepulse_error_alerts_check_debug_log() {
         }
 
         if ($has_fatal_error) {
-            sitepulse_error_alert_send(
-                'php_fatal',
-                'Alerte SitePulse: Erreur Fatale Détectée',
-                sprintf('Vérifiez le fichier %s pour les détails.', $log_file)
+            $site_name = get_bloginfo('name');
+
+            /* translators: %s: Site title. */
+            $subject = sprintf(
+                __('SitePulse Alert: Fatal Error Detected on %s', 'sitepulse'),
+                $site_name
             );
+
+            /* translators: 1: Log file path. 2: Site title. */
+            $message = sprintf(
+                esc_html__('Review %1$s for error details affecting %2$s.', 'sitepulse'),
+                $log_file,
+                $site_name
+            );
+
+            sitepulse_error_alert_send('php_fatal', $subject, $message);
             break;
         }
     }


### PR DESCRIPTION
## Summary
- localize CPU and fatal error alert email subjects and bodies with translation wrappers and site metadata placeholders
- add new strings to the translation template and provide French translations

## Testing
- php -l modules/error_alerts.php

------
https://chatgpt.com/codex/tasks/task_e_68d5b3ef8fe0832e889f50bbcd79f95e