### PR TITLE
Queue SitePulse debug notices for admin display

### DIFF
--- a/sitepulse_FR/includes/debug-notices.php
+++ b/sitepulse_FR/includes/debug-notices.php
@@ -1,0 +1,176 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!defined('SITEPULSE_OPTION_DEBUG_NOTICES')) {
+    define('SITEPULSE_OPTION_DEBUG_NOTICES', 'sitepulse_debug_notices');
+}
+
+if (!defined('SITEPULSE_DEBUG')) {
+    define('SITEPULSE_DEBUG', false);
+}
+
+/**
+ * Tracks notices scheduled during the current request to prevent duplicates.
+ *
+ * @param string|null $notice_key Unique notice identifier. When null the
+ *                                registry state is inspected or reset.
+ * @param bool        $mark       Whether to mark (or reset when key is null)
+ *                                the notice as scheduled.
+ *
+ * @return bool True when the notice was already recorded, false otherwise.
+ */
+function sitepulse_debug_notice_registry($notice_key = null, $mark = false)
+{
+    static $registry = [];
+
+    if ($notice_key === null) {
+        if ($mark) {
+            $registry = [];
+        }
+
+        return !empty($registry);
+    }
+
+    $notice_key = (string) $notice_key;
+
+    if ($mark) {
+        $registry[$notice_key] = true;
+    }
+
+    return isset($registry[$notice_key]);
+}
+
+/**
+ * Schedules an admin notice to report SitePulse debug errors.
+ *
+ * When invoked outside of the admin area the notice is queued for later
+ * display. The queue is flushed on the next admin page load to ensure that
+ * administrators are notified even when issues happen on the frontend.
+ *
+ * @param string $message The notice body.
+ * @param string $type    The notice type (error, warning, info, success).
+ *
+ * @return void
+ */
+function sitepulse_schedule_debug_admin_notice($message, $type = 'error')
+{
+    if (!SITEPULSE_DEBUG || !function_exists('add_action')) {
+        return;
+    }
+
+    $allowed_types = ['error', 'warning', 'info', 'success'];
+    $type          = in_array($type, $allowed_types, true) ? $type : 'error';
+    $message       = (string) $message;
+    $notice_key    = $type . '|' . $message;
+
+    if (sitepulse_debug_notice_registry($notice_key)) {
+        return;
+    }
+
+    sitepulse_debug_notice_registry($notice_key, true);
+
+    if (!function_exists('is_admin') || !is_admin()) {
+        if (!function_exists('get_option') || !function_exists('update_option')) {
+            return;
+        }
+
+        $queued_notices = get_option(SITEPULSE_OPTION_DEBUG_NOTICES, []);
+
+        if (!is_array($queued_notices)) {
+            $queued_notices = [];
+        }
+
+        foreach ($queued_notices as $queued_notice) {
+            if (!is_array($queued_notice)) {
+                continue;
+            }
+
+            $queued_message = isset($queued_notice['message']) ? (string) $queued_notice['message'] : '';
+            $queued_type    = isset($queued_notice['type']) ? (string) $queued_notice['type'] : 'error';
+
+            if ($queued_message === $message && $queued_type === $type) {
+                return;
+            }
+        }
+
+        $queued_notices[] = [
+            'message' => $message,
+            'type'    => $type,
+        ];
+
+        update_option(SITEPULSE_OPTION_DEBUG_NOTICES, $queued_notices);
+
+        return;
+    }
+
+    $class = 'notice notice-' . $type;
+
+    add_action('admin_notices', function () use ($message, $class) {
+        if (!function_exists('esc_attr') || !function_exists('esc_html')) {
+            return;
+        }
+
+        printf('<div class="%s"><p>%s</p></div>', esc_attr($class), esc_html($message));
+    });
+}
+
+/**
+ * Outputs queued debug notices during admin requests.
+ *
+ * @return void
+ */
+function sitepulse_display_queued_debug_notices()
+{
+    if (!SITEPULSE_DEBUG || !function_exists('get_option')) {
+        return;
+    }
+
+    $queued_notices = get_option(SITEPULSE_OPTION_DEBUG_NOTICES, []);
+
+    if (!is_array($queued_notices) || $queued_notices === []) {
+        return;
+    }
+
+    if (!function_exists('esc_attr') || !function_exists('esc_html')) {
+        return;
+    }
+
+    $allowed_types = ['error', 'warning', 'info', 'success'];
+
+    foreach ($queued_notices as $notice) {
+        if (!is_array($notice) || !isset($notice['message'])) {
+            continue;
+        }
+
+        $message = (string) $notice['message'];
+        $type    = isset($notice['type']) ? (string) $notice['type'] : 'error';
+
+        if (!in_array($type, $allowed_types, true)) {
+            $type = 'error';
+        }
+
+        $class = 'notice notice-' . $type;
+
+        $notice_key = $type . '|' . $message;
+
+        if (sitepulse_debug_notice_registry($notice_key)) {
+            continue;
+        }
+
+        sitepulse_debug_notice_registry($notice_key, true);
+
+        printf('<div class="%s"><p>%s</p></div>', esc_attr($class), esc_html($message));
+    }
+
+    if (function_exists('delete_option')) {
+        delete_option(SITEPULSE_OPTION_DEBUG_NOTICES);
+    } elseif (function_exists('update_option')) {
+        update_option(SITEPULSE_OPTION_DEBUG_NOTICES, []);
+    }
+}
+
+if (function_exists('add_action')) {
+    add_action('admin_notices', 'sitepulse_display_queued_debug_notices', 0);
+}

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -31,6 +31,7 @@ define('SITEPULSE_OPTION_ALERT_RECIPIENTS', 'sitepulse_alert_recipients');
 define('SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE', 'sitepulse_impact_loader_signature');
 define('SITEPULSE_OPTION_ERROR_ALERT_LOG_POINTER', 'sitepulse_error_alert_log_pointer');
 define('SITEPULSE_OPTION_CRON_WARNINGS', 'sitepulse_cron_warnings');
