### PR TITLE
Internationalize admin menus and maintenance advisor strings

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -35,6 +35,7 @@ function sitepulse_render_dashboard_page() {
         $notice = __('Le module de tableau de bord est activé mais son rendu est indisponible. Vérifiez les fichiers du plugin ou les journaux d’erreurs.', 'sitepulse');
     } else {
         $notice = sprintf(
+            /* translators: %s is the URL to the SitePulse settings page. */
             __('Le module de tableau de bord est désactivé. Activez-le depuis les <a href="%s">réglages de SitePulse</a>.', 'sitepulse'),
             esc_url($settings_url)
         );
@@ -51,8 +52,8 @@ function sitepulse_render_dashboard_page() {
  */
 function sitepulse_admin_menu() {
     add_menu_page(
-        'SitePulse Dashboard',
-        'Sitepulse - JLG',
+        __('SitePulse Dashboard', 'sitepulse'),
+        __('Sitepulse - JLG', 'sitepulse'),
         'manage_options',
         'sitepulse-dashboard',
         'sitepulse_render_dashboard_page',
@@ -62,8 +63,8 @@ function sitepulse_admin_menu() {
 
     add_submenu_page(
         'sitepulse-dashboard',
-        'SitePulse Settings',
-        'Settings',
+        __('SitePulse Settings', 'sitepulse'),
+        __('Settings', 'sitepulse'),
         'manage_options',
         'sitepulse-settings',
         'sitepulse_settings_page'
@@ -72,8 +73,8 @@ function sitepulse_admin_menu() {
     if (defined('SITEPULSE_DEBUG') && SITEPULSE_DEBUG) {
         add_submenu_page(
             'sitepulse-dashboard',
-            'SitePulse Debug',
-            'Debug',
+            __('SitePulse Debug', 'sitepulse'),
+            __('Debug', 'sitepulse'),
             'manage_options',
             'sitepulse-debug',
             'sitepulse_debug_page'
@@ -536,6 +537,7 @@ function sitepulse_debug_page() {
         <p class="description">
             <?php
             printf(
+                /* translators: 1: number of log lines kept, 2: formatted size limit. */
                 esc_html__('Seules les %1$d dernières lignes du journal (limitées à %2$s) sont chargées pour éviter toute surcharge mémoire.', 'sitepulse'),
                 (int) $log_max_lines,
                 wp_kses_post(size_format($log_max_bytes))

--- a/sitepulse_FR/modules/maintenance_advisor.php
+++ b/sitepulse_FR/modules/maintenance_advisor.php
@@ -1,6 +1,15 @@
 <?php
 if (!defined('ABSPATH')) exit;
-add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Maintenance Advisor', 'Maintenance', 'manage_options', 'sitepulse-maintenance', 'sitepulse_maintenance_advisor_page'); });
+add_action('admin_menu', function() {
+    add_submenu_page(
+        'sitepulse-dashboard',
+        __('Maintenance Advisor', 'sitepulse'),
+        __('Maintenance', 'sitepulse'),
+        'manage_options',
+        'sitepulse-maintenance',
+        'sitepulse_maintenance_advisor_page'
+    );
+});
 function sitepulse_maintenance_advisor_page() {
     if (!current_user_can('manage_options')) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
@@ -9,14 +18,16 @@ function sitepulse_maintenance_advisor_page() {
     require_once ABSPATH . 'wp-admin/includes/update.php';
     $core_updates = get_core_updates();
     $plugin_updates = get_plugin_updates();
-    $core_status = !empty($core_updates) && $core_updates[0]->response !== 'latest' ? 'Mise à jour disponible !' : 'À jour';
+    $core_status = !empty($core_updates) && $core_updates[0]->response !== 'latest'
+        ? __('Mise à jour disponible !', 'sitepulse')
+        : __('À jour', 'sitepulse');
     $plugin_updates_count = count($plugin_updates);
     ?>
     <div class="wrap">
-        <h1><span class="dashicons-before dashicons-update"></span> Conseiller de Maintenance</h1>
-        <p><strong>Mises à jour du Coeur WP:</strong> <?php echo esc_html($core_status); ?></p>
-        <p><strong>Mises à jour des Plugins:</strong> <?php echo esc_html($plugin_updates_count); ?> en attente</p>
-        <p class="description">Recommandations : Faites une sauvegarde avant de mettre à jour, testez sur un site de pré-production.</p>
+        <h1><span class="dashicons-before dashicons-update"></span> <?php esc_html_e('Conseiller de Maintenance', 'sitepulse'); ?></h1>
+        <p><strong><?php esc_html_e('Mises à jour du Coeur WP:', 'sitepulse'); ?></strong> <?php echo esc_html($core_status); ?></p>
+        <p><strong><?php esc_html_e('Mises à jour des Plugins:', 'sitepulse'); ?></strong> <?php echo esc_html($plugin_updates_count); ?> <?php esc_html_e('en attente', 'sitepulse'); ?></p>
+        <p class="description"><?php esc_html_e('Recommandations : Faites une sauvegarde avant de mettre à jour, testez sur un site de pré-production.', 'sitepulse'); ?></p>
     </div>
     <?php
 }


### PR DESCRIPTION
## Summary
- wrap SitePulse admin menu labels in translation helpers using the `sitepulse` text domain
- localize maintenance advisor UI strings and ensure they are safely escaped on output
- add translators comments for placeholder-based dashboard notices

## Testing
- `/root/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpcs --standard=WordPress --sniffs=WordPress.WP.I18n,WordPress.Security.EscapeOutput sitepulse_FR/includes/admin-settings.php sitepulse_FR/modules/maintenance_advisor.php`


------
https://chatgpt.com/codex/tasks/task_e_68d7e05ed508832eb2b43c814ab06c95