### PR TITLE
Ensure transient cleanup casts identifiers as integers

### DIFF
--- a/sitepulse_FR/modules/database_optimizer.php
+++ b/sitepulse_FR/modules/database_optimizer.php
@@ -356,7 +356,7 @@ function sitepulse_cleanup_transient_source($wpdb, $source, $current_time) {
 
         if ($table === $wpdb->sitemeta && $site_id !== null) {
             $sql .= ' AND site_id = %d';
-            $params[] = $site_id;
+            $params[] = (int) $site_id;
         }
 
         $sql .= " ORDER BY {$value_column} ASC LIMIT %d";


### PR DESCRIPTION
## Summary
- cast the multisite site_id parameter to an integer before preparing the transient cleanup query
- extend the fallback transient cleanup test to cover malformed multisite timestamps and assert the prepared statement uses integer parameters

## Testing
- php sitepulse_FR/tests/sitepulse_transient_fallback_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d5b3eddfd8832e8da7d123a1fd5139