### PR TITLE
Make MU loader resilient to renamed plugin folder

### DIFF
--- a/sitepulse_FR/includes/mu-plugin/sitepulse-impact-loader.php
+++ b/sitepulse_FR/includes/mu-plugin/sitepulse-impact-loader.php
@@ -8,14 +8,28 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-$sitepulse_plugin_directory = WP_PLUGIN_DIR . '/sitepulse_FR';
+$sitepulse_plugin_basename_option = 'sitepulse_plugin_basename';
+$sitepulse_plugin_basename = get_option($sitepulse_plugin_basename_option);
+
+if (!is_string($sitepulse_plugin_basename) || $sitepulse_plugin_basename === '') {
+    $sitepulse_plugin_basename = 'sitepulse_FR/sitepulse.php';
+}
+
+$sitepulse_plugin_basename = ltrim($sitepulse_plugin_basename, '/\\');
+$sitepulse_plugin_file = WP_PLUGIN_DIR . '/' . $sitepulse_plugin_basename;
+$sitepulse_plugin_directory = dirname($sitepulse_plugin_file);
+
+if ($sitepulse_plugin_directory === '.' || $sitepulse_plugin_directory === '') {
+    $sitepulse_plugin_directory = WP_PLUGIN_DIR;
+}
 
 if (function_exists('trailingslashit')) {
-    $sitepulse_plugin_directory = trailingslashit(WP_PLUGIN_DIR) . 'sitepulse_FR';
+    $sitepulse_plugin_directory = trailingslashit($sitepulse_plugin_directory);
 } else {
-    $sitepulse_plugin_directory = rtrim(WP_PLUGIN_DIR, '/\\') . '/sitepulse_FR';
+    $sitepulse_plugin_directory = rtrim($sitepulse_plugin_directory, '/\\') . '/';
 }
-$sitepulse_tracker_file = $sitepulse_plugin_directory . '/includes/plugin-impact-tracker.php';
+
+$sitepulse_tracker_file = $sitepulse_plugin_directory . 'includes/plugin-impact-tracker.php';
 
 if (file_exists($sitepulse_tracker_file)) {
     require_once $sitepulse_tracker_file;


### PR DESCRIPTION
## Summary
- Persist the SitePulse plugin basename and generate the MU loader file with the stored value
- Resolve the MU loader's tracker path dynamically based on the stored basename
- Add a regression test to ensure the MU loader boots correctly when the plugin directory is renamed

## Testing
- php -l sitepulse_FR/sitepulse.php
- php -l sitepulse_FR/includes/mu-plugin/sitepulse-impact-loader.php
- php -l tests/phpunit/test-plugin-impact-loader.php
- phpunit --configuration phpunit.xml.dist --testsuite sitepulse *(fails: phpunit not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe9010b84832e8bc5d356d9e96d57