### PR TITLE
Validate Chart.js overrides for custom dashboards

### DIFF
--- a/tests/phpunit/test-custom-dashboard-assets.php
+++ b/tests/phpunit/test-custom-dashboard-assets.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Tests for the SitePulse custom dashboard asset registration.
+ */
+
+require_once __DIR__ . '/includes/stubs.php';
+
+require_once dirname(__DIR__, 2) . '/sitepulse_FR/modules/custom_dashboards.php';
+
+class Sitepulse_Custom_Dashboard_Assets_Test extends WP_UnitTestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        $GLOBALS['sitepulse_logger'] = [];
+        remove_all_filters('sitepulse_chartjs_src');
+
+        $scripts = wp_scripts();
+        $scripts->remove('sitepulse-chartjs');
+        $scripts->remove('sitepulse-dashboard-charts');
+    }
+
+    public function test_invalid_chartjs_url_is_rejected(): void {
+        add_filter('sitepulse_chartjs_src', static function () {
+            return 'http://malicious.example.com/chart.js';
+        });
+
+        sitepulse_custom_dashboard_enqueue_assets('toplevel_page_sitepulse-dashboard');
+
+        $scripts = wp_scripts();
+        $this->assertArrayHasKey('sitepulse-chartjs', $scripts->registered);
+        $this->assertSame(
+            SITEPULSE_URL . 'modules/vendor/chart.js/chart.umd.js',
+            $scripts->registered['sitepulse-chartjs']->src
+        );
+
+        $this->assertNotEmpty($GLOBALS['sitepulse_logger']);
+        $this->assertSame('DEBUG', $GLOBALS['sitepulse_logger'][0]['level']);
+        $this->assertStringContainsString('invalid Chart.js source override rejected', $GLOBALS['sitepulse_logger'][0]['message']);
+    }
+
+    public function test_https_chartjs_url_is_accepted(): void {
+        $custom_src = 'https://cdn.example.com/chart.js';
+
+        add_filter('sitepulse_chartjs_src', static function () use ($custom_src) {
+            return $custom_src;
+        });
+
+        sitepulse_custom_dashboard_enqueue_assets('toplevel_page_sitepulse-dashboard');
+
+        $scripts = wp_scripts();
+        $this->assertArrayHasKey('sitepulse-chartjs', $scripts->registered);
+        $this->assertSame($custom_src, $scripts->registered['sitepulse-chartjs']->src);
+        $this->assertEmpty($GLOBALS['sitepulse_logger']);
+    }
+}


### PR DESCRIPTION
## Summary
- validate custom Chart.js overrides so only HTTPS or internal plugin URLs are registered and log rejected overrides for easier debugging
- add PHPUnit coverage ensuring invalid Chart.js URLs fall back to the bundled asset while HTTPS overrides remain functional

## Testing
- php -l sitepulse_FR/modules/custom_dashboards.php
- php -l tests/phpunit/test-custom-dashboard-assets.php
- phpunit --configuration phpunit.xml.dist *(fails: phpunit not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da62636d4c832ea766d6f97ccdf29d