### PR TITLE
Add MU loader warning handling and tests

### DIFF
--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -344,6 +344,13 @@ function sitepulse_plugin_impact_install_mu_loader() {
 
     $filesystem = sitepulse_get_filesystem();
     $stored_signature = get_option(SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE);
+    $warning_message = sprintf(
+        __(
+            'SitePulse n’a pas pu installer le chargeur MU du suivi d’impact (%s). Vérifiez les permissions du dossier mu-plugins.',
+            'sitepulse'
+        ),
+        $target_dir
+    );
 
     if ($filesystem instanceof WP_Filesystem_Base) {
         if (!$filesystem->is_dir($target_dir)) {
@@ -353,6 +360,7 @@ function sitepulse_plugin_impact_install_mu_loader() {
         if (!$filesystem->is_dir($target_dir) || !$filesystem->is_writable($target_dir)) {
             sitepulse_log(sprintf('SitePulse impact loader directory not writable via WP_Filesystem (%s).', $target_dir), 'ERROR');
             delete_option(SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE);
+            sitepulse_register_cron_warning('plugin_impact', $warning_message);
 
             return;
         }
@@ -364,6 +372,7 @@ function sitepulse_plugin_impact_install_mu_loader() {
         if (!is_dir($target_dir) || !is_writable($target_dir)) {
             sitepulse_log(sprintf('SitePulse impact loader directory not writable (%s).', $target_dir), 'ERROR');
             delete_option(SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE);
+            sitepulse_register_cron_warning('plugin_impact', $warning_message);
 
             return;
         }
@@ -447,9 +456,11 @@ function sitepulse_plugin_impact_install_mu_loader() {
 
     if ($has_valid_loader) {
         update_option(SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE, $signature, false);
+        sitepulse_clear_cron_warning('plugin_impact');
     } else {
         delete_option(SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE);
         sitepulse_log(sprintf('SitePulse impact loader installation failed for %s.', $target_file), 'ERROR');
+        sitepulse_register_cron_warning('plugin_impact', $warning_message);
     }
 }
 

--- a/tests/phpunit/test-plugin-impact-loader.php
+++ b/tests/phpunit/test-plugin-impact-loader.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Tests for the plugin impact MU loader installation warnings.
+ */
+
+class Sitepulse_Plugin_Impact_Loader_Test extends WP_UnitTestCase {
+    protected $mu_loader_dir;
+    protected $mu_loader_file;
+
+    public static function setUpBeforeClass(): void {
+        parent::setUpBeforeClass();
+
+        if (!function_exists('sitepulse_plugin_impact_install_mu_loader')) {
+            require_once dirname(__DIR__, 2) . '/sitepulse_FR/sitepulse.php';
+        }
+    }
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        delete_option(SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE);
+        delete_option(SITEPULSE_OPTION_CRON_WARNINGS);
+
+        $paths = sitepulse_plugin_impact_get_mu_loader_paths();
+        $this->mu_loader_dir  = $paths['dir'];
+        $this->mu_loader_file = $paths['file'];
+
+        if (file_exists($this->mu_loader_file)) {
+            unlink($this->mu_loader_file);
+        }
+
+        if (file_exists($this->mu_loader_dir) && !is_dir($this->mu_loader_dir)) {
+            unlink($this->mu_loader_dir);
+        }
+
+        if (!is_dir($this->mu_loader_dir)) {
+            wp_mkdir_p($this->mu_loader_dir);
+        }
+    }
+
+    protected function tearDown(): void {
+        if (file_exists($this->mu_loader_file)) {
+            unlink($this->mu_loader_file);
+        }
+
+        if (!is_dir($this->mu_loader_dir)) {
+            if (file_exists($this->mu_loader_dir)) {
+                unlink($this->mu_loader_dir);
+            }
+
+            wp_mkdir_p($this->mu_loader_dir);
+        } else {
+            @chmod($this->mu_loader_dir, 0755);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_registers_warning_when_mu_directory_is_unwritable(): void {
+        $original_dir = $this->mu_loader_dir;
+        $backup_dir   = null;
+
+        if (is_dir($original_dir)) {
+            $backup_dir = $original_dir . '-backup-' . uniqid('', true);
+
+            if (!@rename($original_dir, $backup_dir)) {
+                $backup_dir = null;
+            }
+        }
+
+        file_put_contents($original_dir, '');
+
+        try {
+            sitepulse_plugin_impact_install_mu_loader();
+
+            $warnings = get_option(SITEPULSE_OPTION_CRON_WARNINGS, []);
+
+            $this->assertIsArray($warnings, 'Cron warnings option should store an array.');
+            $this->assertArrayHasKey('plugin_impact', $warnings, 'Plugin impact warning should be registered on failure.');
+            $this->assertNotEmpty(
+                $warnings['plugin_impact']['message'] ?? '',
+                'Registered warning should include a user-facing message.'
+            );
+        } finally {
+            if (file_exists($original_dir) && !is_dir($original_dir)) {
+                unlink($original_dir);
+            }
+
+            if ($backup_dir !== null && is_dir($backup_dir)) {
+                @rename($backup_dir, $original_dir);
+            } elseif (!is_dir($original_dir)) {
+                wp_mkdir_p($original_dir);
+            }
+        }
+    }
+
+    public function test_successful_installation_clears_warning(): void {
+        update_option(
+            SITEPULSE_OPTION_CRON_WARNINGS,
+            [
+                'plugin_impact' => ['message' => 'Existing warning'],
+                'other'         => ['message' => 'Keep me'],
+            ],
+            false
+        );
+
+        sitepulse_plugin_impact_install_mu_loader();
+
+        $warnings = get_option(SITEPULSE_OPTION_CRON_WARNINGS, []);
+
+        $this->assertIsArray($warnings, 'Cron warnings option should remain an array after clearing entries.');
+        $this->assertArrayNotHasKey('plugin_impact', $warnings, 'Successful installation should clear the plugin impact warning.');
+        $this->assertArrayHasKey('other', $warnings, 'Other cron warnings should remain untouched.');
+    }
+}


### PR DESCRIPTION
## Summary
- register a SitePulse cron warning when the MU loader cannot be installed and clear it after successful installs
- log the same warning when filesystem access fails so administrators are notified
- add PHPUnit coverage for failure and success scenarios around the MU loader installation

## Testing
- `phpunit` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d66f83cdfc832ebfe697bec3453010