### PR TITLE
Add filter for SitePulse debug log base directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ SitePulse - JLG est un plugin WordPress développé par Jérôme Le Gousse. Il s
 - **Nettoyage et désinstallation** : les réglages permettent de purger journaux et données, tandis que la routine `uninstall.php` supprime options, transients, tâches planifiées et fichiers de log en toute sécurité lors de la suppression du plugin.【F:sitepulse_FR/includes/admin-settings.php†L333-L366】【F:sitepulse_FR/uninstall.php†L1-L126】
 - **Pour aller plus loin** : consultez chaque module dans `sitepulse_FR/modules/` pour comprendre les métriques collectées, les interfaces générées et adapter vos interventions si besoin.【F:sitepulse_FR/modules/custom_dashboards.php†L1-L121】
 
+## Sécurisation du journal de debug
+- **Localisation par défaut** : SitePulse écrit ses logs dans `wp-content/uploads/sitepulse/sitepulse-debug.log` et crée automatiquement le dossier si nécessaire.【F:sitepulse_FR/sitepulse.php†L75-L114】
+- **Attention sur Nginx** : sur les environnements qui n'appliquent pas les directives `.htaccess`/`web.config`, le fichier peut rester téléchargeable publiquement. Déplacez-le vers un répertoire protégé (hors webroot) via le filtre `sitepulse_debug_log_base_dir` ou ajoutez une règle serveur qui bloque l'accès HTTP.【F:sitepulse_FR/sitepulse.php†L75-L114】
+- **Exemple de déplacement** :
+
+  ```php
+  add_filter('sitepulse_debug_log_base_dir', function ($base_dir) {
+      return '/var/log/sitepulse'; // répertoire hors webroot, accessible en écriture
+  });
+  ```
+
+  Assurez-vous de créer le dossier cible avec les bonnes permissions si WordPress ne peut pas le faire automatiquement.
+
+
 ## Tests
 Un harnais PHPUnit/WP-Unit est disponible dans `tests/phpunit/` (configuré via `phpunit.xml.dist`) afin de valider les modules clefs : suivi d'uptime, notices de debug, nettoyage des transients ainsi que l'analyse du journal d'erreurs (pointeurs de lecture, détection des fatals et verrou de cooldown).
 
@@ -47,3 +61,4 @@ Ce flux peut être réutilisé en CI pour éviter les régressions sur les fonct
 
 ## Filtres disponibles
 - `sitepulse_uptime_request_args` : ajuste les arguments passés à `wp_remote_get()` lors de la vérification d'uptime. Peut être utilisé pour désactiver `sslverify`, modifier le `timeout` ou définir une clé `url` pointant vers une adresse de test dédiée.
+- `sitepulse_debug_log_base_dir` : permet de modifier le répertoire racine qui accueillera `sitepulse-debug.log` afin de le déplacer hors du webroot ou vers un volume dédié.【F:sitepulse_FR/sitepulse.php†L86-L114】

--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -422,6 +422,7 @@ function sitepulse_settings_page() {
                         <input type="hidden" name="<?php echo esc_attr(SITEPULSE_OPTION_DEBUG_MODE); ?>" value="0">
                         <input type="checkbox" id="<?php echo esc_attr(SITEPULSE_OPTION_DEBUG_MODE); ?>" name="<?php echo esc_attr(SITEPULSE_OPTION_DEBUG_MODE); ?>" value="1" <?php checked($is_debug_mode_enabled); ?>>
                         <p class="description"><?php esc_html_e("Active la journalisation détaillée et le tableau de bord de débogage. À n'utiliser que pour le dépannage.", 'sitepulse'); ?></p>
+                        <p class="description"><?php printf(esc_html__('Sur Nginx (ou tout serveur qui ignore .htaccess / web.config), déplacez le journal via le filtre %s ou bloquez-le côté serveur.', 'sitepulse'), 'sitepulse_debug_log_base_dir'); ?></p>
                     </td>
                 </tr>
             </table>

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -105,12 +105,35 @@ if (is_array($sitepulse_upload_dir) && empty($sitepulse_upload_dir['error']) && 
     $sitepulse_debug_basedir = $sitepulse_upload_dir['basedir'];
 }
 
+/**
+ * Filters the base directory used to store SitePulse debug logs.
+ *
+ * This filter allows hosts to move the log directory outside of the publicly
+ * accessible web root when server-level protections (such as .htaccess or
+ * web.config) are not enforced.
+ *
+ * @param string     $sitepulse_debug_basedir Current base directory.
+ * @param array|bool $sitepulse_upload_dir    Result of wp_upload_dir().
+ */
+$sitepulse_filtered_basedir = apply_filters('sitepulse_debug_log_base_dir', $sitepulse_debug_basedir, $sitepulse_upload_dir);
+
+if (is_string($sitepulse_filtered_basedir) && $sitepulse_filtered_basedir !== '') {
+    $sitepulse_debug_basedir = $sitepulse_filtered_basedir;
+}
+
 $sitepulse_debug_directory = rtrim($sitepulse_debug_basedir, '/\\') . '/sitepulse';
 
 if (function_exists('wp_mkdir_p') && !is_dir($sitepulse_debug_directory)) {
     wp_mkdir_p($sitepulse_debug_directory);
 }
 
+/**
+ * Absolute path to the SitePulse debug log file.
+ *
+ * By default, the log lives in the WordPress uploads directory. Use the
+ * `sitepulse_debug_log_base_dir` filter to relocate it (e.g. outside the
+ * web root) when web server protections cannot be enforced automatically.
+ */
 define('SITEPULSE_DEBUG_LOG', rtrim($sitepulse_debug_directory, '/\\') . '/sitepulse-debug.log');
 
 require_once SITEPULSE_PATH . 'includes/debug-notices.php';


### PR DESCRIPTION
## Summary
- add a `sitepulse_debug_log_base_dir` filter around the debug log directory selection so hosts can move the file outside the web root and document the constant
- surface guidance in the settings screen for Nginx users to relocate or protect the debug log
- extend the README with relocation instructions and filter documentation for securing the debug log

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68d99f57ea40832eb752ce7de02d2818