### PR TITLE
Add PHPUnit harness and regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,18 @@ SitePulse - JLG est un plugin WordPress développé par Jérôme Le Gousse. Il s
 - **Nettoyage et désinstallation** : les réglages permettent de purger journaux et données, tandis que la routine `uninstall.php` supprime options, transients, tâches planifiées et fichiers de log en toute sécurité lors de la suppression du plugin.【F:sitepulse_FR/includes/admin-settings.php†L333-L366】【F:sitepulse_FR/uninstall.php†L1-L126】
 - **Pour aller plus loin** : consultez chaque module dans `sitepulse_FR/modules/` pour comprendre les métriques collectées, les interfaces générées et adapter vos interventions si besoin.【F:sitepulse_FR/modules/custom_dashboards.php†L1-L121】
 
+## Tests
+Un harnais PHPUnit/WP-Unit est disponible dans `tests/phpunit/` afin de valider les modules clefs (suivi d'uptime, notices de debug, nettoyage des transients, alertes d'erreurs et verrou de cooldown).
+
+1. Installez la bibliothèque de tests WordPress et définissez la variable d'environnement `WP_TESTS_DIR` (par exemple via `bin/install-wp-tests.sh <db-name> <db-user> <db-pass>`).
+2. Assurez-vous que `phpunit` est disponible sur votre machine (ou utilisez un binaire local tel que `vendor/bin/phpunit`).
+3. Exécutez les tests depuis la racine du dépôt :
+
+   ```bash
+   phpunit
+   ```
+
+Ce flux peut être réutilisé en CI pour éviter les régressions sur les fonctionnalités critiques.
+
 ## Filtres disponibles
 - `sitepulse_uptime_request_args` : ajuste les arguments passés à `wp_remote_get()` lors de la vérification d'uptime. Peut être utilisé pour désactiver `sslverify`, modifier le `timeout` ou définir une clé `url` pointant vers une adresse de test dédiée.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="tests/phpunit/bootstrap.php"
