### PR TITLE
Improve uptime tracker accessibility metadata

### DIFF
--- a/sitepulse_FR/modules/css/uptime-tracker.css
+++ b/sitepulse_FR/modules/css/uptime-tracker.css
@@ -109,3 +109,16 @@
 .uptime-trend__legend-item--low::before {
     background-color: #F44336;
 }
+
+.screen-reader-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+}


### PR DESCRIPTION
## Summary
- add descriptive screen-reader content to uptime bars including timestamp, status, and duration details
- add shared screen reader utility styles to the uptime tracker stylesheet

## Testing
- php -l sitepulse_FR/modules/uptime_tracker.php

------
https://chatgpt.com/codex/tasks/task_e_68dd0f36a2f0832e83ed8e4ee6d38afa