### PR TITLE
Handle MU loader cleanup on uninstall

### DIFF
--- a/sitepulse_FR/uninstall.php
+++ b/sitepulse_FR/uninstall.php
@@ -30,6 +30,7 @@ $sitepulse_constants = [
     'SITEPULSE_OPTION_CRON_WARNINGS'              => 'sitepulse_cron_warnings',
     'SITEPULSE_TRANSIENT_RESOURCE_MONITOR_SNAPSHOT' => 'sitepulse_resource_monitor_snapshot',
     'SITEPULSE_PLUGIN_IMPACT_OPTION'              => 'sitepulse_plugin_impact_stats',
+    'SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE'    => 'sitepulse_impact_loader_signature',
 ];
 
 foreach ($sitepulse_constants as $constant => $value) {
@@ -59,6 +60,7 @@ $options = [
     SITEPULSE_OPTION_ERROR_ALERT_LOG_POINTER,
     SITEPULSE_OPTION_CRON_WARNINGS,
     SITEPULSE_PLUGIN_IMPACT_OPTION,
+    SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE,
 ];
 
 $transients = [
@@ -274,5 +276,16 @@ if (!empty($legacy_log_files)) {
         if (is_file($legacy_log_file)) {
             @unlink($legacy_log_file);
         }
+    }
+}
+
+$mu_loader_dir  = trailingslashit(WP_CONTENT_DIR) . 'mu-plugins';
+$mu_loader_file = trailingslashit($mu_loader_dir) . 'sitepulse-impact-loader.php';
+
+if (is_file($mu_loader_file)) {
+    if (function_exists('wp_delete_file')) {
+        wp_delete_file($mu_loader_file);
+    } else {
+        @unlink($mu_loader_file);
     }
 }

--- a/tests/phpunit/test-uninstall-impact-loader.php
+++ b/tests/phpunit/test-uninstall-impact-loader.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Tests for uninstall routines related to the plugin impact MU loader.
+ */
+
+class Sitepulse_Uninstall_Impact_Loader_Test extends WP_UnitTestCase {
+    private $mu_loader_dir;
+    private $mu_loader_file;
+
+    public static function setUpBeforeClass(): void {
+        parent::setUpBeforeClass();
+
+        if (!function_exists('sitepulse_plugin_impact_get_mu_loader_paths')) {
+            require_once dirname(__DIR__, 2) . '/sitepulse_FR/sitepulse.php';
+        }
+    }
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $paths = sitepulse_plugin_impact_get_mu_loader_paths();
+        $this->mu_loader_dir  = $paths['dir'];
+        $this->mu_loader_file = $paths['file'];
+
+        if (!is_dir($this->mu_loader_dir)) {
+            wp_mkdir_p($this->mu_loader_dir);
+        }
+
+        if (file_exists($this->mu_loader_file)) {
+            unlink($this->mu_loader_file);
+        }
+
+        delete_option(SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE);
+    }
+
+    protected function tearDown(): void {
+        if (file_exists($this->mu_loader_file)) {
+            unlink($this->mu_loader_file);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_uninstall_removes_mu_loader_and_signature_option(): void {
+        $this->assertTrue(
+            (bool) file_put_contents($this->mu_loader_file, 'dummy loader'),
+            'Failed to create the fake MU loader file before running uninstall.'
+        );
+
+        update_option(SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE, 'dummy-signature');
+
+        if (!defined('WP_UNINSTALL_PLUGIN')) {
+            define('WP_UNINSTALL_PLUGIN', true);
+        }
+
+        require dirname(__DIR__, 2) . '/sitepulse_FR/uninstall.php';
+
+        $this->assertFileDoesNotExist(
+            $this->mu_loader_file,
+            'Uninstall routine should remove the MU loader file.'
+        );
+
+        $this->assertFalse(
+            get_option(SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE, false),
+            'Signature option should be deleted during uninstall.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the uninstall routine defines the impact loader signature constant, removes the MU loader file, and clears the signature option
- add a PHPUnit test that exercises uninstall.php to confirm the MU loader file and signature option are removed

## Testing
- php -l sitepulse_FR/uninstall.php
- php -l tests/phpunit/test-uninstall-impact-loader.php

------
https://chatgpt.com/codex/tasks/task_e_68d86c171098832e988910d35ff420ff