### PR TITLE
Handle missing update data in maintenance advisor

### DIFF
--- a/sitepulse_FR/modules/maintenance_advisor.php
+++ b/sitepulse_FR/modules/maintenance_advisor.php
@@ -16,17 +16,40 @@ function sitepulse_maintenance_advisor_page() {
     }
 
     require_once ABSPATH . 'wp-admin/includes/update.php';
-    $core_updates = get_core_updates();
-    $plugin_updates = get_plugin_updates();
-    $core_status = !empty($core_updates) && $core_updates[0]->response !== 'latest'
-        ? __('Mise à jour disponible !', 'sitepulse')
-        : __('À jour', 'sitepulse');
-    $plugin_updates_count = count($plugin_updates);
+    $core_updates = apply_filters('sitepulse_maintenance_advisor_core_updates', get_core_updates());
+    $plugin_updates = apply_filters('sitepulse_maintenance_advisor_plugin_updates', get_plugin_updates());
+
+    $core_updates_available = !is_wp_error($core_updates) && is_array($core_updates);
+    $plugin_updates_available = !is_wp_error($plugin_updates) && is_array($plugin_updates);
+    $has_update_data = $core_updates_available && $plugin_updates_available;
+
+    if ($has_update_data) {
+        $core_update_entry = $core_updates_available && isset($core_updates[0]) && is_object($core_updates[0])
+            ? $core_updates[0]
+            : null;
+
+        $core_status = $core_update_entry !== null
+            && property_exists($core_update_entry, 'response')
+            && $core_update_entry->response !== 'latest'
+            ? __('Mise à jour disponible !', 'sitepulse')
+            : __('À jour', 'sitepulse');
+
+        $plugin_updates_count = count($plugin_updates);
+    }
     ?>
     <div class="wrap">
         <h1><span class="dashicons-before dashicons-update"></span> <?php esc_html_e('Conseiller de Maintenance', 'sitepulse'); ?></h1>
-        <p><strong><?php esc_html_e('Mises à jour du Coeur WP:', 'sitepulse'); ?></strong> <?php echo esc_html($core_status); ?></p>
-        <p><strong><?php esc_html_e('Mises à jour des Plugins:', 'sitepulse'); ?></strong> <?php echo esc_html($plugin_updates_count); ?> <?php esc_html_e('en attente', 'sitepulse'); ?></p>
+        <?php if (!$has_update_data) : ?>
+            <div class="notice notice-error">
+                <p><?php esc_html_e(
+                    'Impossible de récupérer les données de mise à jour de WordPress. Le nombre de mises à jour disponibles est inconnu.',
+                    'sitepulse'
+                ); ?></p>
+            </div>
+        <?php else : ?>
+            <p><strong><?php esc_html_e('Mises à jour du Coeur WP:', 'sitepulse'); ?></strong> <?php echo esc_html($core_status); ?></p>
+            <p><strong><?php esc_html_e('Mises à jour des Plugins:', 'sitepulse'); ?></strong> <?php echo esc_html($plugin_updates_count); ?> <?php esc_html_e('en attente', 'sitepulse'); ?></p>
+        <?php endif; ?>
         <p class="description"><?php esc_html_e('Recommandations : Faites une sauvegarde avant de mettre à jour, testez sur un site de pré-production.', 'sitepulse'); ?></p>
     </div>
     <?php

--- a/tests/phpunit/test-maintenance-advisor.php
+++ b/tests/phpunit/test-maintenance-advisor.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Tests for the Maintenance Advisor module fallbacks.
+ */
+
+require_once __DIR__ . '/includes/stubs.php';
+
+if (!function_exists('sitepulse_get_capability')) {
+    function sitepulse_get_capability() {
+        return 'manage_options';
+    }
+}
+
+require_once dirname(__DIR__, 2) . '/sitepulse_FR/modules/maintenance_advisor.php';
+
+class Sitepulse_Maintenance_Advisor_Test extends WP_UnitTestCase {
+    protected function setUp(): void {
+        parent::setUp();
+
+        wp_set_current_user($this->factory->user->create(['role' => 'administrator']));
+    }
+
+    public function test_displays_warning_notice_when_update_data_missing(): void {
+        add_filter('sitepulse_maintenance_advisor_core_updates', '__return_false');
+        add_filter('sitepulse_maintenance_advisor_plugin_updates', [$this, 'filter_return_wp_error']);
+
+        $warnings = [];
+        $handler = function($errno, $errstr) use (&$warnings) {
+            if ($errno === E_WARNING) {
+                $warnings[] = $errstr;
+            }
+
+            return false;
+        };
+
+        set_error_handler($handler);
+
+        try {
+            ob_start();
+            sitepulse_maintenance_advisor_page();
+            $output = ob_get_clean();
+        } finally {
+            restore_error_handler();
+            remove_filter('sitepulse_maintenance_advisor_core_updates', '__return_false');
+            remove_filter('sitepulse_maintenance_advisor_plugin_updates', [$this, 'filter_return_wp_error']);
+        }
+
+        $this->assertStringContainsString('notice notice-error', $output);
+        $this->assertStringContainsString(
+            'Impossible de récupérer les données de mise à jour de WordPress',
+            $output,
+            'The Maintenance Advisor should explain when update counts are unavailable.'
+        );
+        $this->assertEmpty(
+            $warnings,
+            'The Maintenance Advisor fallback must avoid emitting PHP warnings when update data is missing.'
+        );
+    }
+
+    public function filter_return_wp_error($value) {
+        return new WP_Error('sitepulse-tests', 'Mocked failure');
+    }
+}


### PR DESCRIPTION
## Summary
- guard the maintenance advisor against invalid results from WordPress update APIs
- display an admin error notice when update counts cannot be retrieved
- add PHPUnit coverage to ensure the fallback notice renders without PHP warnings

## Testing
- Not run (phpunit not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd2084bc9c832e880317ff18952536