### PR TITLE
Normalize debug log paths before sanitizing

### DIFF
--- a/sitepulse_FR/modules/error_alerts.php
+++ b/sitepulse_FR/modules/error_alerts.php
@@ -517,7 +517,15 @@ function sitepulse_error_alerts_check_debug_log() {
             $raw_site_name = get_bloginfo('name');
             $site_name     = trim(wp_strip_all_tags((string) $raw_site_name));
 
-            $log_file_for_message = is_string($log_file) ? sanitize_text_field($log_file) : '';
+            $log_file_for_message = '';
+
+            if (is_string($log_file)) {
+                $normalized_log_file = function_exists('wp_normalize_path')
+                    ? wp_normalize_path($log_file)
+                    : str_replace('\\', '/', $log_file);
+
+                $log_file_for_message = sanitize_textarea_field($normalized_log_file);
+            }
 
             /* translators: %s: Site title. */
             $subject = sprintf(


### PR DESCRIPTION
## Summary
- normalize the debug log path before sanitizing so fatal alert emails retain directory separators
- add a regression test that simulates a Windows-style log path and verifies the normalized path appears in the email message

## Testing
- Not run (phpunit command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d99f95d068832e96394d932b8ac89e