### PR TITLE
Add coverage for truncated error alert log scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ SitePulse - JLG est un plugin WordPress développé par Jérôme Le Gousse. Il s
 - **Pour aller plus loin** : consultez chaque module dans `sitepulse_FR/modules/` pour comprendre les métriques collectées, les interfaces générées et adapter vos interventions si besoin.【F:sitepulse_FR/modules/custom_dashboards.php†L1-L121】
 
 ## Tests
-Un harnais PHPUnit/WP-Unit est disponible dans `tests/phpunit/` afin de valider les modules clefs (suivi d'uptime, notices de debug, nettoyage des transients, alertes d'erreurs et verrou de cooldown).
+Un harnais PHPUnit/WP-Unit est disponible dans `tests/phpunit/` (configuré via `phpunit.xml.dist`) afin de valider les modules clefs : suivi d'uptime, notices de debug, nettoyage des transients ainsi que l'analyse du journal d'erreurs (pointeurs de lecture, détection des fatals et verrou de cooldown).
 
 1. Installez la bibliothèque de tests WordPress et définissez la variable d'environnement `WP_TESTS_DIR` (par exemple via `bin/install-wp-tests.sh <db-name> <db-user> <db-pass>`).
 2. Assurez-vous que `phpunit` est disponible sur votre machine (ou utilisez un binaire local tel que `vendor/bin/phpunit`).


### PR DESCRIPTION
## Summary
- load the error alert module via `wpSetUpBeforeClass` and add a helper to cap scan size during tests
- add a regression test that simulates truncated log scanning to ensure fatal errors are still detected and pointers updated
- update the README test section to note the phpunit configuration and expanded coverage

## Testing
- phpunit *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6617847a4832e824a1e7e5a443c87