### PR TITLE
Block debug log writes when relocation fails

### DIFF
--- a/tests/phpunit/includes/stubs.php
+++ b/tests/phpunit/includes/stubs.php
@@ -75,6 +75,10 @@ if (!defined('SITEPULSE_URL')) {
 
 if (!function_exists('sitepulse_log')) {
     function sitepulse_log($message, $level = 'INFO') {
+        if (isset($GLOBALS['sitepulse_log_callable']) && is_callable($GLOBALS['sitepulse_log_callable'])) {
+            return call_user_func($GLOBALS['sitepulse_log_callable'], $message, $level);
+        }
+
         if (!isset($GLOBALS['sitepulse_logger'])) {
             $GLOBALS['sitepulse_logger'] = [];
         }


### PR DESCRIPTION
## Summary
- guard the debug log writer so it aborts when relocation fails on servers that ignore protection files and schedule an admin warning
- expose the logging implementation through a helper wrapper and track the blocked state for reuse and testing
- extend the PHPUnit stubs and add coverage ensuring no writes occur when the relocation_failed security context is present

## Testing
- php -l sitepulse_FR/sitepulse.php
- php -l tests/phpunit/test-debug-notices.php
- php -l tests/phpunit/includes/stubs.php

------
https://chatgpt.com/codex/tasks/task_e_68da625c9ccc832ea9157c83cd0349ee