### PR TITLE
Handle failed multisite switches during activation

### DIFF
--- a/tests/phpunit/test-network-hooks.php
+++ b/tests/phpunit/test-network-hooks.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Tests for SitePulse network activation and deactivation helpers.
+ */
+
+class Sitepulse_Network_Hooks_Test extends WP_UnitTestCase {
+    public static function setUpBeforeClass(): void {
+        parent::setUpBeforeClass();
+
+        if (!function_exists('sitepulse_run_for_site')) {
+            require_once dirname(__DIR__, 2) . '/sitepulse_FR/sitepulse.php';
+        }
+    }
+
+    public function test_restore_not_called_when_switch_to_blog_fails(): void {
+        $target_site_id = 98765;
+        $callback_invocations = 0;
+        $restores = 0;
+
+        $filter = static function ($pre_switched, $site_id, $context) use ($target_site_id) {
+            if ($site_id === $target_site_id && 'activation' === $context) {
+                return false;
+            }
+
+            return $pre_switched;
+        };
+
+        add_filter('sitepulse_pre_switch_to_site', $filter, 10, 3);
+
+        $action = static function ($new_blog_id, $prev_blog_id, $context) use (&$restores) {
+            if ('restore' === $context) {
+                $restores++;
+            }
+        };
+
+        add_action('switch_blog', $action, 10, 3);
+
+        $result = sitepulse_run_for_site(
+            $target_site_id,
+            function () use (&$callback_invocations) {
+                $callback_invocations++;
+            },
+            'activation'
+        );
+
+        remove_filter('sitepulse_pre_switch_to_site', $filter, 10);
+        remove_action('switch_blog', $action, 10);
+
+        $this->assertFalse($result, 'Helper should report failure when the site switch fails.');
+        $this->assertSame(0, $callback_invocations, 'Callback should not run when switch_to_blog fails.');
+        $this->assertSame(0, $restores, 'restore_current_blog should not be called when switch_to_blog fails.');
+    }
+}


### PR DESCRIPTION
## Summary
- guard network activation and deactivation loops with a helper that only runs when switching to a site succeeds
- log skipped sites when switch_to_blog fails and expose a filter to simulate switch results
- add a PHPUnit test to ensure restore_current_blog is not called when switching fails

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d99f54c574832e8b960e0a4fc0129e