### PR TITLE
Queue SitePulse debug notices for admin display

### DIFF
--- a/sitepulse_FR/tests/sitepulse_debug_notices_test.php
+++ b/sitepulse_FR/tests/sitepulse_debug_notices_test.php
@@ -83,7 +83,7 @@ sitepulse_schedule_debug_admin_notice('Rotation failed', 'error');
 $queued = get_option(SITEPULSE_OPTION_DEBUG_NOTICES, []);
 sitepulse_assert(count($queued) === 1, 'Frontend scheduling should queue a notice.');
 sitepulse_assert($queued[0]['message'] === 'Rotation failed', 'Queued message must be preserved.');
-sitepulse_assert($queued[0]['type'] === 'error', 'Queued type must be normalized.');
+sitepulse_assert($queued[0]['level'] === 'error', 'Queued level must be normalized.');
 
 // Duplicate message should not be added twice.
 sitepulse_schedule_debug_admin_notice('Rotation failed', 'error');


### PR DESCRIPTION
## Summary
- queue debug notices triggered outside the admin area so they can be displayed later
- ensure deferred notices render safely in the dashboard and support legacy queue entries
- adjust unit coverage to assert deferred notice behaviour

## Testing
- php sitepulse_FR/tests/sitepulse_debug_notices_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d6513dfba0832eae61d840335241a1