### PR TITLE
Allow customizing SitePulse admin capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ SitePulse - JLG est un plugin WordPress développé par Jérôme Le Gousse. Il s
 4. **Alertes** : définissez le seuil d'alerte CPU et la fenêtre anti-spam pour contrôler la fréquence des e-mails envoyés par le module d'alertes.【F:sitepulse_FR/includes/admin-settings.php†L273-L287】【F:sitepulse_FR/modules/error_alerts.php†L9-L63】
 5. **Mode debug et nettoyage** : activez le mode debug pour exposer le sous-menu de diagnostic, vider le journal de debug ou réinitialiser les données directement depuis la même page de réglages.【F:sitepulse_FR/includes/admin-settings.php†L265-L366】
 
+### Droits d'accès et capacités
+- **Capacité dédiée** : SitePulse vérifie systématiquement la capacité renvoyée par `sitepulse_get_capability()` (filtrable via `sitepulse_required_capability`) afin de protéger le menu principal, les sous-menus et les écrans de réglages.【F:sitepulse_FR/includes/admin-settings.php†L14-L88】【F:sitepulse_FR/modules/resource_monitor.php†L1-L8】
+- **Activation** : lors de l'activation du plugin, cette capacité est automatiquement ajoutée au rôle `administrator`, garantissant l'accès immédiat à l'interface.【F:sitepulse_FR/sitepulse.php†L1192-L1206】
+- **Rôles personnalisés** : pour déléguer la gestion à un rôle sur mesure, ajoutez la capacité filtrée sur un hook (exemple ci-dessous avec une capacité `manage_sitepulse`).
+
+  ```php
+  add_filter('sitepulse_required_capability', function () {
+      return 'manage_sitepulse';
+  });
+
+  add_action('init', function () {
+      if ($role = get_role('gestionnaire_sitepulse')) {
+          $role->add_cap('manage_sitepulse');
+      }
+  });
+  ```
+
 ## Intégrations et automatisations
 - **Planification de la disponibilité** : le module de suivi programme un cron horaire (`wp_schedule_event`) pour exécuter `sitepulse_run_uptime_check`, conservant un historique glissant de 30 points et consignant les incidents.【F:sitepulse_FR/modules/uptime_tracker.php†L5-L74】
 - **Boucle d'alertes automatisées** : un cron personnalisé toutes les cinq minutes orchestre la lecture du fichier `debug.log` et la surveillance de la charge CPU, avec verrouillage par transient pour éviter le spam d'e-mails.【F:sitepulse_FR/modules/error_alerts.php†L1-L121】

