### PR TITLE
Move module styles to dedicated CSS files

### DIFF
--- a/sitepulse_FR/modules/css/plugin-impact-scanner.css
+++ b/sitepulse_FR/modules/css/plugin-impact-scanner.css
@@ -1,0 +1,31 @@
+.impact-bar-bg {
+    background: #eee;
+    border-radius: 3px;
+    overflow: hidden;
+    width: 100%;
+}
+
+.impact-bar {
+    height: 18px;
+    border-radius: 3px;
+    background-color: #ffc107;
+    text-align: right;
+    color: #fff;
+    padding-right: 5px;
+    white-space: nowrap;
+    font-size: 12px;
+    line-height: 18px;
+}
+
+.sitepulse-impact-meta {
+    margin-bottom: 1em;
+}
+
+.sitepulse-impact-meta p {
+    margin: 0.2em 0;
+}
+
+.sitepulse-impact-limitations {
+    list-style: disc;
+    margin-left: 1.5em;
+}

--- a/sitepulse_FR/modules/css/speed-analyzer.css
+++ b/sitepulse_FR/modules/css/speed-analyzer.css
@@ -1,0 +1,58 @@
+.speed-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.speed-card {
+    background: #fff;
+    padding: 20px;
+    border: 1px solid #ddd;
+}
+
+.speed-card h3 {
+    margin-top: 0;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 10px;
+    font-size: 16px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.health-list {
+    list-style: none;
+    padding-left: 0;
+}
+
+.health-list li {
+    padding: 10px 0;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.health-list li:last-child {
+    border-bottom: none;
+}
+
+.health-list .metric-name {
+    font-weight: bold;
+    display: block;
+}
+
+.health-list .metric-value {
+    float: right;
+    font-weight: bold;
+}
+
+.status-ok {
+    color: #4caf50;
+}
+
+.status-warn {
+    color: #ffc107;
+}
+
+.status-bad {
+    color: #f44336;
+}

--- a/sitepulse_FR/modules/css/uptime-tracker.css
+++ b/sitepulse_FR/modules/css/uptime-tracker.css
@@ -1,0 +1,22 @@
+.uptime-chart {
+    display: flex;
+    gap: 2px;
+    height: 60px;
+    align-items: flex-end;
+}
+
+.uptime-bar {
+    flex-grow: 1;
+}
+
+.uptime-bar.up {
+    background-color: #4caf50;
+}
+
+.uptime-bar.down {
+    background-color: #f44336;
+}
+
+.uptime-bar.unknown {
+    background-color: #9e9e9e;
+}

--- a/sitepulse_FR/modules/plugin_impact_scanner.php
+++ b/sitepulse_FR/modules/plugin_impact_scanner.php
@@ -17,6 +17,27 @@ add_action(
     }
 );
 
+add_action('admin_enqueue_scripts', 'sitepulse_plugin_impact_scanner_enqueue_assets');
+
+/**
+ * Enqueues the stylesheet required for the plugin impact scanner admin screen.
+ *
+ * @param string $hook_suffix Identifier of the current admin page.
+ * @return void
+ */
+function sitepulse_plugin_impact_scanner_enqueue_assets($hook_suffix) {
+    if ($hook_suffix !== 'sitepulse-dashboard_page_sitepulse-plugins') {
+        return;
+    }
+
+    wp_enqueue_style(
+        'sitepulse-plugin-impact',
+        SITEPULSE_URL . 'modules/css/plugin-impact-scanner.css',
+        [],
+        SITEPULSE_VERSION
+    );
+}
+
 add_action('upgrader_process_complete', 'sitepulse_plugin_impact_clear_dir_cache_on_upgrade', 10, 2);
 
 function sitepulse_plugin_impact_clear_dir_cache_on_upgrade($upgrader, $hook_extra) {
@@ -296,13 +317,6 @@ function sitepulse_plugin_impact_scanner_page() {
         sitepulse_plugin_impact_format_interval($interval)
     );
     ?>
-    <style>
-        .impact-bar-bg { background: #eee; border-radius: 3px; overflow: hidden; width: 100%; }
-        .impact-bar { height: 18px; border-radius: 3px; background-color: #FFC107; text-align: right; color: white; padding-right: 5px; white-space: nowrap; font-size: 12px; line-height: 18px; }
-        .sitepulse-impact-meta { margin-bottom: 1em; }
-        .sitepulse-impact-meta p { margin: 0.2em 0; }
-        .sitepulse-impact-limitations { list-style: disc; margin-left: 1.5em; }
-    </style>
     <div class="wrap">
         <h1><span class="dashicons-before dashicons-filter"></span> <?php esc_html_e("Analyseur d'Impact des Plugins", 'sitepulse'); ?></h1>
 

--- a/sitepulse_FR/modules/speed_analyzer.php
+++ b/sitepulse_FR/modules/speed_analyzer.php
@@ -13,6 +13,27 @@ add_action('admin_menu', function() {
     );
 });
 
+add_action('admin_enqueue_scripts', 'sitepulse_speed_analyzer_enqueue_assets');
+
+/**
+ * Enqueues the stylesheet for the speed analyzer admin page.
+ *
+ * @param string $hook_suffix Identifier of the current admin page.
+ * @return void
+ */
+function sitepulse_speed_analyzer_enqueue_assets($hook_suffix) {
+    if ($hook_suffix !== 'sitepulse-dashboard_page_sitepulse-speed') {
+        return;
+    }
+
+    wp_enqueue_style(
+        'sitepulse-speed-analyzer',
+        SITEPULSE_URL . 'modules/css/speed-analyzer.css',
+        [],
+        SITEPULSE_VERSION
+    );
+}
+
 /**
  * Renders the Speed Analyzer page.
  * The analysis is now based on internal WordPress timers for better reliability.
@@ -58,19 +79,6 @@ function sitepulse_speed_analyzer_page() {
     $php_version = PHP_VERSION;
 
     ?>
-    <style>
-        .speed-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 20px; }
-        .speed-card { background: #fff; padding: 20px; border: 1px solid #ddd; }
-        .speed-card h3 { margin-top: 0; border-bottom: 1px solid #eee; padding-bottom: 10px; font-size: 16px; display: flex; align-items: center; gap: 8px; }
-        .health-list { list-style: none; padding-left: 0; }
-        .health-list li { padding: 10px 0; border-bottom: 1px solid #f0f0f0; }
-        .health-list li:last-child { border-bottom: none; }
-        .health-list .metric-name { font-weight: bold; display: block; }
-        .health-list .metric-value { float: right; font-weight: bold; }
-        .status-ok { color: #4CAF50; }
-        .status-warn { color: #FFC107; }
-        .status-bad { color: #F44336; }
-    </style>
     <div class="wrap">
         <h1><span class="dashicons-before dashicons-performance"></span> Analyseur de Vitesse</h1>
         <p>Cet outil analyse la performance interne de votre serveur et de votre base de données à chaque chargement de page.</p>

--- a/sitepulse_FR/modules/uptime_tracker.php
+++ b/sitepulse_FR/modules/uptime_tracker.php
@@ -9,6 +9,27 @@ $sitepulse_uptime_cron_hook = function_exists('sitepulse_get_cron_hook') ? sitep
 
 add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Uptime Tracker', 'Uptime', 'manage_options', 'sitepulse-uptime', 'sitepulse_uptime_tracker_page'); });
 
+add_action('admin_enqueue_scripts', 'sitepulse_uptime_tracker_enqueue_assets');
+
+/**
+ * Enqueues the stylesheet for the uptime tracker admin page.
+ *
+ * @param string $hook_suffix Identifier of the current admin page.
+ * @return void
+ */
+function sitepulse_uptime_tracker_enqueue_assets($hook_suffix) {
+    if ($hook_suffix !== 'sitepulse-dashboard_page_sitepulse-uptime') {
+        return;
+    }
+
+    wp_enqueue_style(
+        'sitepulse-uptime-tracker',
+        SITEPULSE_URL . 'modules/css/uptime-tracker.css',
+        [],
+        SITEPULSE_VERSION
+    );
+}
+
 if (!empty($sitepulse_uptime_cron_hook)) {
     add_action('init', 'sitepulse_uptime_tracker_ensure_cron');
     add_action($sitepulse_uptime_cron_hook, 'sitepulse_run_uptime_check');
@@ -160,7 +181,6 @@ function sitepulse_uptime_tracker_page() {
         reset($uptime_log);
     }
     ?>
-    <style> .uptime-chart { display: flex; gap: 2px; height: 60px; align-items: flex-end; } .uptime-bar { flex-grow: 1; } .uptime-bar.up { background-color: #4CAF50; } .uptime-bar.down { background-color: #F44336; } .uptime-bar.unknown { background-color: #9E9E9E; } </style>
     <div class="wrap">
         <h1><span class="dashicons-before dashicons-chart-bar"></span> Suivi de Disponibilité</h1>
         <p>Cet outil vérifie la disponibilité de votre site toutes les heures. Voici le statut des <?php echo esc_html($total_checks); ?> dernières vérifications.</p>


### PR DESCRIPTION
## Summary
- move inline admin styles for the plugin impact scanner, speed analyzer, and uptime tracker into dedicated CSS files
- enqueue the new stylesheets on their respective SitePulse admin submenu pages

## Testing
- php -l sitepulse_FR/modules/plugin_impact_scanner.php
- php -l sitepulse_FR/modules/speed_analyzer.php
- php -l sitepulse_FR/modules/uptime_tracker.php

------
https://chatgpt.com/codex/tasks/task_e_68d6b35b5be0832e983c47427db345f1