### PR TITLE
Normalize unlimited memory limit display

### DIFF
--- a/sitepulse_FR/modules/resource_monitor.php
+++ b/sitepulse_FR/modules/resource_monitor.php
@@ -89,7 +89,25 @@ function sitepulse_resource_monitor_get_snapshot() {
     }
 
     $memory_usage = size_format(memory_get_usage());
-    $memory_limit = ini_get('memory_limit');
+    $memory_limit_ini = ini_get('memory_limit');
+    $memory_limit = $memory_limit_ini;
+
+    if ($memory_limit_ini !== false) {
+        $memory_limit_value = trim((string) $memory_limit_ini);
+        $memory_limit = $memory_limit_value;
+
+        if ($memory_limit_value !== '') {
+            $memory_limit_lower = strtolower($memory_limit_value);
+
+            if (
+                $memory_limit_lower === '-1'
+                || $memory_limit_lower === 'unlimited'
+                || (float) $memory_limit_value === -1.0
+            ) {
+                $memory_limit = __('Illimitée', 'sitepulse');
+            }
+        }
+    }
 
     $disk_free = 'N/A';
 


### PR DESCRIPTION
## Summary
- normalize the resource monitor snapshot so unlimited PHP memory limits render as a translated label
- cover the behavior with a PHPUnit test that simulates an unlimited memory limit

## Testing
- `vendor/bin/phpunit` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d83b2629c4832e9fde904f767495a3