### PR TITLE
Improve impact bar contrast in plugin impact scanner

### DIFF
--- a/sitepulse_FR/modules/css/plugin-impact-scanner.css
+++ b/sitepulse_FR/modules/css/plugin-impact-scanner.css
@@ -8,13 +8,14 @@
 .impact-bar {
     height: 18px;
     border-radius: 3px;
-    background-color: #FFC107;
+    background-color: #FAD768;
     text-align: right;
-    color: #fff;
+    color: #1F2933;
     padding-right: 5px;
     white-space: nowrap;
     font-size: 12px;
     line-height: 18px;
+    font-weight: 600;
 }
 
 .sitepulse-impact-meta {

--- a/sitepulse_FR/modules/plugin_impact_scanner.php
+++ b/sitepulse_FR/modules/plugin_impact_scanner.php
@@ -368,13 +368,13 @@ function sitepulse_plugin_impact_scanner_page() {
                 <?php else : ?>
                     <?php foreach ($impacts as $data) :
                         $weight = ($total_impact > 0 && $data['impact'] !== null) ? ($data['impact'] / $total_impact) * 100 : null;
-                        $weight_color = '#4CAF50';
+                        $weight_color = '#81C784';
 
                         if (is_numeric($weight)) {
                             if ($weight > 20) {
-                                $weight_color = '#F44336';
+                                $weight_color = '#E57373';
                             } elseif ($weight > 10) {
-                                $weight_color = '#FFC107';
+                                $weight_color = '#FAD768';
                             }
                         }
 


### PR DESCRIPTION
## Summary
- update the plugin impact bar styling to use a darker text color and accessible fallback background
- align the PHP-provided weight colors with the revised palette so inline styles match the new design

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd0f3420e0832e8f39bcf3a654873f