### PR TITLE
Improve speed analyzer mobile layout

### DIFF
--- a/sitepulse_FR/modules/css/speed-analyzer.css
+++ b/sitepulse_FR/modules/css/speed-analyzer.css
@@ -45,8 +45,9 @@
 
 .health-list .metric-value {
     font-weight: bold;
-    margin-left: auto;
-    flex-basis: auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
 }
 
 .health-list .description {
@@ -64,4 +65,11 @@
 
 .status-bad {
     color: #F44336;
+}
+
+@media (max-width: 782px) {
+    .speed-grid {
+        grid-template-columns: 1fr;
+        gap: 16px;
+    }
 }


### PR DESCRIPTION
## Summary
- switch the speed grid to a single column with tighter spacing on small screens
- replace the metric value float with a flex container to keep labels and values aligned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcf6e406dc832ead468dfc0dd27d13