### PR TITLE
Ensure custom capability removed on plugin cleanup

### DIFF
--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -1217,6 +1217,29 @@ function sitepulse_activate_site() {
 }
 
 /**
+ * Removes the SitePulse capability from the administrator role.
+ *
+ * @return void
+ */
+function sitepulse_remove_administrator_capability() {
+    if (!function_exists('get_role')) {
+        return;
+    }
+
+    $capability = sitepulse_get_capability();
+
+    if (!is_string($capability) || $capability === '') {
+        return;
+    }
+
+    $administrator_role = get_role('administrator');
+
+    if ($administrator_role instanceof \WP_Role) {
+        $administrator_role->remove_cap($capability);
+    }
+}
+
+/**
  * Ensures SitePulse defaults are applied to a newly created site.
  *
  * @param int $site_id Site identifier.
@@ -1353,6 +1376,8 @@ function sitepulse_deactivate_site() {
     foreach (sitepulse_get_cron_hooks() as $hook) {
         wp_clear_scheduled_hook($hook);
     }
+
+    sitepulse_remove_administrator_capability();
 
     if (!sitepulse_is_plugin_active_anywhere()) {
         sitepulse_plugin_impact_remove_mu_loader();

--- a/sitepulse_FR/uninstall.php
+++ b/sitepulse_FR/uninstall.php
@@ -48,6 +48,33 @@ if (!defined('SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK')) {
     define('SITEPULSE_TRANSIENT_ERROR_ALERT_PHP_FATAL_LOCK', SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_PREFIX . 'php_fatal' . SITEPULSE_TRANSIENT_ERROR_ALERT_LOCK_SUFFIX);
 }
 
+require_once __DIR__ . '/includes/admin-settings.php';
+
+if (!function_exists('sitepulse_remove_administrator_capability')) {
+    /**
+     * Removes the SitePulse capability from the administrator role.
+     *
+     * @return void
+     */
+    function sitepulse_remove_administrator_capability() {
+        if (!function_exists('get_role')) {
+            return;
+        }
+
+        $capability = sitepulse_get_capability();
+
+        if (!is_string($capability) || $capability === '') {
+            return;
+        }
+
+        $administrator_role = get_role('administrator');
+
+        if ($administrator_role instanceof \WP_Role) {
+            $administrator_role->remove_cap($capability);
+        }
+    }
+}
+
 $options = [
     SITEPULSE_OPTION_ACTIVE_MODULES,
     SITEPULSE_OPTION_DEBUG_MODE,
@@ -188,6 +215,8 @@ function sitepulse_uninstall_cleanup_blog($options, $transients, $cron_hooks, $t
     foreach ($cron_hooks as $hook) {
         wp_clear_scheduled_hook($hook);
     }
+
+    sitepulse_remove_administrator_capability();
 }
 
 if (is_multisite()) {

--- a/tests/phpunit/test-deactivation-capability.php
+++ b/tests/phpunit/test-deactivation-capability.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @covers ::sitepulse_deactivate_site
+ */
+class Sitepulse_Deactivation_Capability_Test extends WP_UnitTestCase {
+    /**
+     * Ensures the filtered capability is removed from administrators on deactivation.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_deactivate_site_removes_filtered_capability(): void {
+        require_once dirname(__DIR__, 2) . '/sitepulse_FR/sitepulse.php';
+
+        $filter = function() {
+            return 'manage_sitepulse';
+        };
+
+        add_filter('sitepulse_required_capability', $filter);
+
+        $administrator_role = get_role('administrator');
+        $this->assertInstanceOf(WP_Role::class, $administrator_role);
+
+        $administrator_role->add_cap('manage_sitepulse');
+        $this->assertTrue($administrator_role->has_cap('manage_sitepulse'));
+
+        sitepulse_deactivate_site();
+
+        $administrator_role = get_role('administrator');
+        $this->assertInstanceOf(WP_Role::class, $administrator_role);
+        $this->assertFalse($administrator_role->has_cap('manage_sitepulse'));
+
+        remove_filter('sitepulse_required_capability', $filter);
+    }
+}

--- a/tests/phpunit/test-uninstall.php
+++ b/tests/phpunit/test-uninstall.php
@@ -35,5 +35,27 @@ class SitePulse_Uninstall_Test extends WP_UnitTestCase {
 
         $this->assertFalse(get_site_option(SITEPULSE_OPTION_DEBUG_NOTICES, false));
     }
+
+    public function test_uninstall_removes_filtered_capability(): void {
+        $filter = function() {
+            return 'manage_sitepulse';
+        };
+
+        add_filter('sitepulse_required_capability', $filter);
+
+        $administrator_role = get_role('administrator');
+        $this->assertInstanceOf(WP_Role::class, $administrator_role);
+
+        $administrator_role->add_cap('manage_sitepulse');
+        $this->assertTrue($administrator_role->has_cap('manage_sitepulse'));
+
+        $this->run_uninstall();
+
+        $administrator_role = get_role('administrator');
+        $this->assertInstanceOf(WP_Role::class, $administrator_role);
+        $this->assertFalse($administrator_role->has_cap('manage_sitepulse'));
+
+        remove_filter('sitepulse_required_capability', $filter);
+    }
 }
 


### PR DESCRIPTION
## Summary
- add a helper that removes the filtered SitePulse capability from the administrator role and invoke it during deactivation and uninstall
- load the helper inside the uninstall workflow so each site clears the capability while options, transients, and cron hooks are removed
- extend the PHPUnit suite with coverage for capability cleanup on both deactivation and uninstall

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68dc43d55f8c832eae1e7e1c689793da