### PR TITLE
Add cron-driven AI insights generation with history support

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -279,7 +279,9 @@ function sitepulse_settings_page() {
         }
         if (isset($_POST['sitepulse_clear_data'])) {
             delete_option(SITEPULSE_OPTION_UPTIME_LOG);
+            delete_option(SITEPULSE_OPTION_AI_INSIGHT_HISTORY);
             delete_transient(SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS);
+            delete_transient(SITEPULSE_TRANSIENT_AI_INSIGHT_LOCK);
             echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__('Données stockées effacées.', 'sitepulse') . '</p></div>';
         }
         if (isset($_POST['sitepulse_reset_all'])) {
@@ -290,6 +292,7 @@ function sitepulse_settings_page() {
                 SITEPULSE_OPTION_DEBUG_MODE,
                 SITEPULSE_OPTION_GEMINI_API_KEY,
                 SITEPULSE_OPTION_UPTIME_LOG,
+                SITEPULSE_OPTION_AI_INSIGHT_HISTORY,
                 SITEPULSE_OPTION_LAST_LOAD_TIME,
                 SITEPULSE_OPTION_CPU_ALERT_THRESHOLD,
                 SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES,
@@ -306,6 +309,7 @@ function sitepulse_settings_page() {
             $transients_to_delete = [
                 SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS,
                 SITEPULSE_TRANSIENT_AI_INSIGHT,
+                SITEPULSE_TRANSIENT_AI_INSIGHT_LOCK,
                 SITEPULSE_TRANSIENT_ERROR_ALERT_CPU_LOCK,
                 SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK,
             ];

--- a/sitepulse_FR/includes/cron-hooks.php
+++ b/sitepulse_FR/includes/cron-hooks.php
@@ -5,4 +5,5 @@ return [
     'error_alerts'      => 'sitepulse_error_alerts_cron',
     'resource_monitor'  => 'sitepulse_resource_monitor_cron',
     'log_analyzer'      => 'sitepulse_log_analyzer_cron',
+    'ai_insights'       => 'sitepulse_ai_insights_cron',
 ];

--- a/sitepulse_FR/modules/ai_insights.php
+++ b/sitepulse_FR/modules/ai_insights.php
@@ -13,6 +13,484 @@ add_action('admin_menu', function() {
 });
 add_action('admin_enqueue_scripts', 'sitepulse_ai_insights_enqueue_assets');
 add_action('wp_ajax_sitepulse_generate_ai_insight', 'sitepulse_generate_ai_insight');
+add_action('init', 'sitepulse_ai_insights_schedule');
+add_action('sitepulse_ai_insights_cron', 'sitepulse_ai_insights_run_cron');
+add_action('update_option_' . SITEPULSE_OPTION_GEMINI_API_KEY, 'sitepulse_ai_insights_schedule', 10, 0);
+
+function sitepulse_ai_insights_schedule() {
+    if (!function_exists('wp_next_scheduled') || !function_exists('wp_schedule_event')) {
+        return;
+    }
+
+    $cron_hook = 'sitepulse_ai_insights_cron';
+    $api_key   = trim((string) get_option(SITEPULSE_OPTION_GEMINI_API_KEY));
+
+    if ($api_key === '') {
+        if (function_exists('wp_clear_scheduled_hook')) {
+            wp_clear_scheduled_hook($cron_hook);
+        }
+
+        return;
+    }
+
+    if (!wp_next_scheduled($cron_hook)) {
+        wp_schedule_event(time(), 'daily', $cron_hook);
+    }
+}
+
+function sitepulse_ai_insights_run_cron() {
+    $result = sitepulse_ai_generate_insight_payload([
+        'source' => 'cron',
+    ]);
+
+    if (is_wp_error($result)) {
+        $message = $result->get_error_message();
+        $error_data = $result->get_error_data();
+        $status_code = null;
+
+        if (is_array($error_data) && isset($error_data['status_code'])) {
+            $status_code = (int) $error_data['status_code'];
+        }
+
+        if ($message !== '') {
+            sitepulse_ai_log_error($message, $status_code);
+        }
+
+        return;
+    }
+}
+
+function sitepulse_ai_log_error($message, $status_code = null) {
+    if (!function_exists('sitepulse_log')) {
+        return;
+    }
+
+    $message = (string) $message;
+    $log_message = $status_code !== null
+        ? sprintf('AI Insights (%d): %s', (int) $status_code, $message)
+        : sprintf('AI Insights: %s', $message);
+
+    sitepulse_log($log_message, 'ERROR');
+}
+
+function sitepulse_ai_get_history_limit() {
+    $limit = defined('SITEPULSE_AI_INSIGHT_HISTORY_LIMIT') ? (int) SITEPULSE_AI_INSIGHT_HISTORY_LIMIT : 7;
+    $limit = (int) apply_filters('sitepulse_ai_insight_history_limit', $limit);
+
+    if ($limit <= 0) {
+        $limit = 1;
+    }
+
+    return $limit;
+}
+
+function sitepulse_ai_normalize_insight_entry($text, $timestamp = 0, $source = 'manual') {
+    $text = sanitize_textarea_field((string) $text);
+
+    if ($text === '') {
+        return null;
+    }
+
+    $timestamp = absint($timestamp);
+
+    if ($timestamp <= 0) {
+        $timestamp = absint(current_time('timestamp', true));
+    }
+
+    $allowed_sources = ['manual', 'cron'];
+
+    if (!in_array($source, $allowed_sources, true)) {
+        $source = 'manual';
+    }
+
+    return [
+        'text'      => $text,
+        'timestamp' => $timestamp,
+        'source'    => $source,
+    ];
+}
+
+function sitepulse_ai_get_insight_storage($force_refresh = false) {
+    static $storage = null;
+
+    if ($force_refresh) {
+        $storage = null;
+
+        return [
+            'entries'           => [],
+            'last_auto_refresh' => null,
+        ];
+    }
+
+    if ($storage !== null) {
+        return $storage;
+    }
+
+    $storage = [
+        'entries'           => [],
+        'last_auto_refresh' => null,
+    ];
+
+    $option_value = get_option(SITEPULSE_OPTION_AI_INSIGHT_HISTORY, []);
+
+    if (is_array($option_value)) {
+        if (isset($option_value['entries']) && is_array($option_value['entries'])) {
+            foreach ($option_value['entries'] as $entry) {
+                if (!is_array($entry)) {
+                    continue;
+                }
+
+                $normalized = sitepulse_ai_normalize_insight_entry(
+                    $entry['text'] ?? '',
+                    isset($entry['timestamp']) ? $entry['timestamp'] : 0,
+                    isset($entry['source']) ? $entry['source'] : 'manual'
+                );
+
+                if ($normalized !== null) {
+                    $storage['entries'][] = $normalized;
+                }
+
+                if (count($storage['entries']) >= sitepulse_ai_get_history_limit()) {
+                    break;
+                }
+            }
+        }
+
+        if (isset($option_value['last_auto_refresh'])) {
+            $last_auto_refresh = absint($option_value['last_auto_refresh']);
+
+            if ($last_auto_refresh > 0) {
+                $storage['last_auto_refresh'] = $last_auto_refresh;
+            }
+        }
+    }
+
+    if (empty($storage['entries'])) {
+        $transient_value = get_transient(SITEPULSE_TRANSIENT_AI_INSIGHT);
+        $migrated_entry  = null;
+
+        if (is_array($transient_value) && isset($transient_value['text'])) {
+            $migrated_entry = sitepulse_ai_normalize_insight_entry(
+                $transient_value['text'],
+                isset($transient_value['timestamp']) ? $transient_value['timestamp'] : 0,
+                'manual'
+            );
+        } elseif (is_string($transient_value) && $transient_value !== '') {
+            $migrated_entry = sitepulse_ai_normalize_insight_entry($transient_value, 0, 'manual');
+        }
+
+        if ($migrated_entry !== null) {
+            $storage['entries'][] = $migrated_entry;
+            update_option(SITEPULSE_OPTION_AI_INSIGHT_HISTORY, $storage);
+            delete_transient(SITEPULSE_TRANSIENT_AI_INSIGHT);
+        }
+    }
+
+    return $storage;
+}
+
+function sitepulse_ai_get_history_entries() {
+    $storage = sitepulse_ai_get_insight_storage();
+
+    return $storage['entries'];
+}
+
+function sitepulse_ai_get_last_auto_refresh_timestamp() {
+    $storage = sitepulse_ai_get_insight_storage();
+
+    return $storage['last_auto_refresh'];
+}
+
+function sitepulse_ai_store_insight_entry($text, $timestamp, $source = 'manual') {
+    $entry = sitepulse_ai_normalize_insight_entry($text, $timestamp, $source);
+
+    if ($entry === null) {
+        return null;
+    }
+
+    $storage = sitepulse_ai_get_insight_storage();
+
+    array_unshift($storage['entries'], $entry);
+    $storage['entries'] = array_slice($storage['entries'], 0, sitepulse_ai_get_history_limit());
+
+    if ('cron' === $entry['source']) {
+        $storage['last_auto_refresh'] = $entry['timestamp'];
+    } elseif (!isset($storage['last_auto_refresh'])) {
+        $storage['last_auto_refresh'] = null;
+    }
+
+    update_option(SITEPULSE_OPTION_AI_INSIGHT_HISTORY, $storage);
+    sitepulse_ai_get_insight_storage(true);
+    sitepulse_ai_get_cached_insight(true);
+
+    return $entry;
+}
+
+function sitepulse_ai_prepare_history_payload() {
+    $history = [];
+
+    foreach (sitepulse_ai_get_history_entries() as $entry) {
+        $history[] = [
+            'text'      => $entry['text'],
+            'timestamp' => $entry['timestamp'],
+            'source'    => $entry['source'],
+        ];
+    }
+
+    return $history;
+}
+
+function sitepulse_ai_prepare_response_payload($entry, $is_cached) {
+    $payload = [
+        'text'             => '',
+        'timestamp'        => null,
+        'source'           => 'manual',
+        'cached'           => (bool) $is_cached,
+        'history'          => sitepulse_ai_prepare_history_payload(),
+        'lastAutoRefresh'  => sitepulse_ai_get_last_auto_refresh_timestamp(),
+    ];
+
+    if (is_array($entry)) {
+        if (isset($entry['text'])) {
+            $payload['text'] = $entry['text'];
+        }
+
+        if (isset($entry['timestamp'])) {
+            $payload['timestamp'] = $entry['timestamp'];
+        }
+
+        if (isset($entry['source'])) {
+            $payload['source'] = $entry['source'];
+        }
+    }
+
+    return $payload;
+}
+
+function sitepulse_ai_generate_insight_payload($args = []) {
+    $defaults = [
+        'source' => 'manual',
+    ];
+
+    $args = wp_parse_args($args, $defaults);
+
+    $api_key = trim((string) get_option(SITEPULSE_OPTION_GEMINI_API_KEY));
+
+    if ($api_key === '') {
+        return new WP_Error(
+            'sitepulse_ai_missing_api_key',
+            esc_html__('Veuillez entrer votre clé API Google Gemini dans les réglages de SitePulse.', 'sitepulse')
+        );
+    }
+
+    $lock_acquired = false;
+    $lock_ttl      = MINUTE_IN_SECONDS * 5;
+
+    if ($lock_ttl <= 0) {
+        $lock_ttl = MINUTE_IN_SECONDS * 5;
+    }
+
+    if (false !== get_transient(SITEPULSE_TRANSIENT_AI_INSIGHT_LOCK)) {
+        return new WP_Error(
+            'sitepulse_ai_generation_locked',
+            esc_html__('Une analyse est déjà en cours. Veuillez patienter quelques instants.', 'sitepulse')
+        );
+    }
+
+    $lock_acquired = set_transient(SITEPULSE_TRANSIENT_AI_INSIGHT_LOCK, 1, $lock_ttl);
+
+    if (!$lock_acquired) {
+        return new WP_Error(
+            'sitepulse_ai_lock_failure',
+            esc_html__('Impossible de démarrer la génération pour le moment. Réessayez dans quelques instants.', 'sitepulse')
+        );
+    }
+
+    try {
+        $endpoint = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent';
+
+        $site_name        = wp_strip_all_tags(get_bloginfo('name'));
+        $site_url         = esc_url_raw(home_url());
+        $site_description = wp_strip_all_tags(get_bloginfo('description'));
+
+        $prompt_sections = [
+            __('Tu es un expert en optimisation de sites WordPress.', 'sitepulse'),
+            sprintf(
+                /* translators: %1$s: Site name, %2$s: Site URL */
+                __('Analyse les performances du site "%1$s" disponible à l\'adresse %2$s.', 'sitepulse'),
+                $site_name,
+                $site_url
+            ),
+            __('Fournis trois recommandations concrètes pour améliorer la vitesse, le référencement et la conversion. Réponds en français.', 'sitepulse'),
+        ];
+
+        if (!empty($site_description)) {
+            $prompt_sections[] = sprintf(
+                /* translators: %s: site description */
+                __('Description du site : %s.', 'sitepulse'),
+                $site_description
+            );
+        }
+
+        $request_body = [
+            'contents' => [
+                [
+                    'parts' => [
+                        [
+                            'text' => implode(' ', array_filter($prompt_sections)),
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $json_body = wp_json_encode($request_body);
+
+        if (false === $json_body) {
+            $error_detail = function_exists('json_last_error_msg') ? json_last_error_msg() : '';
+
+            if ($error_detail === '') {
+                $error_detail = esc_html__('erreur JSON inconnue', 'sitepulse');
+            }
+
+            $sanitized_detail = sanitize_text_field($error_detail);
+
+            return new WP_Error(
+                'sitepulse_ai_json_error',
+                sprintf(
+                    /* translators: %s: error detail */
+                    esc_html__('Impossible de préparer la requête pour Gemini : %s', 'sitepulse'),
+                    $sanitized_detail
+                )
+            );
+        }
+
+        $response_size_limit = (int) apply_filters('sitepulse_ai_response_size_limit', defined('MB_IN_BYTES') ? MB_IN_BYTES : 1_048_576);
+
+        $request_args = [
+            'headers' => [
+                'Content-Type'   => 'application/json',
+                'x-goog-api-key' => $api_key,
+            ],
+            'body'    => $json_body,
+            'timeout' => 30,
+        ];
+
+        if ($response_size_limit > 0) {
+            $request_args['limit_response_size'] = $response_size_limit;
+        }
+
+        $response = wp_remote_post($endpoint, $request_args);
+
+        if (is_wp_error($response)) {
+            if (
+                $response_size_limit > 0
+                && 'http_request_failed' === $response->get_error_code()
+                && false !== stripos($response->get_error_message(), 'limit')
+            ) {
+                $formatted_limit = size_format($response_size_limit, 2);
+                $sanitized_limit = sanitize_text_field($formatted_limit);
+
+                return new WP_Error(
+                    'sitepulse_ai_response_too_large',
+                    sprintf(
+                        /* translators: %s: formatted size limit */
+                        esc_html__('La réponse de Gemini dépasse la taille maximale autorisée (%s). Veuillez réessayer ou augmenter la limite via le filtre sitepulse_ai_response_size_limit.', 'sitepulse'),
+                        $sanitized_limit
+                    )
+                );
+            }
+
+            $sanitized_error_message = sanitize_text_field($response->get_error_message());
+
+            return new WP_Error(
+                'sitepulse_ai_http_error',
+                sprintf(
+                    /* translators: %s: error message */
+                    esc_html__('Erreur lors de la génération de l’analyse IA : %s', 'sitepulse'),
+                    $sanitized_error_message
+                )
+            );
+        }
+
+        $status_code = (int) wp_remote_retrieve_response_code($response);
+        $body        = wp_remote_retrieve_body($response);
+
+        if ($status_code < 200 || $status_code >= 300) {
+            $error_detail = '';
+
+            if (!empty($body)) {
+                $decoded_error = json_decode($body, true);
+
+                if (is_array($decoded_error) && isset($decoded_error['error']['message'])) {
+                    $error_detail = $decoded_error['error']['message'];
+                } else {
+                    $error_detail = $body;
+                }
+            }
+
+            if ($error_detail === '') {
+                $error_detail = sprintf(esc_html__('HTTP %d', 'sitepulse'), $status_code);
+            }
+
+            $sanitized_error_detail = sanitize_text_field($error_detail);
+
+            return new WP_Error(
+                'sitepulse_ai_http_error_status',
+                sprintf(
+                    /* translators: %s: error message */
+                    esc_html__('Erreur lors de la génération de l’analyse IA : %s', 'sitepulse'),
+                    $sanitized_error_detail
+                ),
+                [
+                    'status_code' => $status_code,
+                ]
+            );
+        }
+
+        $decoded_body = json_decode($body, true);
+
+        if (!is_array($decoded_body) || !isset($decoded_body['candidates'][0]['content']['parts']) || !is_array($decoded_body['candidates'][0]['content']['parts'])) {
+            return new WP_Error(
+                'sitepulse_ai_unexpected_response',
+                esc_html__('Structure de réponse inattendue reçue depuis Gemini.', 'sitepulse')
+            );
+        }
+
+        $generated_text = '';
+
+        foreach ($decoded_body['candidates'][0]['content']['parts'] as $part) {
+            if (isset($part['text'])) {
+                $generated_text .= ' ' . $part['text'];
+            }
+        }
+
+        $generated_text = trim($generated_text);
+
+        if ($generated_text === '') {
+            return new WP_Error(
+                'sitepulse_ai_empty_response',
+                esc_html__('La réponse de Gemini ne contient aucun texte exploitable.', 'sitepulse')
+            );
+        }
+
+        $generated_text = sanitize_textarea_field($generated_text);
+        $timestamp      = absint(current_time('timestamp', true));
+
+        $stored_entry = sitepulse_ai_store_insight_entry($generated_text, $timestamp, $args['source']);
+
+        if ($stored_entry === null) {
+            return new WP_Error(
+                'sitepulse_ai_storage_failure',
+                esc_html__('Impossible d’enregistrer la recommandation générée.', 'sitepulse')
+            );
+        }
+
+        return $stored_entry;
+    } finally {
+        delete_transient(SITEPULSE_TRANSIENT_AI_INSIGHT_LOCK);
+    }
+}
 
 /**
  * Retrieves the cached AI insight payload for the current request.
@@ -27,6 +505,8 @@ function sitepulse_ai_get_cached_insight($force_refresh = false) {
     if ($force_refresh) {
         $cached_insight = null;
 
+        sitepulse_ai_get_insight_storage(true);
+
         return [];
     }
 
@@ -35,24 +515,16 @@ function sitepulse_ai_get_cached_insight($force_refresh = false) {
     }
 
     $cached_insight = [];
-    $stored_insight = get_transient(SITEPULSE_TRANSIENT_AI_INSIGHT);
+    $history        = sitepulse_ai_get_history_entries();
 
-    if (is_array($stored_insight) && isset($stored_insight['text'])) {
-        $cached_text = sanitize_textarea_field($stored_insight['text']);
+    if (!empty($history)) {
+        $latest_entry = $history[0];
 
-        if ('' !== $cached_text) {
-            $cached_insight['text'] = $cached_text;
-
-            if (isset($stored_insight['timestamp'])) {
-                $cached_insight['timestamp'] = (int) $stored_insight['timestamp'];
-            }
-        }
-    } elseif (is_string($stored_insight) && '' !== $stored_insight) {
-        $cached_text = sanitize_textarea_field($stored_insight);
-
-        if ('' !== $cached_text) {
-            $cached_insight['text'] = $cached_text;
-        }
+        $cached_insight = [
+            'text'      => $latest_entry['text'],
+            'timestamp' => $latest_entry['timestamp'],
+            'source'    => $latest_entry['source'],
+        ];
     }
 
     return $cached_insight;
@@ -71,9 +543,13 @@ function sitepulse_ai_insights_enqueue_assets($hook_suffix) {
         true
     );
 
-    $stored_insight    = sitepulse_ai_get_cached_insight();
-    $insight_text      = isset($stored_insight['text']) ? $stored_insight['text'] : '';
-    $insight_timestamp = isset($stored_insight['timestamp']) ? absint($stored_insight['timestamp']) : null;
+    $stored_insight     = sitepulse_ai_get_cached_insight();
+    $insight_text       = isset($stored_insight['text']) ? $stored_insight['text'] : '';
+    $insight_timestamp  = isset($stored_insight['timestamp']) ? absint($stored_insight['timestamp']) : null;
+    $insight_source     = isset($stored_insight['source']) ? $stored_insight['source'] : 'manual';
+    $history_entries    = sitepulse_ai_prepare_history_payload();
+    $last_auto_refresh  = sitepulse_ai_get_last_auto_refresh_timestamp();
+    $history_limit      = sitepulse_ai_get_history_limit();
 
     wp_localize_script(
         'sitepulse-ai-insights',
@@ -83,12 +559,21 @@ function sitepulse_ai_insights_enqueue_assets($hook_suffix) {
             'nonce'             => wp_create_nonce(SITEPULSE_NONCE_ACTION_AI_INSIGHT),
             'initialInsight'    => $insight_text,
             'initialTimestamp'  => null !== $insight_timestamp ? absint($insight_timestamp) : null,
+            'initialSource'     => $insight_source,
+            'initialHistory'    => $history_entries,
+            'lastAutoRefresh'   => null !== $last_auto_refresh ? absint($last_auto_refresh) : null,
+            'historyLimit'      => $history_limit,
             'strings'           => [
                 'defaultError'    => esc_html__('Une erreur inattendue est survenue. Veuillez réessayer.', 'sitepulse'),
                 'cachedPrefix'    => esc_html__('Dernière mise à jour :', 'sitepulse'),
                 'statusCached'    => esc_html__('Résultat issu du cache.', 'sitepulse'),
                 'statusFresh'     => esc_html__('Nouvelle analyse générée.', 'sitepulse'),
                 'statusGenerating' => esc_html__('Génération en cours…', 'sitepulse'),
+                'historyLabel'    => esc_html__('Historique des analyses', 'sitepulse'),
+                'historyEmpty'    => esc_html__('Aucune analyse enregistrée pour le moment.', 'sitepulse'),
+                'historyManual'   => esc_html__('Génération manuelle', 'sitepulse'),
+                'historyAuto'     => esc_html__('Génération automatique', 'sitepulse'),
+                'lastAutoRefresh' => esc_html__('Dernier rafraîchissement automatique :', 'sitepulse'),
             ],
             'initialCached'     => '' !== $insight_text,
         ]
@@ -118,6 +603,14 @@ function sitepulse_ai_insights_page() {
                 </label>
                 <span class="spinner" id="sitepulse-ai-spinner" style="float: none; margin-top: 0;"></span>
             </div>
+            <div class="sitepulse-ai-insight-meta" style="margin-top: 15px;">
+                <label for="sitepulse-ai-history" class="sitepulse-ai-history-label" style="display: block; margin-bottom: 5px;">
+                    <?php esc_html_e('Historique des analyses', 'sitepulse'); ?>
+                </label>
+                <select id="sitepulse-ai-history" class="sitepulse-ai-history-select" style="min-width: 260px;">
+                </select>
+                <p id="sitepulse-ai-last-auto" class="description" style="display: none; margin-top: 10px;"></p>
+            </div>
         <?php endif; ?>
         <div id="sitepulse-ai-insight-error" class="notice notice-error" style="display: none;"><p></p></div>
         <div id="sitepulse-ai-insight-result" style="display: none; background: #fff; border: 1px solid #ccc; padding: 15px; margin-top: 20px;">
@@ -131,23 +624,10 @@ function sitepulse_ai_insights_page() {
 }
 
 function sitepulse_generate_ai_insight() {
-    $log_ai_error = static function ($message, $status_code = null) {
-        if (!function_exists('sitepulse_log')) {
-            return;
-        }
-
-        $message = (string) $message;
-        $log_message = null !== $status_code
-            ? sprintf('AI Insights (%d): %s', (int) $status_code, $message)
-            : sprintf('AI Insights: %s', $message);
-
-        sitepulse_log($log_message, 'ERROR');
-    };
-
     if (!current_user_can('manage_options')) {
         $error_message = esc_html__("Vous n'avez pas les permissions nécessaires pour effectuer cette action.", 'sitepulse');
 
-        $log_ai_error($error_message, 403);
+        sitepulse_ai_log_error($error_message, 403);
 
         wp_send_json_error([
             'message' => $error_message,
@@ -159,7 +639,7 @@ function sitepulse_generate_ai_insight() {
     if (!wp_verify_nonce($nonce, SITEPULSE_NONCE_ACTION_AI_INSIGHT)) {
         $error_message = esc_html__('Échec de la vérification de sécurité. Veuillez recharger la page et réessayer.', 'sitepulse');
 
-        $log_ai_error($error_message, 400);
+        sitepulse_ai_log_error($error_message, 400);
 
         wp_send_json_error([
             'message' => $error_message,
@@ -172,234 +652,53 @@ function sitepulse_generate_ai_insight() {
         $force_refresh = filter_var(wp_unslash($_POST['force_refresh']), FILTER_VALIDATE_BOOLEAN);
     }
 
-    $cached_payload = $force_refresh
-        ? sitepulse_ai_get_cached_insight(true)
-        : sitepulse_ai_get_cached_insight();
-
-    if (!$force_refresh && !empty($cached_payload)) {
-        $cached_payload['cached'] = true;
-        wp_send_json_success($cached_payload);
+    if ($force_refresh) {
+        sitepulse_ai_get_cached_insight(true);
     }
 
-    $api_key = trim((string) get_option(SITEPULSE_OPTION_GEMINI_API_KEY));
+    if (!$force_refresh) {
+        $cached_entry = sitepulse_ai_get_cached_insight();
 
-    if ('' === $api_key) {
-        $error_message = esc_html__('Veuillez entrer votre clé API Google Gemini dans les réglages de SitePulse.', 'sitepulse');
+        if (!empty($cached_entry)) {
+            $payload = sitepulse_ai_prepare_response_payload($cached_entry, true);
 
-        $log_ai_error($error_message, 400);
-
-        wp_send_json_error([
-            'message' => $error_message,
-        ], 400);
-    }
-
-    $endpoint = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent';
-
-    $site_name        = wp_strip_all_tags(get_bloginfo('name'));
-    $site_url         = esc_url_raw(home_url());
-    $site_description = wp_strip_all_tags(get_bloginfo('description'));
-
-    $prompt_sections = [
-        __('Tu es un expert en optimisation de sites WordPress.', 'sitepulse'),
-        sprintf(
-            /* translators: %1$s: Site name, %2$s: Site URL */
-            __('Analyse les performances du site "%1$s" disponible à l\'adresse %2$s.', 'sitepulse'),
-            $site_name,
-            $site_url
-        ),
-        __('Fournis trois recommandations concrètes pour améliorer la vitesse, le référencement et la conversion. Réponds en français.', 'sitepulse'),
-    ];
-
-    if (!empty($site_description)) {
-        $prompt_sections[] = sprintf(
-            /* translators: %s: site description */
-            __('Description du site : %s.', 'sitepulse'),
-            $site_description
-        );
-    }
-
-    $request_body = [
-        'contents' => [
-            [
-                'parts' => [
-                    [
-                        'text' => implode(' ', array_filter($prompt_sections)),
-                    ],
-                ],
-            ],
-        ],
-    ];
-
-    $json_body = wp_json_encode($request_body);
-
-    if (false === $json_body) {
-        $error_detail = function_exists('json_last_error_msg') ? json_last_error_msg() : '';
-
-        if ('' === $error_detail) {
-            $error_detail = esc_html__('erreur JSON inconnue', 'sitepulse');
-        }
-
-        $sanitized_detail = sanitize_text_field($error_detail);
-        $error_message    = sprintf(
-            /* translators: %s: error detail */
-            esc_html__('Impossible de préparer la requête pour Gemini : %s', 'sitepulse'),
-            $sanitized_detail
-        );
-
-        $log_ai_error($error_message, 500);
-
-        wp_send_json_error([
-            'message' => $error_message,
-        ], 500);
-    }
-
-    $response_size_limit = (int) apply_filters('sitepulse_ai_response_size_limit', defined('MB_IN_BYTES') ? MB_IN_BYTES : 1_048_576);
-
-    $request_args = [
-        'headers' => [
-            'Content-Type'   => 'application/json',
-            'x-goog-api-key' => $api_key,
-        ],
-        'body'    => $json_body,
-        'timeout' => 30,
-    ];
-
-    if ($response_size_limit > 0) {
-        $request_args['limit_response_size'] = $response_size_limit;
-    }
-
-    $response = wp_remote_post(
-        $endpoint,
-        $request_args
-    );
-
-    if (is_wp_error($response)) {
-        if (
-            $response_size_limit > 0
-            && 'http_request_failed' === $response->get_error_code()
-            && false !== stripos($response->get_error_message(), 'limit')
-        ) {
-            $formatted_limit = size_format($response_size_limit, 2);
-            $sanitized_limit = sanitize_text_field($formatted_limit);
-            $error_message   = sprintf(
-                /* translators: %s: formatted size limit */
-                esc_html__('La réponse de Gemini dépasse la taille maximale autorisée (%s). Veuillez réessayer ou augmenter la limite via le filtre sitepulse_ai_response_size_limit.', 'sitepulse'),
-                $sanitized_limit
-            );
-
-            $log_ai_error($error_message, 500);
-
-            wp_send_json_error([
-                'message' => $error_message,
-            ], 500);
-        }
-
-        $sanitized_error_message = sanitize_text_field($response->get_error_message());
-        $error_message           = sprintf(
-            /* translators: %s: error message */
-            esc_html__('Erreur lors de la génération de l’analyse IA : %s', 'sitepulse'),
-            $sanitized_error_message
-        );
-
-        $log_ai_error($error_message, 500);
-
-        wp_send_json_error([
-            'message' => $error_message,
-        ], 500);
-    }
-
-    $status_code = (int) wp_remote_retrieve_response_code($response);
-    $body        = wp_remote_retrieve_body($response);
-
-    if ($status_code < 200 || $status_code >= 300) {
-        $error_detail = '';
-
-        if (!empty($body)) {
-            $decoded_error = json_decode($body, true);
-
-            if (is_array($decoded_error) && isset($decoded_error['error']['message'])) {
-                $error_detail = $decoded_error['error']['message'];
-            } else {
-                $error_detail = $body;
-            }
-        }
-
-        if ('' === $error_detail) {
-            $error_detail = sprintf(esc_html__('HTTP %d', 'sitepulse'), $status_code);
-        }
-
-        $sanitized_error_detail = sanitize_text_field($error_detail);
-        $error_message          = sprintf(
-            /* translators: %s: error message */
-            esc_html__('Erreur lors de la génération de l’analyse IA : %s', 'sitepulse'),
-            $sanitized_error_detail
-        );
-
-        $log_ai_error($error_message, $status_code);
-
-        wp_send_json_error([
-            'message' => $error_message,
-        ], 500);
-    }
-
-    $decoded_body = json_decode($body, true);
-
-    if (!is_array($decoded_body) || !isset($decoded_body['candidates'][0]['content']['parts']) || !is_array($decoded_body['candidates'][0]['content']['parts'])) {
-        $error_message = esc_html__('Structure de réponse inattendue reçue depuis Gemini.', 'sitepulse');
-
-        $log_ai_error($error_message, 500);
-
-        wp_send_json_error([
-            'message' => $error_message,
-        ], 500);
-    }
-
-    $generated_text = '';
-
-    foreach ($decoded_body['candidates'][0]['content']['parts'] as $part) {
-        if (isset($part['text'])) {
-            $generated_text .= ' ' . $part['text'];
+            wp_send_json_success($payload);
         }
     }
 
-    $generated_text = trim($generated_text);
-
-    if ('' === $generated_text) {
-        $error_message = esc_html__('La réponse de Gemini ne contient aucun texte exploitable.', 'sitepulse');
-
-        $log_ai_error($error_message, 500);
-
-        wp_send_json_error([
-            'message' => $error_message,
-        ], 500);
-    }
-
-    $generated_text = sanitize_textarea_field($generated_text);
-    $timestamp      = absint(current_time('timestamp', true));
-
-    set_transient(
-        SITEPULSE_TRANSIENT_AI_INSIGHT,
-        [
-            'text'      => $generated_text,
-            'timestamp' => $timestamp,
-        ],
-        HOUR_IN_SECONDS
-    );
-
-    sitepulse_ai_get_cached_insight(true);
-
-    $fresh_payload = sitepulse_ai_get_cached_insight();
-
-    if (empty($fresh_payload)) {
-        $fresh_payload = [
-            'text'      => $generated_text,
-            'timestamp' => $timestamp,
-        ];
-    }
-
-    wp_send_json_success([
-        'text'      => isset($fresh_payload['text']) ? $fresh_payload['text'] : $generated_text,
-        'timestamp' => isset($fresh_payload['timestamp']) ? $fresh_payload['timestamp'] : $timestamp,
-        'cached'    => false,
+    $result = sitepulse_ai_generate_insight_payload([
+        'source' => 'manual',
     ]);
+
+    if (is_wp_error($result)) {
+        $status_code = 500;
+        $error_code  = $result->get_error_code();
+        $error_data  = $result->get_error_data();
+
+        if (is_array($error_data) && isset($error_data['status_code'])) {
+            $status_code = (int) $error_data['status_code'];
+        } elseif ('sitepulse_ai_missing_api_key' === $error_code) {
+            $status_code = 400;
+        } elseif ('sitepulse_ai_generation_locked' === $error_code) {
+            $status_code = 409;
+        } elseif ('sitepulse_ai_lock_failure' === $error_code) {
+            $status_code = 503;
+        }
+
+        if ($status_code < 100) {
+            $status_code = 500;
+        }
+
+        $message = $result->get_error_message();
+
+        sitepulse_ai_log_error($message, $status_code);
+
+        wp_send_json_error([
+            'message' => $message,
+        ], $status_code);
+    }
+
+    $payload = sitepulse_ai_prepare_response_payload($result, false);
+
+    wp_send_json_success($payload);
 }

--- a/sitepulse_FR/modules/js/sitepulse-ai-insights.js
+++ b/sitepulse_FR/modules/js/sitepulse-ai-insights.js
@@ -78,6 +78,144 @@
         $errorContainer.show();
     }
 
+    function getHistoryLimit() {
+        var limit = parseInt(sitepulseAIInsights.historyLimit, 10);
+
+        if (!isFinite(limit) || limit <= 0) {
+            limit = 7;
+        }
+
+        return limit;
+    }
+
+    function sanitizeHistoryEntry(entry) {
+        if (!entry || typeof entry.text !== 'string') {
+            return null;
+        }
+
+        var text = entry.text.trim();
+
+        if (text === '') {
+            return null;
+        }
+
+        var timestamp = null;
+
+        if (typeof entry.timestamp !== 'undefined' && entry.timestamp !== null) {
+            var parsed = parseInt(entry.timestamp, 10);
+
+            if (isFinite(parsed) && parsed > 0) {
+                timestamp = parsed;
+            }
+        }
+
+        var source = typeof entry.source === 'string' ? entry.source : 'manual';
+
+        if (source !== 'cron') {
+            source = 'manual';
+        }
+
+        var cached = typeof entry.cached !== 'undefined' ? !!entry.cached : true;
+
+        return {
+            text: text,
+            timestamp: timestamp,
+            source: source,
+            cached: cached
+        };
+    }
+
+    function normalizeHistory(entries) {
+        var normalized = [];
+        var limit = getHistoryLimit();
+
+        if (!Array.isArray(entries)) {
+            return normalized;
+        }
+
+        for (var i = 0; i < entries.length; i++) {
+            var sanitized = sanitizeHistoryEntry(entries[i]);
+
+            if (sanitized) {
+                normalized.push(sanitized);
+            }
+
+            if (normalized.length >= limit) {
+                break;
+            }
+        }
+
+        return normalized;
+    }
+
+    function getSourceLabel(source) {
+        return source === 'cron'
+            ? sitepulseAIInsights.strings.historyAuto
+            : sitepulseAIInsights.strings.historyManual;
+    }
+
+    function buildHistoryOptionLabel(entry) {
+        var formattedTimestamp = formatTimestamp(entry.timestamp);
+        var parts = [];
+
+        if (formattedTimestamp) {
+            parts.push(formattedTimestamp);
+        }
+
+        parts.push(getSourceLabel(entry.source));
+
+        return parts.join(' – ');
+    }
+
+    function populateHistorySelect($select, $label, history) {
+        $label.text(sitepulseAIInsights.strings.historyLabel);
+        $select.empty();
+
+        if (!history.length) {
+            $select.append($('<option></option>').text(sitepulseAIInsights.strings.historyEmpty));
+            $select.prop('disabled', true);
+            return;
+        }
+
+        $select.prop('disabled', false);
+
+        for (var i = 0; i < history.length; i++) {
+            var option = $('<option></option>')
+                .val(String(i))
+                .text(buildHistoryOptionLabel(history[i]));
+
+            if (i === 0) {
+                option.prop('selected', true);
+            }
+
+            $select.append(option);
+        }
+    }
+
+    function updateLastAutoRefresh($element, timestamp) {
+        var formatted = formatTimestamp(timestamp);
+
+        if (formatted) {
+            $element.text(sitepulseAIInsights.strings.lastAutoRefresh + ' ' + formatted).show();
+        } else {
+            $element.hide().text('');
+        }
+    }
+
+    function findHistoryIndex(history, entry) {
+        if (!entry) {
+            return -1;
+        }
+
+        for (var i = 0; i < history.length; i++) {
+            if (history[i].text === entry.text && history[i].timestamp === entry.timestamp) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
     $(function () {
         if (typeof sitepulseAIInsights === 'undefined') {
             return;
@@ -92,15 +230,59 @@
         var $resultText = $resultContainer.find('.sitepulse-ai-insight-text');
         var $timestampEl = $resultContainer.find('.sitepulse-ai-insight-timestamp');
         var $forceRefreshToggle = $('#sitepulse-ai-force-refresh');
+        var $historySelect = $('#sitepulse-ai-history');
+        var $historyLabel = $('.sitepulse-ai-history-label');
+        var $lastAuto = $('#sitepulse-ai-last-auto');
+        var history = normalizeHistory(sitepulseAIInsights.initialHistory);
+        var limit = getHistoryLimit();
         var lastResultData = null;
+
+        if (!history.length && typeof sitepulseAIInsights.initialInsight === 'string') {
+            var seeded = sanitizeHistoryEntry({
+                text: sitepulseAIInsights.initialInsight,
+                timestamp: sitepulseAIInsights.initialTimestamp,
+                source: sitepulseAIInsights.initialSource,
+                cached: !!sitepulseAIInsights.initialCached
+            });
+
+            if (seeded) {
+                history.push(seeded);
+            }
+        }
+
+        if (history.length > limit) {
+            history = history.slice(0, limit);
+        }
+
+        populateHistorySelect($historySelect, $historyLabel, history);
+        updateLastAutoRefresh($lastAuto, sitepulseAIInsights.lastAutoRefresh);
 
         $errorContainer.hide();
         $spinner.removeClass('is-active');
 
-        lastResultData = renderResult($resultContainer, $resultText, $timestampEl, $statusEl, {
+        var initialEntry = history.length ? history[0] : sanitizeHistoryEntry({
             text: sitepulseAIInsights.initialInsight,
             timestamp: sitepulseAIInsights.initialTimestamp,
             cached: !!sitepulseAIInsights.initialCached
+        });
+
+        lastResultData = renderResult($resultContainer, $resultText, $timestampEl, $statusEl, initialEntry || {});
+
+        $historySelect.on('change', function () {
+            var value = parseInt($(this).val(), 10);
+
+            if (!isFinite(value) || value < 0 || value >= history.length) {
+                return;
+            }
+
+            var selectedEntry = history[value];
+            var isCached = value === 0 ? !!selectedEntry.cached : true;
+
+            lastResultData = renderResult($resultContainer, $resultText, $timestampEl, $statusEl, {
+                text: selectedEntry.text,
+                timestamp: selectedEntry.timestamp,
+                cached: isCached
+            });
         });
 
         $button.on('click', function (event) {
@@ -117,6 +299,7 @@
             $resultContainer.show();
             setStatus($statusEl, sitepulseAIInsights.strings.statusGenerating);
 
+            var previousSelection = $historySelect.val();
             var requestData = {
                 action: 'sitepulse_generate_ai_insight',
                 nonce: sitepulseAIInsights.nonce
@@ -130,9 +313,62 @@
 
             $.post(sitepulseAIInsights.ajaxUrl, requestData).done(function (response) {
                 if (response && response.success && response.data) {
-                    lastResultData = renderResult($resultContainer, $resultText, $timestampEl, $statusEl, response.data);
+                    var responseHistory = normalizeHistory(response.data.history);
+                    var responseEntry = sanitizeHistoryEntry({
+                        text: response.data.text,
+                        timestamp: response.data.timestamp,
+                        source: response.data.source,
+                        cached: response.data.cached
+                    });
+
+                    if (!responseHistory.length && responseEntry) {
+                        responseHistory.push(responseEntry);
+                    } else if (responseHistory.length && responseEntry) {
+                        responseHistory[0].text = responseEntry.text;
+                        responseHistory[0].timestamp = responseEntry.timestamp;
+                        responseHistory[0].source = responseEntry.source;
+                        responseHistory[0].cached = !!response.data.cached;
+                    }
+
+                    history = responseHistory;
+                    populateHistorySelect($historySelect, $historyLabel, history);
+
+                    var selectedIndex = findHistoryIndex(history, responseEntry);
+
+                    if (selectedIndex < 0) {
+                        if (typeof previousSelection === 'string' && history.length) {
+                            var previousIndex = parseInt(previousSelection, 10);
+
+                            if (isFinite(previousIndex) && previousIndex >= 0 && previousIndex < history.length) {
+                                selectedIndex = previousIndex;
+                            } else {
+                                selectedIndex = 0;
+                            }
+                        } else {
+                            selectedIndex = history.length ? 0 : -1;
+                        }
+                    }
+
+                    if (selectedIndex >= 0) {
+                        $historySelect.val(String(selectedIndex));
+                    }
+
+                    updateLastAutoRefresh($lastAuto, response.data.lastAutoRefresh);
+
+                    var displayEntry = selectedIndex >= 0 ? history[selectedIndex] : responseEntry;
+
+                    lastResultData = renderResult($resultContainer, $resultText, $timestampEl, $statusEl, {
+                        text: displayEntry ? displayEntry.text : '',
+                        timestamp: displayEntry ? displayEntry.timestamp : null,
+                        cached: displayEntry ? !!displayEntry.cached : !!response.data.cached
+                    });
+
+                    if (history.length && selectedIndex >= 0) {
+                        history[selectedIndex].cached = lastResultData.cached;
+                    }
                 } else if (response && response.data && response.data.message) {
                     showError($errorContainer, $errorText, response.data.message);
+
                     if (lastResultData && lastResultData.text) {
                         setStatus(
                             $statusEl,
@@ -144,6 +380,7 @@
                     }
                 } else {
                     showError($errorContainer, $errorText);
+
                     if (lastResultData && lastResultData.text) {
                         setStatus(
                             $statusEl,
@@ -162,6 +399,7 @@
                 }
 
                 showError($errorContainer, $errorText, message);
+
                 if (lastResultData && lastResultData.text) {
                     setStatus(
                         $statusEl,

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -33,15 +33,19 @@ define('SITEPULSE_OPTION_PLUGIN_BASENAME', 'sitepulse_plugin_basename');
 define('SITEPULSE_OPTION_ERROR_ALERT_LOG_POINTER', 'sitepulse_error_alert_log_pointer');
 define('SITEPULSE_OPTION_CRON_WARNINGS', 'sitepulse_cron_warnings');
 define('SITEPULSE_OPTION_DEBUG_NOTICES', 'sitepulse_debug_notices');
+define('SITEPULSE_OPTION_AI_INSIGHT_HISTORY', 'sitepulse_ai_insights');
 
 define('SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS', 'sitepulse_speed_scan_results');
 define('SITEPULSE_TRANSIENT_AI_INSIGHT', 'sitepulse_ai_insight');
+define('SITEPULSE_TRANSIENT_AI_INSIGHT_LOCK', 'sitepulse_ai_insight_lock');
 define('SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX', 'sitepulse_error_alert_');
 define('SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_SUFFIX', '_lock');
 define('SITEPULSE_TRANSIENT_ERROR_ALERT_CPU_LOCK', SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX . 'cpu' . SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_SUFFIX);
 define('SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK', SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX . 'php_fatal' . SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_SUFFIX);
 define('SITEPULSE_TRANSIENT_PLUGIN_DIR_SIZE_PREFIX', 'sitepulse_plugin_dir_size_');
 define('SITEPULSE_TRANSIENT_RESOURCE_MONITOR_SNAPSHOT', 'sitepulse_resource_monitor_snapshot');
+
+define('SITEPULSE_AI_INSIGHT_HISTORY_LIMIT', 7);
 
 define('SITEPULSE_NONCE_ACTION_AI_INSIGHT', 'sitepulse_get_ai_insight');
 define('SITEPULSE_NONCE_ACTION_CLEANUP', 'sitepulse_cleanup');

--- a/sitepulse_FR/uninstall.php
+++ b/sitepulse_FR/uninstall.php
@@ -24,6 +24,7 @@ $sitepulse_constants = [
     'SITEPULSE_OPTION_DEBUG_NOTICES'              => 'sitepulse_debug_notices',
     'SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS'      => 'sitepulse_speed_scan_results',
     'SITEPULSE_TRANSIENT_AI_INSIGHT'              => 'sitepulse_ai_insight',
+    'SITEPULSE_TRANSIENT_AI_INSIGHT_LOCK'         => 'sitepulse_ai_insight_lock',
     'SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX' => 'sitepulse_error_alert_',
     'SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_SUFFIX' => '_lock',
     'SITEPULSE_TRANSIENT_PLUGIN_DIR_SIZE_PREFIX'  => 'sitepulse_plugin_dir_size_',
@@ -32,6 +33,7 @@ $sitepulse_constants = [
     'SITEPULSE_TRANSIENT_RESOURCE_MONITOR_SNAPSHOT' => 'sitepulse_resource_monitor_snapshot',
     'SITEPULSE_PLUGIN_IMPACT_OPTION'              => 'sitepulse_plugin_impact_stats',
     'SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE'    => 'sitepulse_impact_loader_signature',
+    'SITEPULSE_OPTION_AI_INSIGHT_HISTORY'         => 'sitepulse_ai_insights',
 ];
 
 foreach ($sitepulse_constants as $constant => $value) {
@@ -53,6 +55,7 @@ $options = [
     SITEPULSE_OPTION_DEBUG_MODE,
     SITEPULSE_OPTION_GEMINI_API_KEY,
     SITEPULSE_OPTION_UPTIME_LOG,
+    SITEPULSE_OPTION_AI_INSIGHT_HISTORY,
     SITEPULSE_OPTION_LAST_LOAD_TIME,
     SITEPULSE_OPTION_CPU_ALERT_THRESHOLD,
     SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES,
@@ -68,6 +71,7 @@ $options = [
 $transients = [
     SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS,
     SITEPULSE_TRANSIENT_AI_INSIGHT,
+    SITEPULSE_TRANSIENT_AI_INSIGHT_LOCK,
     SITEPULSE_TRANSIENT_ERROR_ALERT_CPU_LOCK,
     SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK,
     SITEPULSE_TRANSIENT_RESOURCE_MONITOR_SNAPSHOT,

--- a/tests/phpunit/includes/stubs.php
+++ b/tests/phpunit/includes/stubs.php
@@ -19,6 +19,10 @@ if (!defined('SITEPULSE_OPTION_DEBUG_NOTICES')) {
     define('SITEPULSE_OPTION_DEBUG_NOTICES', 'sitepulse_debug_notices');
 }
 
+if (!defined('SITEPULSE_OPTION_AI_INSIGHT_HISTORY')) {
+    define('SITEPULSE_OPTION_AI_INSIGHT_HISTORY', 'sitepulse_ai_insights');
+}
+
 if (!defined('SITEPULSE_OPTION_GEMINI_API_KEY')) {
     define('SITEPULSE_OPTION_GEMINI_API_KEY', 'sitepulse_gemini_api_key');
 }
@@ -59,6 +63,14 @@ if (!defined('SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK')) {
 
 if (!defined('SITEPULSE_TRANSIENT_AI_INSIGHT')) {
     define('SITEPULSE_TRANSIENT_AI_INSIGHT', 'sitepulse_ai_insight');
+}
+
+if (!defined('SITEPULSE_TRANSIENT_AI_INSIGHT_LOCK')) {
+    define('SITEPULSE_TRANSIENT_AI_INSIGHT_LOCK', 'sitepulse_ai_insight_lock');
+}
+
+if (!defined('SITEPULSE_AI_INSIGHT_HISTORY_LIMIT')) {
+    define('SITEPULSE_AI_INSIGHT_HISTORY_LIMIT', 7);
 }
 
 if (!defined('SITEPULSE_NONCE_ACTION_AI_INSIGHT')) {

--- a/tests/phpunit/test-admin-settings-cleanup.php
+++ b/tests/phpunit/test-admin-settings-cleanup.php
@@ -143,6 +143,7 @@ class Sitepulse_Admin_Settings_Cleanup_Test extends WP_UnitTestCase {
             SITEPULSE_OPTION_ALERT_INTERVAL         => 10,
             SITEPULSE_OPTION_ALERT_RECIPIENTS       => ['test@example.com'],
             SITEPULSE_PLUGIN_IMPACT_OPTION          => ['payload'],
+            SITEPULSE_OPTION_AI_INSIGHT_HISTORY     => ['entries' => []],
         ];
 
         foreach ($options_to_seed as $option => $value) {
@@ -152,6 +153,7 @@ class Sitepulse_Admin_Settings_Cleanup_Test extends WP_UnitTestCase {
         set_transient(SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS, 'cached');
         set_site_transient(SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS, 'cached');
         set_transient(SITEPULSE_TRANSIENT_AI_INSIGHT, 'ai');
+        set_transient(SITEPULSE_TRANSIENT_AI_INSIGHT_LOCK, 'lock');
         set_transient(SITEPULSE_TRANSIENT_ERROR_ALERT_CPU_LOCK, 'lock');
         set_transient(SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK, 'lock');
 
@@ -177,6 +179,7 @@ class Sitepulse_Admin_Settings_Cleanup_Test extends WP_UnitTestCase {
         $this->assertFalse(get_transient(SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS));
         $this->assertFalse(get_site_transient(SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS));
         $this->assertFalse(get_transient(SITEPULSE_TRANSIENT_AI_INSIGHT));
+        $this->assertFalse(get_transient(SITEPULSE_TRANSIENT_AI_INSIGHT_LOCK));
         $this->assertFalse(get_transient(SITEPULSE_TRANSIENT_ERROR_ALERT_CPU_LOCK));
         $this->assertFalse(get_transient(SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK));
         $this->assertFalse(get_transient($prefixed_transient));


### PR DESCRIPTION
## Summary
- register the AI insights cron hook and schedule a daily event only when an API key exists
- refactor AI insight generation into a reusable helper with locking and option-based history storage
- refresh the admin UI/JS to display the latest automatic refresh, expose history selection, and update related tests

## Testing
- php -l sitepulse_FR/modules/ai_insights.php
- php -l sitepulse_FR/includes/admin-settings.php
- php -l sitepulse_FR/sitepulse.php
- php -l sitepulse_FR/uninstall.php
- ./vendor/bin/phpunit *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc070c084c832eb94456c95b26d9e5