### PR TITLE
Handle dynamic plugin basename for MU loader

### DIFF
--- a/sitepulse_FR/includes/mu-plugin/sitepulse-impact-loader.php
+++ b/sitepulse_FR/includes/mu-plugin/sitepulse-impact-loader.php
@@ -8,14 +8,46 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-$sitepulse_plugin_directory = WP_PLUGIN_DIR . '/sitepulse_FR';
+$sitepulse_plugin_basename = __SITEPULSE_PLUGIN_BASENAME__;
+
+if (!is_string($sitepulse_plugin_basename)) {
+    $sitepulse_plugin_basename = '';
+}
+
+if (function_exists('get_option')) {
+    $stored_basename = get_option('sitepulse_plugin_basename');
+
+    if (is_string($stored_basename) && $stored_basename !== '') {
+        $sitepulse_plugin_basename = $stored_basename;
+    }
+}
+
+$sitepulse_plugin_basename = (string) $sitepulse_plugin_basename;
+
+if ($sitepulse_plugin_basename === '') {
+    $sitepulse_plugin_basename = 'sitepulse_FR/sitepulse.php';
+}
+
+$sitepulse_plugin_basename = ltrim($sitepulse_plugin_basename, '/\\');
+
+$sitepulse_plugin_root = WP_PLUGIN_DIR;
 
 if (function_exists('trailingslashit')) {
-    $sitepulse_plugin_directory = trailingslashit(WP_PLUGIN_DIR) . 'sitepulse_FR';
+    $sitepulse_plugin_root = trailingslashit($sitepulse_plugin_root);
 } else {
-    $sitepulse_plugin_directory = rtrim(WP_PLUGIN_DIR, '/\\') . '/sitepulse_FR';
+    $sitepulse_plugin_root = rtrim($sitepulse_plugin_root, '/\\') . '/';
 }
