### PR TITLE
Adjust speed analyzer layout for mobile

### DIFF
--- a/sitepulse_FR/modules/css/speed-analyzer.css
+++ b/sitepulse_FR/modules/css/speed-analyzer.css
@@ -5,6 +5,13 @@
     margin-top: 20px;
 }
 
+@media (max-width: 782px) {
+    .speed-grid {
+        grid-template-columns: 1fr;
+        gap: 16px;
+    }
+}
+
 .speed-card {
     background: #fff;
     padding: 20px;
@@ -45,8 +52,9 @@
 
 .health-list .metric-value {
     font-weight: bold;
-    margin-left: auto;
-    flex-basis: auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
 }
 
 .health-list .description {


### PR DESCRIPTION
## Summary
- ensure the speed analyzer cards stack into a single column on small screens with tighter spacing
- replace the metric value float with a flex layout so descriptions no longer wrap around the numbers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcf75ee550832e91a816d36fcb0930