+define('SITEPULSE_OPTION_DEBUG_NOTICES', 'sitepulse_debug_notices');
 
 define('SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS', 'sitepulse_speed_scan_results');
 define('SITEPULSE_TRANSIENT_AI_INSIGHT', 'sitepulse_ai_insight');
@@ -112,6 +113,7 @@ if (function_exists('wp_mkdir_p') && !is_dir($sitepulse_debug_directory)) {
 
 define('SITEPULSE_DEBUG_LOG', rtrim($sitepulse_debug_directory, '/\\') . '/sitepulse-debug.log');
 
+require_once SITEPULSE_PATH . 'includes/debug-notices.php';
 require_once SITEPULSE_PATH . 'includes/plugin-impact-tracker.php';
 sitepulse_plugin_impact_tracker_bootstrap();
 
@@ -565,40 +567,6 @@ function sitepulse_handle_module_changes($old_value, $value, $option = null) {
 }
 
 add_action('update_option_' . SITEPULSE_OPTION_ACTIVE_MODULES, 'sitepulse_handle_module_changes', 10, 3);
-
-/**
- * Schedules an admin notice to report SitePulse debug errors.
- *
- * @param string $message The notice body.
- * @param string $type    The notice type (error, warning, info, success).
- *
- * @return void
- */
-function sitepulse_schedule_debug_admin_notice($message, $type = 'error') {
-    if (!SITEPULSE_DEBUG || !function_exists('add_action') || !function_exists('is_admin') || !is_admin()) {
-        return;
-    }
-
-    static $displayed_messages = [];
-
-    if (isset($displayed_messages[$message])) {
-        return;
-    }
-
-    $displayed_messages[$message] = true;
-
-    $allowed_types = ['error', 'warning', 'info', 'success'];
-    $type          = in_array($type, $allowed_types, true) ? $type : 'error';
-    $class         = 'notice notice-' . $type;
-
-    add_action('admin_notices', function () use ($message, $class) {
-        if (!function_exists('esc_attr') || !function_exists('esc_html')) {
-            return;
-        }
-
-        printf('<div class="%s"><p>%s</p></div>', esc_attr($class), esc_html($message));
-    });
-}
 
 /**
  * Logging function for debugging purposes.

--- a/sitepulse_FR/tests/sitepulse_debug_notices_test.php
+++ b/sitepulse_FR/tests/sitepulse_debug_notices_test.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+define('ABSPATH', __DIR__);
+
+$GLOBALS['sitepulse_hooks'] = [];
+$GLOBALS['sitepulse_options'] = [];
+$GLOBALS['sitepulse_is_admin'] = false;
+
+if (!defined('SITEPULSE_DEBUG')) {
+    define('SITEPULSE_DEBUG', true);
+}
+
+if (!function_exists('add_action')) {
+    function add_action($hook, $callback, $priority = 10, $accepted_args = 1)
+    {
+        $GLOBALS['sitepulse_hooks'][$hook][] = $callback;
+    }
+}
+
+if (!function_exists('is_admin')) {
+    function is_admin()
+    {
+        return !empty($GLOBALS['sitepulse_is_admin']);
+    }
+}
+
+if (!function_exists('get_option')) {
+    function get_option($name, $default = false)
+    {
+        return $GLOBALS['sitepulse_options'][$name] ?? $default;
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option($name, $value)
+    {
+        $GLOBALS['sitepulse_options'][$name] = $value;
+
+        return true;
+    }
+}
+
+if (!function_exists('delete_option')) {
+    function delete_option($name)
+    {
+        unset($GLOBALS['sitepulse_options'][$name]);
+
+        return true;
+    }
+}
+
+if (!function_exists('esc_attr')) {
+    function esc_attr($text)
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('esc_html')) {
+    function esc_html($text)
+    {
+        return $text;
+    }
+}
+
+require_once dirname(__DIR__) . '/includes/debug-notices.php';
+
+function sitepulse_assert($condition, $message)
+{
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+// Ensure the queue display hook is registered.
+sitepulse_assert(isset($GLOBALS['sitepulse_hooks']['admin_notices'][0]), 'Queue display hook must be registered.');
+sitepulse_assert($GLOBALS['sitepulse_hooks']['admin_notices'][0] === 'sitepulse_display_queued_debug_notices', 'Queue display hook should point to sitepulse_display_queued_debug_notices.');
+
+// Scenario 1: Notices scheduled on the frontend are queued.
+$GLOBALS['sitepulse_is_admin'] = false;
+sitepulse_schedule_debug_admin_notice('Rotation failed', 'error');
+$queued = get_option(SITEPULSE_OPTION_DEBUG_NOTICES, []);
+sitepulse_assert(count($queued) === 1, 'Frontend scheduling should queue a notice.');
+sitepulse_assert($queued[0]['message'] === 'Rotation failed', 'Queued message must be preserved.');
+sitepulse_assert($queued[0]['type'] === 'error', 'Queued type must be normalized.');
+
+// Duplicate message should not be added twice.
+sitepulse_schedule_debug_admin_notice('Rotation failed', 'error');
+$queued = get_option(SITEPULSE_OPTION_DEBUG_NOTICES, []);
+sitepulse_assert(count($queued) === 1, 'Duplicate frontend notice should be ignored.');
+
+// Different message should be added.
+sitepulse_schedule_debug_admin_notice('Write failure', 'warning');
+$queued = get_option(SITEPULSE_OPTION_DEBUG_NOTICES, []);
+sitepulse_assert(count($queued) === 2, 'Second unique frontend notice should be queued.');
+
+// Scenario 2: Visiting admin displays and clears queued notices.
+sitepulse_debug_notice_registry(null, true);
+$GLOBALS['sitepulse_is_admin'] = true;
+ob_start();
+sitepulse_display_queued_debug_notices();
+$output = ob_get_clean();
+$expected_output = '<div class="notice notice-error"><p>Rotation failed</p></div><div class="notice notice-warning"><p>Write failure</p></div>';
+sitepulse_assert($output === $expected_output, 'Queued notices should render once in admin.');
+sitepulse_assert(get_option(SITEPULSE_OPTION_DEBUG_NOTICES, []) === [], 'Queued notices should be cleared after rendering.');
+
+// Scenario 3: Admin scheduling renders immediately without queuing.
+$initial_hook_count = count($GLOBALS['sitepulse_hooks']['admin_notices']);
+sitepulse_schedule_debug_admin_notice('Immediate notice', 'info');
+$after_hook_count = count($GLOBALS['sitepulse_hooks']['admin_notices']);
+sitepulse_assert($after_hook_count === $initial_hook_count + 1, 'Admin scheduling should register a rendering callback.');
+sitepulse_assert(get_option(SITEPULSE_OPTION_DEBUG_NOTICES, []) === [], 'Admin scheduling should not queue notices.');
+
+$callback = end($GLOBALS['sitepulse_hooks']['admin_notices']);
+ob_start();
+call_user_func($callback);
+$immediate_output = ob_get_clean();
+sitepulse_assert($immediate_output === '<div class="notice notice-info"><p>Immediate notice</p></div>', 'Admin scheduling should render immediately.');
+
+echo "All debug notice assertions passed." . PHP_EOL;


### PR DESCRIPTION
## Summary
- add a dedicated option for debug notice queuing and load the debug notice helpers
- implement queuing, duplicate protection, and admin rendering for deferred debug notices
- cover queued and immediate admin notices with a new unit test harness

## Testing
- php sitepulse_FR/tests/sitepulse_transient_fallback_test.php
- php sitepulse_FR/tests/sitepulse_uptime_tracker_test.php
- php sitepulse_FR/tests/sitepulse_debug_notices_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d5c0180414832eb5a6c9766986485e