-$sitepulse_tracker_file = $sitepulse_plugin_directory . '/includes/plugin-impact-tracker.php';
+
+$sitepulse_plugin_file = $sitepulse_plugin_root . $sitepulse_plugin_basename;
+$sitepulse_plugin_directory = dirname($sitepulse_plugin_file);
+
+if (function_exists('trailingslashit')) {
+    $sitepulse_plugin_directory = trailingslashit($sitepulse_plugin_directory);
+} else {
+    $sitepulse_plugin_directory = rtrim($sitepulse_plugin_directory, '/\\') . '/';
+}
+
+$sitepulse_tracker_file = $sitepulse_plugin_directory . 'includes/plugin-impact-tracker.php';
 
 if (file_exists($sitepulse_tracker_file)) {
     require_once $sitepulse_tracker_file;

--- a/tests/phpunit/test-plugin-impact-loader.php
+++ b/tests/phpunit/test-plugin-impact-loader.php
@@ -34,6 +34,8 @@ if (!class_exists('Sitepulse_Unwritable_Filesystem')) {
 class Sitepulse_Plugin_Impact_Loader_Test extends WP_UnitTestCase {
     protected $mu_loader_dir;
     protected $mu_loader_file;
+    protected $renamed_plugin_dir;
+    protected $renamed_tracker_file;
 
     public static function setUpBeforeClass(): void {
         parent::setUpBeforeClass();
@@ -48,6 +50,7 @@ class Sitepulse_Plugin_Impact_Loader_Test extends WP_UnitTestCase {
 
         delete_option(SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE);
         delete_option(SITEPULSE_OPTION_CRON_WARNINGS);
+        delete_option(SITEPULSE_OPTION_PLUGIN_BASENAME);
 
         $GLOBALS['sitepulse_filesystem_initialized'] = false;
         $GLOBALS['sitepulse_filesystem_instance']    = null;
@@ -56,6 +59,15 @@ class Sitepulse_Plugin_Impact_Loader_Test extends WP_UnitTestCase {
         $paths = sitepulse_plugin_impact_get_mu_loader_paths();
         $this->mu_loader_dir  = $paths['dir'];
         $this->mu_loader_file = $paths['file'];
+
+        $plugins_root = function_exists('trailingslashit')
+            ? trailingslashit(WP_PLUGIN_DIR)
+            : rtrim(WP_PLUGIN_DIR, '/\\') . '/';
+
+        $this->renamed_plugin_dir   = $plugins_root . 'sitepulse-renamed';
+        $this->renamed_tracker_file = $this->renamed_plugin_dir . '/includes/plugin-impact-tracker.php';
+
+        $this->removeTestDirectory($this->renamed_plugin_dir);
 
         if (file_exists($this->mu_loader_file)) {
             unlink($this->mu_loader_file);
@@ -89,7 +101,41 @@ class Sitepulse_Plugin_Impact_Loader_Test extends WP_UnitTestCase {
             @chmod($this->mu_loader_dir, 0755);
         }
 
+        $this->removeTestDirectory($this->renamed_plugin_dir);
+
         parent::tearDown();
+    }
+
+    protected function removeTestDirectory($path): void {
+        if (!file_exists($path)) {
+            return;
+        }
+
+        if (is_file($path) || is_link($path)) {
+            @unlink($path);
+
+            return;
+        }
+
+        $items = scandir($path);
+
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $this->removeTestDirectory($path . DIRECTORY_SEPARATOR . $item);
+        }
+
+        @rmdir($path);
+    }
+
+    public function filter_sitepulse_plugin_basename($basename, $current = null) {
+        return 'sitepulse-renamed/sitepulse.php';
     }
 
     public function test_registers_warning_when_mu_directory_is_unwritable(): void {
@@ -129,5 +175,49 @@ class Sitepulse_Plugin_Impact_Loader_Test extends WP_UnitTestCase {
         $this->assertIsArray($warnings, 'Cron warnings option should remain an array after clearing entries.');
         $this->assertArrayNotHasKey('plugin_impact', $warnings, 'Successful installation should clear the plugin impact warning.');
         $this->assertArrayHasKey('other', $warnings, 'Other cron warnings should remain untouched.');
+    }
+
+    public function test_mu_loader_bootstraps_tracker_with_renamed_directory(): void {
+        wp_mkdir_p(dirname($this->renamed_tracker_file));
+
+        file_put_contents(
+            $this->renamed_tracker_file,
+            "<?php\n\$GLOBALS['sitepulse_tracker_stub_loaded'] = true;\n"
+        );
+
+        remove_action('plugin_loaded', 'sitepulse_plugin_impact_tracker_on_plugin_loaded', PHP_INT_MAX);
+        remove_action('shutdown', 'sitepulse_plugin_impact_tracker_persist', PHP_INT_MAX);
+
+        add_filter('sitepulse_plugin_basename', [$this, 'filter_sitepulse_plugin_basename'], 10, 2);
+
+        sitepulse_plugin_impact_install_mu_loader();
+
+        remove_filter('sitepulse_plugin_basename', [$this, 'filter_sitepulse_plugin_basename'], 10);
+
+        $this->assertFileExists($this->mu_loader_file, 'MU loader should be created.');
+        $this->assertSame(
+            'sitepulse-renamed/sitepulse.php',
+            get_option(SITEPULSE_OPTION_PLUGIN_BASENAME),
+            'Renamed plugin basename should be stored for the MU loader.'
+        );
+
+        unset($GLOBALS['sitepulse_tracker_stub_loaded']);
+
+        require $this->mu_loader_file;
+
+        $this->assertTrue(
+            !empty($GLOBALS['sitepulse_tracker_stub_loaded']),
+            'MU loader should include the tracker file from the renamed directory.'
+        );
+        $this->assertSame(
+            PHP_INT_MAX,
+            has_action('plugin_loaded', 'sitepulse_plugin_impact_tracker_on_plugin_loaded'),
+            'Tracker bootstrap should be re-registered after requiring the MU loader.'
+        );
+        $this->assertSame(
+            PHP_INT_MAX,
+            has_action('shutdown', 'sitepulse_plugin_impact_tracker_persist'),
+            'Shutdown persistence hook should be re-registered after requiring the MU loader.'
+        );
     }
 }


### PR DESCRIPTION
## Summary
- persist the plugin basename in an option and render the MU loader from a templated string so it reflects the current path
- teach the bundled MU loader to resolve the plugin directory from the stored basename before bootstrapping the tracker
- cover the renamed-directory regression with a dedicated PHPUnit test harness and supporting fixtures

## Testing
- not run (phpunit binary not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbf78d71e8832eaef302fff40fbbce