+         colors="true"
+         backupGlobals="false"
+         backupStaticAttributes="false">
+    <testsuites>
+        <testsuite name="SitePulse Plugin Test Suite">
+            <directory suffix=".php">tests/phpunit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * PHPUnit bootstrap file for SitePulse.
+ */
+
+$_tests_dir = getenv('WP_TESTS_DIR');
+
+if (!$_tests_dir) {
+    $_tests_dir = rtrim(sys_get_temp_dir(), '/\') . '/wordpress-tests-lib';
+}
+
+if (!file_exists($_tests_dir . '/includes/functions.php')) {
+    fwrite(STDERR, "Could not find WordPress tests in ${_tests_dir}.\n");
+    exit(1);
+}
+
+require_once $_tests_dir . '/includes/functions.php';
+
+require_once __DIR__ . '/includes/stubs.php';
+
+require $_tests_dir . '/includes/bootstrap.php';
+

--- a/tests/phpunit/includes/stubs.php
+++ b/tests/phpunit/includes/stubs.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Shared test stubs for SitePulse unit tests.
+ */
+
+if (!defined('SITEPULSE_DEBUG')) {
+    define('SITEPULSE_DEBUG', true);
+}
+
+if (!defined('SITEPULSE_OPTION_UPTIME_LOG')) {
+    define('SITEPULSE_OPTION_UPTIME_LOG', 'sitepulse_uptime_log');
+}
+
+if (!defined('SITEPULSE_OPTION_UPTIME_FAILURE_STREAK')) {
+    define('SITEPULSE_OPTION_UPTIME_FAILURE_STREAK', 'sitepulse_uptime_failure_streak');
+}
+
+if (!defined('SITEPULSE_OPTION_DEBUG_NOTICES')) {
+    define('SITEPULSE_OPTION_DEBUG_NOTICES', 'sitepulse_debug_notices');
+}
+
+if (!defined('SITEPULSE_OPTION_ALERT_RECIPIENTS')) {
+    define('SITEPULSE_OPTION_ALERT_RECIPIENTS', 'sitepulse_alert_recipients');
+}
+
+if (!defined('SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES')) {
+    define('SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES', 'sitepulse_alert_cooldown_minutes');
+}
+
+if (!defined('SITEPULSE_OPTION_ERROR_ALERT_LOG_POINTER')) {
+    define('SITEPULSE_OPTION_ERROR_ALERT_LOG_POINTER', 'sitepulse_error_alert_log_pointer');
+}
+
+if (!defined('SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX')) {
+    define('SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX', 'sitepulse_error_alert_');
+}
+
+if (!defined('SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_SUFFIX')) {
+    define('SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_SUFFIX', '_lock');
+}
+
+if (!defined('SITEPULSE_TRANSIENT_ERROR_ALERT_CPU_LOCK')) {
+    define(
+        'SITEPULSE_TRANSIENT_ERROR_ALERT_CPU_LOCK',
+        SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX . 'cpu' . SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_SUFFIX
+    );
+}
+
+if (!defined('SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK')) {
+    define(
+        'SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK',
+        SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX . 'php_fatal' . SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_SUFFIX
+    );
+}
+
+if (!function_exists('sitepulse_log')) {
+    function sitepulse_log($message, $level = 'INFO') {
+        if (!isset($GLOBALS['sitepulse_logger'])) {
+            $GLOBALS['sitepulse_logger'] = [];
+        }
+
+        $GLOBALS['sitepulse_logger'][] = [
+            'message' => (string) $message,
+            'level'   => (string) $level,
+        ];
+    }
+}
+
+if (!function_exists('sitepulse_register_cron_warning')) {
+    function sitepulse_register_cron_warning($module_key, $message) {
+        $GLOBALS['sitepulse_cron_warnings'][$module_key][] = $message;
+    }
+}
+
+if (!function_exists('sitepulse_clear_cron_warning')) {
+    function sitepulse_clear_cron_warning($module_key) {
+        $GLOBALS['sitepulse_cleared_cron_warnings'][] = $module_key;
+    }
+}
+
+if (!function_exists('sitepulse_get_cron_hook')) {
+    function sitepulse_get_cron_hook($module) {
+        return 'sitepulse_' . $module . '_cron';
+    }
+}
+
+if (!function_exists('sitepulse_get_wp_debug_log_path')) {
+    function sitepulse_get_wp_debug_log_path($require_readable = false) {
+        $path = $GLOBALS['sitepulse_test_log_path'] ?? null;
+
+        if ($path === null) {
+            return null;
+        }
+
+        if ($require_readable && (!file_exists($path) || !is_readable($path))) {
+            return null;
+        }
+
+        return $path;
+    }
+}

--- a/tests/phpunit/test-debug-notices.php
+++ b/tests/phpunit/test-debug-notices.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Tests for SitePulse debug notices.
+ */
+
+class Sitepulse_Debug_Notices_Test extends WP_UnitTestCase {
+    public static function wpSetUpBeforeClass($factory) {
+        require_once dirname(__DIR__, 2) . '/sitepulse_FR/includes/debug-notices.php';
+    }
+
+    protected function set_up(): void {
+        parent::set_up();
+
+        update_option(SITEPULSE_OPTION_DEBUG_NOTICES, []);
+        sitepulse_debug_notice_registry(null, true);
+    }
+
+    protected function tear_down(): void {
+        sitepulse_debug_notice_registry(null, true);
+        delete_option(SITEPULSE_OPTION_DEBUG_NOTICES);
+
+        parent::tear_down();
+    }
+
+    private function get_admin_notices_callback_count(): int {
+        global $wp_filter;
+
+        if (!isset($wp_filter['admin_notices']) || !is_object($wp_filter['admin_notices'])) {
+            return 0;
+        }
+
+        $count = 0;
+
+        foreach ($wp_filter['admin_notices']->callbacks as $callbacks) {
+            $count += count($callbacks);
+        }
+
+        return $count;
+    }
+
+    public function test_debug_notices_queue_and_rendering() {
+        $this->assertSame(0, has_action('admin_notices', 'sitepulse_display_queued_debug_notices'));
+
+        set_current_screen('front');
+        sitepulse_schedule_debug_admin_notice('Rotation failed', 'error');
+
+        $queued = get_option(SITEPULSE_OPTION_DEBUG_NOTICES, []);
+        $this->assertCount(1, $queued);
+        $this->assertSame('Rotation failed', $queued[0]['message']);
+        $this->assertSame('error', $queued[0]['level']);
+
+        sitepulse_schedule_debug_admin_notice('Rotation failed', 'error');
+        $this->assertCount(1, get_option(SITEPULSE_OPTION_DEBUG_NOTICES, []));
+
+        sitepulse_schedule_debug_admin_notice('Write failure', 'warning');
+        $queued = get_option(SITEPULSE_OPTION_DEBUG_NOTICES, []);
+        $this->assertCount(2, $queued);
+
+        sitepulse_debug_notice_registry(null, true);
+        set_current_screen('dashboard');
+        ob_start();
+        sitepulse_display_queued_debug_notices();
+        $output = ob_get_clean();
+
+        $expected_output = '<div class="notice notice-error"><p>Rotation failed</p></div>' .
+            '<div class="notice notice-warning"><p>Write failure</p></div>';
+        $this->assertSame($expected_output, $output);
+        $this->assertSame([], get_option(SITEPULSE_OPTION_DEBUG_NOTICES, []));
+
+        $initial_hook_count = $this->get_admin_notices_callback_count();
+        sitepulse_schedule_debug_admin_notice('Immediate notice', 'info');
+        $after_hook_count = $this->get_admin_notices_callback_count();
+        $this->assertSame($initial_hook_count + 1, $after_hook_count);
+        $this->assertSame([], get_option(SITEPULSE_OPTION_DEBUG_NOTICES, []));
+
+        ob_start();
+        do_action('admin_notices');
+        $immediate_output = ob_get_clean();
+
+        $this->assertStringContainsString(
+            '<div class="notice notice-info"><p>Immediate notice</p></div>',
+            $immediate_output
+        );
+    }
+}

--- a/tests/phpunit/test-error-alerts.php
+++ b/tests/phpunit/test-error-alerts.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Tests for error alert log scanning and cooldown behavior.
+ */
+
+require_once dirname(__DIR__, 2) . '/sitepulse_FR/modules/error_alerts.php';
+
+class Sitepulse_Error_Alerts_Test extends WP_UnitTestCase {
+    /**
+     * Captured calls to wp_mail.
+     *
+     * @var array
+     */
+    private $sent_mail = [];
+
+    protected function set_up(): void {
+        parent::set_up();
+
+        $this->sent_mail = [];
+        $GLOBALS['sitepulse_logger'] = [];
+        $GLOBALS['sitepulse_test_log_path'] = null;
+
+        add_filter('pre_wp_mail', [$this, 'intercept_mail'], 10, 2);
+
+        delete_option(SITEPULSE_OPTION_ERROR_ALERT_LOG_POINTER);
+        delete_option(SITEPULSE_OPTION_ALERT_RECIPIENTS);
+        delete_transient(SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK);
+    }
+
+    protected function tear_down(): void {
+        remove_filter('pre_wp_mail', [$this, 'intercept_mail'], 10);
+
+        delete_option(SITEPULSE_OPTION_ERROR_ALERT_LOG_POINTER);
+        delete_option(SITEPULSE_OPTION_ALERT_RECIPIENTS);
+        delete_transient(SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK);
+
+        if (!empty($GLOBALS['sitepulse_test_log_path']) && file_exists($GLOBALS['sitepulse_test_log_path'])) {
+            unlink($GLOBALS['sitepulse_test_log_path']);
+        }
+
+        $GLOBALS['sitepulse_test_log_path'] = null;
+
+        parent::tear_down();
+    }
+
+    public function intercept_mail($short_circuit, $atts) {
+        $this->sent_mail[] = $atts;
+
+        return true;
+    }
+
+    private function create_log_file($contents) {
+        $path = tempnam(sys_get_temp_dir(), 'sitepulse-log-');
+        file_put_contents($path, $contents);
+        $GLOBALS['sitepulse_test_log_path'] = $path;
+
+        return $path;
+    }
+
+    public function test_log_pointer_resets_when_file_shrinks() {
+        $log_path = $this->create_log_file("Info line
+Another line
+");
+
+        update_option(
+            SITEPULSE_OPTION_ERROR_ALERT_LOG_POINTER,
+            [
+                'offset' => 999,
+                'inode'  => 123,
+            ]
+        );
+
+        sitepulse_error_alerts_check_debug_log();
+
+        $pointer = get_option(SITEPULSE_OPTION_ERROR_ALERT_LOG_POINTER, []);
+        $this->assertArrayHasKey('offset', $pointer);
+        $this->assertArrayHasKey('inode', $pointer);
+        $this->assertSame(filesize($log_path), $pointer['offset']);
+        $this->assertSame(@fileinode($log_path), $pointer['inode']);
+        $this->assertEmpty($this->sent_mail, 'No fatal lines should be reported.');
+    }
+
+    public function test_detects_fatal_error_and_enforces_cooldown() {
+        $log_path = $this->create_log_file("PHP Fatal error: Boom
+");
+        update_option(SITEPULSE_OPTION_ALERT_RECIPIENTS, ['alerts@example.com']);
+
+        sitepulse_error_alerts_check_debug_log();
+
+        $this->assertCount(1, $this->sent_mail, 'Fatal error should trigger one alert e-mail.');
+
+        $lock_key = SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX . 'php_fatal' . SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_SUFFIX;
+        $this->assertNotFalse(get_transient($lock_key), 'Cooldown lock should be created after sending.');
+
+        file_put_contents($log_path, "PHP Fatal error: Another crash
+", FILE_APPEND);
+        sitepulse_error_alerts_check_debug_log();
+
+        $this->assertCount(1, $this->sent_mail, 'Cooldown lock must prevent duplicate alerts.');
+        $this->assertNotEmpty($GLOBALS['sitepulse_logger'], 'Cooldown should log a skipped notification.');
+        $this->assertSame(
+            "Alert 'php_fatal' skipped due to active cooldown.",
+            end($GLOBALS['sitepulse_logger'])['message']
+        );
+        $this->assertSame(filesize($log_path), get_option(SITEPULSE_OPTION_ERROR_ALERT_LOG_POINTER)['offset']);
+    }
+}

--- a/tests/phpunit/test-transient-fallback.php
+++ b/tests/phpunit/test-transient-fallback.php
@@ -1,0 +1,362 @@
+<?php
+/**
+ * Tests for the transient fallback cleanup logic.
+ */
+
+require_once dirname(__DIR__, 2) . '/sitepulse_FR/modules/database_optimizer.php';
+
+class Sitepulse_Fake_WPDB {
+    public $options = 'options';
+    public $sitemeta = 'sitemeta';
+    public $siteid = 1;
+
+    private $data = [
+        'options'  => [],
+        'sitemeta' => [],
+    ];
+
+    private $prepared = [];
+    private $prepared_log = [];
+
+    public function esc_like($text) {
+        return addcslashes($text, '_%\\');
+    }
+
+    public function prepare($query, $args = []) {
+        if (!is_array($args)) {
+            $args = array_slice(func_get_args(), 1);
+        }
+
+        $prepared_query = $this->build_prepared_query($query, $args);
+        $statement = [
+            'query'    => $query,
+            'args'     => $args,
+            'prepared' => $prepared_query,
+        ];
+
+        $this->prepared[$prepared_query] = $statement;
+        $this->prepared_log[] = $statement;
+
+        return $prepared_query;
+    }
+
+    public function get_prepared_log() {
+        return $this->prepared_log;
+    }
+
+    public function reset_prepared_log() {
+        $this->prepared_log = [];
+    }
+
+    public function get_col($prepared_query) {
+        if (!isset($this->prepared[$prepared_query])) {
+            return [];
+        }
+
+        $statement = $this->prepared[$prepared_query];
+        unset($this->prepared[$prepared_query]);
+
+        if (!preg_match('/FROM\s+(\S+)/i', $statement['query'], $matches)) {
+            return [];
+        }
+
+        $table = $matches[1];
+        $like_prefix = $this->normalize_like_prefix($statement['args'][0] ?? '');
+        $timestamp = isset($statement['args'][1]) ? (int) $statement['args'][1] : PHP_INT_MAX;
+        $site_id = isset($statement['args'][2]) ? (int) $statement['args'][2] : null;
+
+        $column = ($table === $this->options) ? 'option_name' : 'meta_key';
+        $value_column = ($table === $this->options) ? 'option_value' : 'meta_value';
+
+        $results = [];
+
+        foreach ($this->data[$table] as $row) {
+            if ($like_prefix !== '' && strpos($row[$column], $like_prefix) !== 0) {
+                continue;
+            }
+
+            if ((int) $row[$value_column] >= $timestamp) {
+                continue;
+            }
+
+            if ($table === $this->sitemeta && $site_id !== null && (int) $row['site_id'] !== $site_id) {
+                continue;
+            }
+
+            $results[] = $row[$column];
+        }
+
+        return $results;
+    }
+
+    public function delete($table, $where, $where_format = null) {
+        foreach ($this->data[$table] as $index => $row) {
+            $matches = true;
+
+            foreach ($where as $column => $value) {
+                if (!array_key_exists($column, $row) || (string) $row[$column] !== (string) $value) {
+                    $matches = false;
+                    break;
+                }
+            }
+
+            if ($matches) {
+                unset($this->data[$table][$index]);
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    public function add_option_row($name, $value) {
+        $this->data[$this->options][] = [
+            'option_name'  => $name,
+            'option_value' => $value,
+        ];
+    }
+
+    public function add_sitemeta_row($site_id, $name, $value) {
+        $this->data[$this->sitemeta][] = [
+            'site_id'   => (int) $site_id,
+            'meta_key'  => $name,
+            'meta_value'=> $value,
+        ];
+    }
+
+    public function get_option_value($name) {
+        foreach ($this->data[$this->options] as $row) {
+            if ($row['option_name'] === $name) {
+                return $row['option_value'];
+            }
+        }
+
+        return null;
+    }
+
+    public function get_sitemeta_value($site_id, $name) {
+        foreach ($this->data[$this->sitemeta] as $row) {
+            if ((int) $row['site_id'] === (int) $site_id && $row['meta_key'] === $name) {
+                return $row['meta_value'];
+            }
+        }
+
+        return null;
+    }
+
+    private function normalize_like_prefix($value) {
+        if ($value === '') {
+            return '';
+        }
+
+        if (substr($value, -1) === '%') {
+            $value = substr($value, 0, -1);
+        }
+
+        $value = str_replace('\_', '_', $value);
+        $value = str_replace('\\', '\', $value);
+
+        return $value;
+    }
+
+    private function build_prepared_query($query, $args) {
+        if (empty($args)) {
+            return $query;
+        }
+
+        $prepared = '';
+        $offset = 0;
+        $arg_index = 0;
+
+        while (preg_match('/%(?:%|(?:\d+\$)?[dsf])/i', $query, $matches, PREG_OFFSET_CAPTURE, $offset)) {
+            $placeholder = $matches[0][0];
+            $position = $matches[0][1];
+
+            $prepared .= substr($query, $offset, $position - $offset);
+            $offset = $position + strlen($placeholder);
+
+            if ($placeholder === '%%') {
+                $prepared .= '%';
+                continue;
+            }
+
+            if (!array_key_exists($arg_index, $args)) {
+                break;
+            }
+
+            $prepared .= $this->format_placeholder($placeholder, $args[$arg_index]);
+            $arg_index++;
+        }
+
+        $prepared .= substr($query, $offset);
+
+        return $prepared;
+    }
+
+    private function format_placeholder($placeholder, $value) {
+        switch ($placeholder) {
+            case '%d':
+                return (string) (int) $value;
+            case '%f':
+                return (string) (float) $value;
+            case '%s':
+            default:
+                return "'" . addslashes((string) $value) . "'";
+        }
+    }
+}
+
+class Sitepulse_Transient_Fallback_Test extends WP_UnitTestCase {
+    protected function set_up(): void {
+        parent::set_up();
+        $GLOBALS['sitepulse_cache_log'] = [];
+    }
+
+    protected function tear_down(): void {
+        unset($GLOBALS['sitepulse_cache_log']);
+        parent::tear_down();
+    }
+
+    public function test_single_site_transient_cleanup_removes_expired_entries() {
+        $now = time();
+        $wpdb = new Sitepulse_Fake_WPDB();
+        $previous_wpdb = $GLOBALS['wpdb'] ?? null;
+        $GLOBALS['wpdb'] = $wpdb;
+
+        $wpdb->add_option_row('_transient_timeout_expired', $now - 10);
+        $wpdb->add_option_row('_transient_expired', 'expired-value');
+        $wpdb->add_option_row('_transient_timeout_active', $now + 1000);
+        $wpdb->add_option_row('_transient_active', 'active-value');
+        $wpdb->add_option_row('_transient_timeout_invalid', 'not-a-number');
+        $wpdb->add_option_row('_transient_invalid', 'invalid-value');
+        $wpdb->add_option_row('_site_transient_timeout_site', $now - 10);
+        $wpdb->add_option_row('_site_transient_site', 'site-value');
+
+        $object_cache = $GLOBALS['wp_object_cache'];
+        $spy_cache = new class($object_cache) {
+            public $deletions = [];
+            private $previous;
+
+            public function __construct($previous) {
+                $this->previous = $previous;
+            }
+
+            public function delete($key, $group = '', $force = false, $found = null) {
+                $this->deletions[] = ['group' => $group, 'key' => $key];
+                return $this->previous ? $this->previous->delete($key, $group, $force, $found) : true;
+            }
+        };
+        $GLOBALS['wp_object_cache'] = $spy_cache;
+
+        $cleaned = sitepulse_delete_expired_transients_fallback($wpdb);
+
+        $this->assertSame(3, $cleaned, 'Expected three expired transients to be cleaned, including malformed ones.');
+        $this->assertNull($wpdb->get_option_value('_transient_expired'));
+        $this->assertNull($wpdb->get_option_value('_transient_timeout_expired'));
+        $this->assertNull($wpdb->get_option_value('_transient_invalid'));
+        $this->assertNull($wpdb->get_option_value('_transient_timeout_invalid'));
+        $this->assertNull($wpdb->get_option_value('_site_transient_site'));
+        $this->assertNotNull($wpdb->get_option_value('_transient_active'));
+
+        $prepared_statements = $wpdb->get_prepared_log();
+        $options_query = "SELECT option_name FROM options WHERE option_name LIKE %s AND CAST(option_value AS UNSIGNED) < %d ORDER BY option_value ASC LIMIT %d";
+        $this->assertContains($options_query, wp_list_pluck($prepared_statements, 'query'));
+
+        $expected_prepared = sprintf(
+            "SELECT option_name FROM options WHERE option_name LIKE '%s' AND CAST(option_value AS UNSIGNED) < %d ORDER BY option_value ASC LIMIT %d",
+            addslashes($wpdb->esc_like('_transient_timeout_') . '%'),
+            (int) $now,
+            100
+        );
+
+        $matched_prepared = null;
+
+        foreach ($prepared_statements as $statement) {
+            if ($statement['query'] === $options_query) {
+                $matched_prepared = $statement['prepared'];
+                break;
+            }
+        }
+
+        $this->assertSame($expected_prepared, $matched_prepared, 'Prepared SQL for options cleanup does not match expectation.');
+
+        $found_numeric_cast = false;
+
+        foreach ($prepared_statements as $statement) {
+            if (strpos($statement['query'], 'CAST(option_value AS UNSIGNED) < %d') !== false) {
+                $this->assertIsInt($statement['args'][1]);
+                $found_numeric_cast = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($found_numeric_cast, 'Expected transient cleanup query to cast option_value as UNSIGNED.');
+
+        $expected_cache_keys = [
+            ['group' => 'options', 'key' => '_transient_timeout_expired'],
+            ['group' => 'options', 'key' => '_transient_expired'],
+            ['group' => 'options', 'key' => '_transient_timeout_invalid'],
+            ['group' => 'options', 'key' => '_transient_invalid'],
+            ['group' => 'options', 'key' => '_site_transient_timeout_site'],
+            ['group' => 'options', 'key' => '_site_transient_site'],
+        ];
+
+        $this->assertEquals($expected_cache_keys, $spy_cache->deletions);
+
+        $GLOBALS['wp_object_cache'] = $object_cache;
+        $GLOBALS['wpdb'] = $previous_wpdb;
+    }
+
+    public function test_site_meta_cleanup_targets_current_network() {
+        $now = time();
+        $wpdb = new Sitepulse_Fake_WPDB();
+        $previous_wpdb = $GLOBALS['wpdb'] ?? null;
+        $GLOBALS['wpdb'] = $wpdb;
+        $wpdb->siteid = 7;
+
+        $wpdb->add_sitemeta_row(7, '_site_transient_timeout_network', $now - 20);
+        $wpdb->add_sitemeta_row(7, '_site_transient_network', 'network-value');
+        $wpdb->add_sitemeta_row(3, '_site_transient_timeout_foreign', $now - 50);
+        $wpdb->add_sitemeta_row(3, '_site_transient_foreign', 'should-stay');
+
+        $object_cache = $GLOBALS['wp_object_cache'];
+        $spy_cache = new class($object_cache) {
+            public $deletions = [];
+            private $previous;
+
+            public function __construct($previous) {
+                $this->previous = $previous;
+            }
+
+            public function delete($key, $group = '', $force = false, $found = null) {
+                $this->deletions[] = ['group' => $group, 'key' => $key];
+                return $this->previous ? $this->previous->delete($key, $group, $force, $found) : true;
+            }
+        };
+        $GLOBALS['wp_object_cache'] = $spy_cache;
+
+        $source = [
+            'timeout_prefix' => '_site_transient_timeout_',
+            'value_prefix'   => '_site_transient_',
+            'table'          => $wpdb->sitemeta,
+            'key_column'     => 'meta_key',
+            'value_column'   => 'meta_value',
+            'cache_group'    => 'site-options',
+            'site_id'        => $wpdb->siteid,
+        ];
+
+        $purged = sitepulse_cleanup_transient_source($wpdb, $source, $now);
+
+        $this->assertSame(1, $purged, 'Only the current network transient should be removed.');
+        $this->assertNull($wpdb->get_sitemeta_value(7, '_site_transient_network'));
+        $this->assertNotNull($wpdb->get_sitemeta_value(3, '_site_transient_foreign'));
+
+        $this->assertEquals([
+            ['group' => 'site-options', 'key' => $wpdb->siteid . ':_site_transient_timeout_network'],
+            ['group' => 'site-options', 'key' => $wpdb->siteid . ':_site_transient_network'],
+        ], $spy_cache->deletions);
+
+        $GLOBALS['wp_object_cache'] = $object_cache;
+        $GLOBALS['wpdb'] = $previous_wpdb;
+    }
+}

--- a/tests/phpunit/test-uptime-tracker.php
+++ b/tests/phpunit/test-uptime-tracker.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Tests for the uptime tracker module.
+ */
+
+class Sitepulse_Uptime_Tracker_Test extends WP_UnitTestCase {
+    /**
+     * Queue of mocked HTTP responses.
+     *
+     * @var array
+     */
+    private $http_queue = [];
+
+    /**
+     * Registers the module under test.
+     */
+    public static function wpSetUpBeforeClass($factory) {
+        $module = dirname(__DIR__, 2) . '/sitepulse_FR/modules/uptime_tracker.php';
+        require_once $module;
+    }
+
+    protected function set_up(): void {
+        parent::set_up();
+
+        $this->http_queue = [];
+        $GLOBALS['sitepulse_logger'] = [];
+
+        add_filter('pre_http_request', [$this, 'mock_http_request'], 10, 3);
+        add_filter('sitepulse_uptime_consecutive_failures', [$this, 'force_failure_threshold'], 10, 2);
+
+        delete_option(SITEPULSE_OPTION_UPTIME_LOG);
+        delete_option(SITEPULSE_OPTION_UPTIME_FAILURE_STREAK);
+    }
+
+    protected function tear_down(): void {
+        remove_filter('pre_http_request', [$this, 'mock_http_request'], 10);
+        remove_filter('sitepulse_uptime_consecutive_failures', [$this, 'force_failure_threshold'], 10);
+
+        delete_option(SITEPULSE_OPTION_UPTIME_LOG);
+        delete_option(SITEPULSE_OPTION_UPTIME_FAILURE_STREAK);
+
+        parent::tear_down();
+    }
+
+    /**
+     * Forces the uptime tracker to escalate on the second failure.
+     *
+     * @param int $default Default threshold.
+     * @return int
+     */
+    public function force_failure_threshold($default, $streak = 0) {
+        return 2;
+    }
+
+    /**
+     * Supplies deterministic HTTP responses to the uptime tracker.
+     *
+     * @return mixed
+     */
+    public function mock_http_request($preempt, $args, $url) {
+        if (empty($this->http_queue)) {
+            $this->fail('Unexpected HTTP request; the queue is empty.');
+        }
+
+        return array_shift($this->http_queue);
+    }
+
+    /**
+     * Adds a mocked HTTP response.
+     *
+     * @param mixed $response Response to enqueue.
+     */
+    private function enqueue_response($response) {
+        $this->http_queue[] = $response;
+    }
+
+    public function test_uptime_tracker_handles_network_errors_and_recovery() {
+        $this->enqueue_response(new WP_Error('timeout', 'Request timeout'));
+        sitepulse_run_uptime_check();
+
+        $log = get_option(SITEPULSE_OPTION_UPTIME_LOG, []);
+        $this->assertCount(1, $log, 'Expected one log entry after first WP_Error.');
+        $this->assertSame('unknown', $log[0]['status']);
+        $this->assertSame('Request timeout', $log[0]['error']);
+        $this->assertArrayNotHasKey('incident_start', $log[0], 'Unknown status should not record an incident start.');
+        $this->assertSame(1, get_option(SITEPULSE_OPTION_UPTIME_FAILURE_STREAK, 0));
+
+        $last_log = end($GLOBALS['sitepulse_logger']);
+        $this->assertSame('WARNING', $last_log['level']);
+
+        $this->enqueue_response(new WP_Error('timeout', 'Request timeout'));
+        sitepulse_run_uptime_check();
+
+        $log = get_option(SITEPULSE_OPTION_UPTIME_LOG, []);
+        $this->assertCount(2, $log, 'Expected two log entries after consecutive WP_Error.');
+        $this->assertSame(2, get_option(SITEPULSE_OPTION_UPTIME_FAILURE_STREAK, 0));
+
+        $last_log = end($GLOBALS['sitepulse_logger']);
+        $this->assertSame('ALERT', $last_log['level']);
+
+        $this->enqueue_response(['response' => ['code' => 200]]);
+        sitepulse_run_uptime_check();
+
+        $log = get_option(SITEPULSE_OPTION_UPTIME_LOG, []);
+        $this->assertTrue(end($log)['status']);
+        $this->assertSame(0, get_option(SITEPULSE_OPTION_UPTIME_FAILURE_STREAK, 0));
+    }
+
+    public function test_mixed_outage_preserves_incident_start_across_unknown_samples() {
+        $this->enqueue_response(['response' => ['code' => 500]]);
+        sitepulse_run_uptime_check();
+
+        $log = get_option(SITEPULSE_OPTION_UPTIME_LOG, []);
+        $this->assertFalse($log[0]['status']);
+        $this->assertArrayHasKey('incident_start', $log[0]);
+        $incident_start = $log[0]['incident_start'];
+
+        $this->enqueue_response(new WP_Error('timeout', 'Temporary glitch'));
+        sitepulse_run_uptime_check();
+
+        $log = get_option(SITEPULSE_OPTION_UPTIME_LOG, []);
+        $this->assertSame('unknown', $log[1]['status']);
+        $this->assertArrayNotHasKey('incident_start', $log[1]);
+
+        $this->enqueue_response(['response' => ['code' => 500]]);
+        sitepulse_run_uptime_check();
+
+        $log = get_option(SITEPULSE_OPTION_UPTIME_LOG, []);
+        $this->assertFalse($log[2]['status']);
+        $this->assertSame($incident_start, $log[2]['incident_start']);
+    }
+}


### PR DESCRIPTION
## Summary
- add a phpunit.xml.dist bootstrap and shared stubs so the plugin can run under the WordPress test framework
- port the existing uptime, debug notice, and transient scripts into WP_UnitTestCase classes under tests/phpunit
- extend coverage to the error alert module, including log pointer resets and cooldown locking, and document the workflow in README

## Testing
- phpunit *(fails: phpunit executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d65d479624832ebeada3c6bb727272