### PR TITLE
Gate dashboard cards by active modules

### DIFF
--- a/sitepulse_FR/modules/custom_dashboards.php
+++ b/sitepulse_FR/modules/custom_dashboards.php
@@ -131,9 +131,8 @@ function sitepulse_custom_dashboards_page() {
         wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
     }
 
-    global $wpdb;
-
     $active_modules = array_map('strval', (array) get_option(SITEPULSE_OPTION_ACTIVE_MODULES, []));
+    global $wpdb;
     $is_speed_enabled = in_array('speed_analyzer', $active_modules, true);
     $is_uptime_enabled = in_array('uptime_tracker', $active_modules, true);
     $is_database_enabled = in_array('database_optimizer', $active_modules, true);
@@ -465,6 +464,19 @@ function sitepulse_custom_dashboards_page() {
         ];
     }
 
+    $module_chart_keys = [
+        'speed_analyzer'     => 'speed',
+        'uptime_tracker'     => 'uptime',
+        'database_optimizer' => 'database',
+        'log_analyzer'       => 'logs',
+    ];
+
+    foreach ($module_chart_keys as $module_key => $chart_key) {
+        if (!in_array($module_key, $active_modules, true)) {
+            unset($charts_payload[$chart_key]);
+        }
+    }
+
     $charts_for_localization = empty($charts_payload) ? new stdClass() : $charts_payload;
 
     $localization_payload = [
@@ -514,7 +526,7 @@ function sitepulse_custom_dashboards_page() {
         <p><?php esc_html_e("A real-time overview of your site's performance and health.", 'sitepulse'); ?></p>
 
         <div class="sitepulse-grid">
-            <?php if ($speed_card !== null): ?>
+            <?php if ($is_speed_enabled && $speed_card !== null): ?>
                 <div class="sitepulse-card">
                     <div class="sitepulse-card-header">
                         <h2><span class="dashicons dashicons-performance"></span> <?php esc_html_e('Speed', 'sitepulse'); ?></h2>
@@ -529,7 +541,7 @@ function sitepulse_custom_dashboards_page() {
                 </div>
             <?php endif; ?>
 
-            <?php if ($uptime_card !== null): ?>
+            <?php if ($is_uptime_enabled && $uptime_card !== null): ?>
                 <div class="sitepulse-card">
                     <div class="sitepulse-card-header">
                         <h2><span class="dashicons dashicons-chart-bar"></span> <?php esc_html_e('Uptime', 'sitepulse'); ?></h2>
@@ -544,7 +556,7 @@ function sitepulse_custom_dashboards_page() {
                 </div>
             <?php endif; ?>
 
-            <?php if ($database_card !== null): ?>
+            <?php if ($is_database_enabled && $database_card !== null): ?>
                 <div class="sitepulse-card">
                     <div class="sitepulse-card-header">
                         <h2><span class="dashicons dashicons-database"></span> <?php esc_html_e('Database Health', 'sitepulse'); ?></h2>
@@ -562,7 +574,7 @@ function sitepulse_custom_dashboards_page() {
                 </div>
             <?php endif; ?>
 
-            <?php if ($logs_card !== null): ?>
+            <?php if ($is_logs_enabled && $logs_card !== null): ?>
                 <div class="sitepulse-card">
                     <div class="sitepulse-card-header">
                         <h2><span class="dashicons dashicons-hammer"></span> <?php esc_html_e('Error Log', 'sitepulse'); ?></h2>

--- a/tests/phpunit/includes/stubs.php
+++ b/tests/phpunit/includes/stubs.php
@@ -123,3 +123,27 @@ if (!function_exists('sitepulse_get_wp_debug_log_path')) {
         return $path;
     }
 }
+
+if (!function_exists('sitepulse_get_recent_log_lines')) {
+    function sitepulse_get_recent_log_lines($file_path, $max_lines = 100, $max_bytes = 131072) {
+        if (!is_string($file_path) || $file_path === '') {
+            return null;
+        }
+
+        if (!file_exists($file_path) || !is_readable($file_path)) {
+            return null;
+        }
+
+        $contents = file($file_path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
+        if ($contents === false) {
+            return null;
+        }
+
+        if ($max_lines > 0 && count($contents) > $max_lines) {
+            $contents = array_slice($contents, -$max_lines);
+        }
+
+        return array_values($contents);
+    }
+}

--- a/tests/phpunit/test-custom-dashboard-render.php
+++ b/tests/phpunit/test-custom-dashboard-render.php
@@ -22,6 +22,11 @@ if (!function_exists('sitepulse_get_capability')) {
 require_once dirname(__DIR__, 2) . '/sitepulse_FR/modules/custom_dashboards.php';
 
 class Sitepulse_Custom_Dashboard_Render_Test extends WP_UnitTestCase {
+    /**
+     * @var string|null
+     */
+    private $logFile;
+
     protected function setUp(): void {
         parent::setUp();
 
@@ -33,9 +38,110 @@ class Sitepulse_Custom_Dashboard_Render_Test extends WP_UnitTestCase {
         $scripts = wp_scripts();
         $scripts->remove('sitepulse-chartjs');
         $scripts->remove('sitepulse-dashboard-charts');
+
+        $this->logFile = tempnam(sys_get_temp_dir(), 'sitepulse-log');
+        $GLOBALS['sitepulse_test_log_path'] = $this->logFile;
+    }
+
+    protected function tearDown(): void {
+        unset($GLOBALS['sitepulse_test_log_path']);
+
+        if (is_string($this->logFile) && $this->logFile !== '' && file_exists($this->logFile)) {
+            unlink($this->logFile);
+        }
+
+        $this->logFile = null;
+
+        parent::tearDown();
+    }
+
+    private function seedModuleData(): void {
+        set_transient(
+            SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS,
+            [
+                'server_processing_ms' => 150,
+            ]
+        );
+
+        update_option(
+            SITEPULSE_OPTION_UPTIME_LOG,
+            [
+                [
+                    'timestamp' => time(),
+                    'status'    => true,
+                ],
+                [
+                    'timestamp' => time() - HOUR_IN_SECONDS,
+                    'status'    => false,
+                ],
+            ]
+        );
+
+        if (is_string($this->logFile)) {
+            file_put_contents(
+                $this->logFile,
+                "[2024-01-01 00:00:00] PHP Warning: Something happened\n" .
+                "[2024-01-01 00:05:00] PHP Deprecated: Old function used\n"
+            );
+        }
+
+        $post_id = $this->factory->post->create([
+            'post_title'   => 'Seeded Post',
+            'post_content' => 'Initial content',
+            'post_status'  => 'publish',
+        ]);
+
+        if ($post_id && !is_wp_error($post_id)) {
+            wp_update_post([
+                'ID'           => $post_id,
+                'post_content' => 'Updated content to create revision',
+            ]);
+        }
+    }
+
+    private function getModuleExpectations(): array {
+        return [
+            'speed_analyzer'     => [
+                'chart_id'  => 'sitepulse-speed-chart',
+                'link'      => 'admin.php?page=sitepulse-speed',
+                'chart_key' => 'speed',
+            ],
+            'uptime_tracker'     => [
+                'chart_id'  => 'sitepulse-uptime-chart',
+                'link'      => 'admin.php?page=sitepulse-uptime',
+                'chart_key' => 'uptime',
+            ],
+            'database_optimizer' => [
+                'chart_id'  => 'sitepulse-database-chart',
+                'link'      => 'admin.php?page=sitepulse-db',
+                'chart_key' => 'database',
+            ],
+            'log_analyzer'       => [
+                'chart_id'  => 'sitepulse-log-chart',
+                'link'      => 'admin.php?page=sitepulse-logs',
+                'chart_key' => 'logs',
+            ],
+        ];
+    }
+
+    private function getLocalizedCharts(): array {
+        $scripts = wp_scripts();
+        $data = $scripts->get_data('sitepulse-dashboard-charts', 'data');
+
+        $this->assertIsString($data);
+        $this->assertSame(1, preg_match('/var SitePulseDashboardData = (.*);/', $data, $matches));
+
+        $payload = json_decode($matches[1], true);
+
+        $this->assertIsArray($payload);
+        $this->assertArrayHasKey('charts', $payload);
+        $this->assertIsArray($payload['charts']);
+
+        return $payload['charts'];
     }
 
     public function test_disabling_modules_hides_cards_and_data(): void {
+        $this->seedModuleData();
         update_option(SITEPULSE_OPTION_ACTIVE_MODULES, ['custom_dashboards']);
 
         sitepulse_custom_dashboard_enqueue_assets('toplevel_page_sitepulse-dashboard');
@@ -53,18 +159,69 @@ class Sitepulse_Custom_Dashboard_Render_Test extends WP_UnitTestCase {
         $this->assertStringNotContainsString('sitepulse-log-chart', $output);
         $this->assertStringNotContainsString('admin.php?page=sitepulse-logs', $output);
 
-        $scripts = wp_scripts();
-        $data = $scripts->get_data('sitepulse-dashboard-charts', 'data');
-        $this->assertIsString($data);
-        $this->assertSame(1, preg_match('/var SitePulseDashboardData = (.*);/', $data, $matches));
+        $charts = $this->getLocalizedCharts();
+        $this->assertArrayNotHasKey('speed', $charts);
+        $this->assertArrayNotHasKey('uptime', $charts);
+        $this->assertArrayNotHasKey('database', $charts);
+        $this->assertArrayNotHasKey('logs', $charts);
+    }
 
-        $payload = json_decode($matches[1], true);
-        $this->assertIsArray($payload);
-        $this->assertArrayHasKey('charts', $payload);
-        $this->assertIsArray($payload['charts']);
-        $this->assertArrayNotHasKey('speed', $payload['charts']);
-        $this->assertArrayNotHasKey('uptime', $payload['charts']);
-        $this->assertArrayNotHasKey('database', $payload['charts']);
-        $this->assertArrayNotHasKey('logs', $payload['charts']);
+    /**
+     * @return array<string, array{module: string}>
+     */
+    public function moduleDisablingDataProvider(): array {
+        return [
+            'speed analyzer disabled' => ['module' => 'speed_analyzer'],
+            'uptime tracker disabled' => ['module' => 'uptime_tracker'],
+            'database optimizer disabled' => ['module' => 'database_optimizer'],
+            'log analyzer disabled' => ['module' => 'log_analyzer'],
+        ];
+    }
+
+    /**
+     * @dataProvider moduleDisablingDataProvider
+     */
+    public function test_disabling_single_module_hides_card_and_localized_data(array $config): void {
+        $this->seedModuleData();
+
+        $module_expectations = $this->getModuleExpectations();
+        $active_modules = array_keys($module_expectations);
+        $active_modules[] = 'custom_dashboards';
+        $active_modules = array_values(array_filter($active_modules, function ($module) use ($config) {
+            return $module !== $config['module'];
+        }));
+
+        update_option(SITEPULSE_OPTION_ACTIVE_MODULES, $active_modules);
+
+        sitepulse_custom_dashboard_enqueue_assets('toplevel_page_sitepulse-dashboard');
+
+        ob_start();
+        sitepulse_custom_dashboards_page();
+        $output = ob_get_clean();
+
+        $disabled = $module_expectations[$config['module']];
+        $this->assertStringNotContainsString($disabled['chart_id'], $output);
+        $this->assertStringNotContainsString($disabled['link'], $output);
+
+        foreach ($module_expectations as $module_key => $details) {
+            if ($module_key === $config['module']) {
+                continue;
+            }
+
+            $this->assertStringContainsString($details['chart_id'], $output);
+            $this->assertStringContainsString($details['link'], $output);
+        }
+
+        $charts = $this->getLocalizedCharts();
+
+        $this->assertArrayNotHasKey($disabled['chart_key'], $charts);
+
+        foreach ($module_expectations as $module_key => $details) {
+            if ($module_key === $config['module']) {
+                continue;
+            }
+
+            $this->assertArrayHasKey($details['chart_key'], $charts);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- gate dashboard cards and chart datasets based on the active module list
- strip inactive module data from the localization payload for SitePulseDashboardData
- expand dashboard render tests with module toggling coverage and supporting stubs

## Testing
- php -l sitepulse_FR/modules/custom_dashboards.php
- php -l tests/phpunit/includes/stubs.php
- php -l tests/phpunit/test-custom-dashboard-render.php

------
https://chatgpt.com/codex/tasks/task_e_68dc34ac8b20832e9a65789582d6f3c2