--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -10,6 +10,25 @@
 if (!defined('ABSPATH')) exit;
 
 /**
+ * Returns the capability required to manage SitePulse settings.
+ *
+ * @return string Filterable capability name.
+ */
+function sitepulse_get_capability() {
+    $default_capability = 'manage_options';
+
+    if (function_exists('apply_filters')) {
+        $filtered_capability = apply_filters('sitepulse_required_capability', $default_capability);
+
+        if (is_string($filtered_capability) && $filtered_capability !== '') {
+            return $filtered_capability;
+        }
+    }
+
+    return $default_capability;
+}
+
+/**
  * Wrapper for the main SitePulse dashboard page.
  *
  * Ensures that the menu callback registered via {@see add_menu_page()} is always
@@ -18,7 +37,7 @@ if (!defined('ABSPATH')) exit;
  * notice is displayed with guidance on how to enable the feature.
  */
 function sitepulse_render_dashboard_page() {
-    if (!current_user_can('manage_options')) {
+    if (!current_user_can(sitepulse_get_capability())) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }
 
@@ -54,7 +73,7 @@ function sitepulse_admin_menu() {
     add_menu_page(
         __('SitePulse Dashboard', 'sitepulse'),
         __('Sitepulse - JLG', 'sitepulse'),
-        'manage_options',
+        sitepulse_get_capability(),
         'sitepulse-dashboard',
         'sitepulse_render_dashboard_page',
         'dashicons-chart-area',
@@ -65,7 +84,7 @@ function sitepulse_admin_menu() {
         'sitepulse-dashboard',
         __('SitePulse Settings', 'sitepulse'),
         __('Settings', 'sitepulse'),
-        'manage_options',
+        sitepulse_get_capability(),
         'sitepulse-settings',
         'sitepulse_settings_page'
     );
@@ -75,7 +94,7 @@ function sitepulse_admin_menu() {
             'sitepulse-dashboard',
             __('SitePulse Debug', 'sitepulse'),
             __('Debug', 'sitepulse'),
-            'manage_options',
+            sitepulse_get_capability(),
             'sitepulse-debug',
             'sitepulse_debug_page'
         );
@@ -226,7 +245,7 @@ function sitepulse_sanitize_alert_recipients($value) {
  * Renders the settings page.
  */
 function sitepulse_settings_page() {
-    if (!current_user_can('manage_options')) {
+    if (!current_user_can(sitepulse_get_capability())) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }
 
@@ -507,7 +526,7 @@ function sitepulse_settings_page() {
  * Renders the debug page.
  */
 function sitepulse_debug_page() {
-    if (!current_user_can('manage_options')) {
+    if (!current_user_can(sitepulse_get_capability())) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }
 

--- a/sitepulse_FR/modules/ai_insights.php
+++ b/sitepulse_FR/modules/ai_insights.php
@@ -6,7 +6,7 @@ add_action('admin_menu', function() {
         'sitepulse-dashboard',
         __('AI Insights', 'sitepulse'),
         __('AI Insights', 'sitepulse'),
-        'manage_options',
+        sitepulse_get_capability(),
         'sitepulse-ai',
         'sitepulse_ai_insights_page'
     );
@@ -98,7 +98,7 @@ function sitepulse_ai_insights_enqueue_assets($hook_suffix) {
 }
 
 function sitepulse_ai_insights_page() {
-    if (!current_user_can('manage_options')) {
+    if (!current_user_can(sitepulse_get_capability())) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }
 
@@ -144,7 +144,7 @@ function sitepulse_generate_ai_insight() {
         sitepulse_log($log_message, 'ERROR');
     };
 
-    if (!current_user_can('manage_options')) {
+    if (!current_user_can(sitepulse_get_capability())) {
         $error_message = esc_html__("Vous n'avez pas les permissions nécessaires pour effectuer cette action.", 'sitepulse');
 
         $log_ai_error($error_message, 403);

--- a/sitepulse_FR/modules/custom_dashboards.php
+++ b/sitepulse_FR/modules/custom_dashboards.php
@@ -127,7 +127,7 @@ function sitepulse_custom_dashboard_enqueue_assets($hook_suffix) {
  * to prevent conflicts and duplicate menus.
  */
 function sitepulse_custom_dashboards_page() {
-    if (!current_user_can('manage_options')) {
+    if (!current_user_can(sitepulse_get_capability())) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }
 

--- a/sitepulse_FR/modules/database_optimizer.php
+++ b/sitepulse_FR/modules/database_optimizer.php
@@ -5,13 +5,13 @@ add_action('admin_menu', function() {
         'sitepulse-dashboard',
         __('Database Optimizer', 'sitepulse'),
         __('Database', 'sitepulse'),
-        'manage_options',
+        sitepulse_get_capability(),
         'sitepulse-db',
         'sitepulse_database_optimizer_page'
     );
 });
 function sitepulse_database_optimizer_page() {
-    if (!current_user_can('manage_options')) {
+    if (!current_user_can(sitepulse_get_capability())) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }
 

--- a/sitepulse_FR/modules/log_analyzer.php
+++ b/sitepulse_FR/modules/log_analyzer.php
@@ -7,7 +7,7 @@ add_action('admin_menu', function() {
         'sitepulse-dashboard',
         'Log Analyzer',
         'Logs',
-        'manage_options',
+        sitepulse_get_capability(),
         'sitepulse-logs',
         'sitepulse_log_analyzer_page'
     );
@@ -17,7 +17,7 @@ add_action('admin_menu', function() {
  * Renders the Log Analyzer page with improved logic and explanations.
  */
 function sitepulse_log_analyzer_page() {
-    if (!current_user_can('manage_options')) {
+    if (!current_user_can(sitepulse_get_capability())) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }
 

--- a/sitepulse_FR/modules/maintenance_advisor.php
+++ b/sitepulse_FR/modules/maintenance_advisor.php
@@ -5,13 +5,13 @@ add_action('admin_menu', function() {
         'sitepulse-dashboard',
         __('Maintenance Advisor', 'sitepulse'),
         __('Maintenance', 'sitepulse'),
-        'manage_options',
+        sitepulse_get_capability(),
         'sitepulse-maintenance',
         'sitepulse_maintenance_advisor_page'
     );
 });
 function sitepulse_maintenance_advisor_page() {
-    if (!current_user_can('manage_options')) {
+    if (!current_user_can(sitepulse_get_capability())) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }
 

--- a/sitepulse_FR/modules/plugin_impact_scanner.php
+++ b/sitepulse_FR/modules/plugin_impact_scanner.php
@@ -10,7 +10,7 @@ add_action(
             'sitepulse-dashboard',
             'Plugin Impact Scanner',
             'Plugin Impact',
-            'manage_options',
+            sitepulse_get_capability(),
             'sitepulse-plugins',
             'sitepulse_plugin_impact_scanner_page'
         );
@@ -120,7 +120,7 @@ function sitepulse_plugin_impact_clear_dir_cache_on_upgrade($upgrader, $hook_ext
 }
 
 function sitepulse_plugin_impact_scanner_page() {
-    if (!current_user_can('manage_options')) {
+    if (!current_user_can(sitepulse_get_capability())) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }
 

--- a/sitepulse_FR/modules/resource_monitor.php
+++ b/sitepulse_FR/modules/resource_monitor.php
@@ -2,7 +2,7 @@
 if (!defined('ABSPATH')) exit;
 
 add_action('admin_menu', function() {
-    add_submenu_page('sitepulse-dashboard', 'Resource Monitor', 'Resources', 'manage_options', 'sitepulse-resources', 'sitepulse_resource_monitor_page');
+    add_submenu_page('sitepulse-dashboard', 'Resource Monitor', 'Resources', sitepulse_get_capability(), 'sitepulse-resources', 'sitepulse_resource_monitor_page');
 });
 
 add_action('admin_enqueue_scripts', 'sitepulse_resource_monitor_enqueue_assets');
@@ -273,7 +273,7 @@ function sitepulse_resource_monitor_get_snapshot() {
 }
 
 function sitepulse_resource_monitor_page() {
-    if (!current_user_can('manage_options')) {
+    if (!current_user_can(sitepulse_get_capability())) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }
 

--- a/sitepulse_FR/modules/speed_analyzer.php
+++ b/sitepulse_FR/modules/speed_analyzer.php
@@ -7,7 +7,7 @@ add_action('admin_menu', function() {
         'sitepulse-dashboard',
         'Speed Analyzer',
         'Speed',
-        'manage_options',
+        sitepulse_get_capability(),
         'sitepulse-speed',
         'sitepulse_speed_analyzer_page'
     );
@@ -39,7 +39,7 @@ function sitepulse_speed_analyzer_enqueue_assets($hook_suffix) {
  * The analysis is now based on internal WordPress timers for better reliability.
  */
 function sitepulse_speed_analyzer_page() {
-    if (!current_user_can('manage_options')) {
+    if (!current_user_can(sitepulse_get_capability())) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }
 

--- a/sitepulse_FR/modules/uptime_tracker.php
+++ b/sitepulse_FR/modules/uptime_tracker.php
@@ -7,7 +7,9 @@ if (!defined('SITEPULSE_OPTION_UPTIME_FAILURE_STREAK')) {
 
 $sitepulse_uptime_cron_hook = function_exists('sitepulse_get_cron_hook') ? sitepulse_get_cron_hook('uptime_tracker') : 'sitepulse_uptime_tracker_cron';
 
-add_action('admin_menu', function() { add_submenu_page('sitepulse-dashboard', 'Uptime Tracker', 'Uptime', 'manage_options', 'sitepulse-uptime', 'sitepulse_uptime_tracker_page'); });
+add_action('admin_menu', function() {
+    add_submenu_page('sitepulse-dashboard', 'Uptime Tracker', 'Uptime', sitepulse_get_capability(), 'sitepulse-uptime', 'sitepulse_uptime_tracker_page');
+});
 
 add_action('admin_enqueue_scripts', 'sitepulse_uptime_tracker_enqueue_assets');
 
@@ -162,7 +164,7 @@ function sitepulse_normalize_uptime_log($log) {
 }
 
 function sitepulse_uptime_tracker_page() {
-    if (!current_user_can('manage_options')) {
+    if (!current_user_can(sitepulse_get_capability())) {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }
 

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -555,7 +555,7 @@ function sitepulse_clear_cron_warning($module_key) {
  * @return void
  */
 function sitepulse_render_cron_warnings() {
-    if (!is_admin() || !current_user_can('manage_options')) {
+    if (!is_admin() || !current_user_can(sitepulse_get_capability())) {
         return;
     }
 
@@ -1200,6 +1200,18 @@ function sitepulse_activate_site() {
     add_option(SITEPULSE_OPTION_CRON_WARNINGS, [], '', false);
 
     sitepulse_plugin_impact_install_mu_loader();
+
+    if (function_exists('get_role')) {
+        $capability = sitepulse_get_capability();
+
+        if (is_string($capability) && $capability !== '') {
+            $administrator_role = get_role('administrator');
+
+            if ($administrator_role instanceof \WP_Role) {
+                $administrator_role->add_cap($capability);
+            }
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a `sitepulse_get_capability()` helper filtered via `sitepulse_required_capability`
- switch the admin menu, modules and cron warnings to reuse the helper
- grant the capability to administrators on activation and document how to delegate it to custom roles

## Testing
- `for file in sitepulse_FR/includes/admin-settings.php sitepulse_FR/modules/maintenance_advisor.php sitepulse_FR/modules/database_optimizer.php sitepulse_FR/modules/ai_insights.php sitepulse_FR/modules/plugin_impact_scanner.php sitepulse_FR/modules/speed_analyzer.php sitepulse_FR/modules/log_analyzer.php sitepulse_FR/modules/uptime_tracker.php sitepulse_FR/modules/resource_monitor.php sitepulse_FR/modules/custom_dashboards.php sitepulse_FR/sitepulse.php; do php -l "$file" || break; done`


------
https://chatgpt.com/codex/tasks/task_e_68dc06fd5f7c832ebb2eeb6233226774