### PR TITLE
Sanitize plugin impact tracker interval handling

### DIFF
--- a/sitepulse_FR/includes/plugin-impact-tracker.php
+++ b/sitepulse_FR/includes/plugin-impact-tracker.php
@@ -238,6 +238,11 @@ function sitepulse_plugin_impact_tracker_persist() {
     }
 
     $interval = apply_filters('sitepulse_plugin_impact_refresh_interval', SITEPULSE_PLUGIN_IMPACT_REFRESH_INTERVAL);
+
+    if (!is_scalar($interval)) {
+        $interval = 0;
+    }
+
     $interval = absint($interval);
     $interval = max(1, $interval);
     $last_updated = isset($existing['last_updated']) ? (int) $existing['last_updated'] : 0;

--- a/tests/phpunit/test-plugin-impact-tracker.php
+++ b/tests/phpunit/test-plugin-impact-tracker.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Tests for the plugin impact tracker persistence logic.
+ */
+
+require_once dirname(__DIR__, 2) . '/sitepulse_FR/includes/plugin-impact-tracker.php';
+
+class Sitepulse_Plugin_Impact_Tracker_Test extends WP_UnitTestCase {
+    public static function setUpBeforeClass(): void {
+        parent::setUpBeforeClass();
+
+        if (!defined('SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS')) {
+            define('SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS', 'sitepulse_speed_scan_results');
+        }
+
+        if (!defined('SITEPULSE_OPTION_LAST_LOAD_TIME')) {
+            define('SITEPULSE_OPTION_LAST_LOAD_TIME', 'sitepulse_last_load_time');
+        }
+    }
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        global $sitepulse_plugin_impact_tracker_samples, $sitepulse_plugin_impact_tracker_force_persist;
+
+        $sitepulse_plugin_impact_tracker_samples = [];
+        $sitepulse_plugin_impact_tracker_force_persist = false;
+
+        delete_option(SITEPULSE_PLUGIN_IMPACT_OPTION);
+        delete_transient(SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS);
+    }
+
+    public function test_persist_sanitizes_interval_from_filter(): void {
+        global $sitepulse_plugin_impact_tracker_samples, $sitepulse_plugin_impact_tracker_force_persist;
+
+        $sitepulse_plugin_impact_tracker_force_persist = true;
+        $sitepulse_plugin_impact_tracker_samples = [
+            'example/plugin.php' => 0.123,
+        ];
+
+        $callback = function () {
+            return ['invalid'];
+        };
+
+        add_filter('sitepulse_plugin_impact_refresh_interval', $callback);
+
+        $errors = [];
+        set_error_handler(
+            function ($errno, $errstr) use (&$errors) {
+                $errors[] = $errstr;
+                return false;
+            },
+            E_WARNING | E_NOTICE
+        );
+
+        sitepulse_plugin_impact_tracker_persist();
+
+        restore_error_handler();
+
+        remove_filter('sitepulse_plugin_impact_refresh_interval', $callback);
+
+        $this->assertSame([], $errors, 'Persistence should not trigger PHP warnings when filter returns invalid data.');
+
+        $payload = get_option(SITEPULSE_PLUGIN_IMPACT_OPTION, []);
+
+        $this->assertIsArray($payload, 'Plugin impact tracker option should persist an array payload.');
+        $this->assertArrayHasKey('interval', $payload, 'Persisted payload must include sanitized interval.');
+        $this->assertSame(1, $payload['interval'], 'Interval should fall back to the sanitized minimum when filter is invalid.');
+    }
+}
+


### PR DESCRIPTION
## Summary
- clamp the plugin impact refresh interval to sanitized integer values before persisting
- guard against non-scalar filter return values when computing the interval
- add PHPUnit coverage to ensure invalid filter results fall back to the sanitized minimum without warnings

## Testing
- phpunit --configuration phpunit.xml.dist *(fails: phpunit binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6617ad2f4832e8ad9232e9cc4f802