### PR TITLE
Add admin settings cleanup PHPUnit coverage

### DIFF
--- a/tests/phpunit/test-admin-settings-cleanup.php
+++ b/tests/phpunit/test-admin-settings-cleanup.php
@@ -150,6 +150,7 @@ class Sitepulse_Admin_Settings_Cleanup_Test extends WP_UnitTestCase {
         }
 
         set_transient(SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS, 'cached');
+        set_site_transient(SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS, 'cached');
         set_transient(SITEPULSE_TRANSIENT_AI_INSIGHT, 'ai');
         set_transient(SITEPULSE_TRANSIENT_ERROR_ALERT_CPU_LOCK, 'lock');
         set_transient(SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK, 'lock');
@@ -158,6 +159,7 @@ class Sitepulse_Admin_Settings_Cleanup_Test extends WP_UnitTestCase {
         set_transient($prefixed_transient, 'size');
 
         $GLOBALS['sitepulse_test_cron_hooks'] = ['sitepulse_fake_cron'];
+        wp_schedule_single_event(time() + MINUTE_IN_SECONDS, 'sitepulse_fake_cron');
 
         $_POST = [
             'sitepulse_reset_all'                  => '1',
@@ -173,10 +175,12 @@ class Sitepulse_Admin_Settings_Cleanup_Test extends WP_UnitTestCase {
         }
 
         $this->assertFalse(get_transient(SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS));
+        $this->assertFalse(get_site_transient(SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS));
         $this->assertFalse(get_transient(SITEPULSE_TRANSIENT_AI_INSIGHT));
         $this->assertFalse(get_transient(SITEPULSE_TRANSIENT_ERROR_ALERT_CPU_LOCK));
         $this->assertFalse(get_transient(SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK));
         $this->assertFalse(get_transient($prefixed_transient));
+        $this->assertFalse(wp_next_scheduled('sitepulse_fake_cron'));
         $this->assertSame(1, $GLOBALS['sitepulse_activate_site_calls']);
         $this->assertStringContainsString('SitePulse a été réinitialisé.', $output);
     }


### PR DESCRIPTION
## Summary
- ensure the admin cleanup tests seed and verify cron, options, and transient state before invoking `sitepulse_settings_page()`
- assert that the cleanup routine clears associated site transients and scheduled cron hooks while preserving success notices

## Testing
- php -d detect_unicode=0 -r "require 'tests/phpunit/bootstrap.php';" *(fails: WordPress test library missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d69f1a1ab4832eb1072c7ec487fdb6