### PR TITLE
Avoid duplicate alert recipient reset option entry

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -259,12 +259,10 @@ function sitepulse_settings_page() {
                 SITEPULSE_OPTION_CPU_ALERT_THRESHOLD,
                 SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES,
                 SITEPULSE_OPTION_ALERT_INTERVAL,
+                // Clear stored alert recipients so the default (empty) list is restored on activation.
                 SITEPULSE_OPTION_ALERT_RECIPIENTS,
                 SITEPULSE_PLUGIN_IMPACT_OPTION,
             ];
-
-            // Clear stored alert recipients so the default (empty) list is restored on activation.
-            $options_to_delete[] = SITEPULSE_OPTION_ALERT_RECIPIENTS;
 
             foreach ($options_to_delete as $option_key) {
                 delete_option($option_key);


### PR DESCRIPTION
## Summary
- prevent duplicate addition of SITEPULSE_OPTION_ALERT_RECIPIENTS when building the reset option list
- retain the explanatory comment directly alongside the option entry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d836843970832ea05ed10c79e39fa9