### PR TITLE
Localize resource monitor fallbacks

### DIFF
--- a/sitepulse_FR/modules/resource_monitor.php
+++ b/sitepulse_FR/modules/resource_monitor.php
@@ -31,8 +31,10 @@ function sitepulse_resource_monitor_enqueue_assets($hook_suffix) {
  * @return string
  */
 function sitepulse_resource_monitor_format_load_display($load_values) {
+    $not_available_label = __('N/A', 'sitepulse');
+
     if (!is_array($load_values) || empty($load_values)) {
-        $load_values = ['N/A', 'N/A', 'N/A'];
+        $load_values = [$not_available_label, $not_available_label, $not_available_label];
     }
 
     $normalized_values = array_map(
@@ -50,19 +52,19 @@ function sitepulse_resource_monitor_format_load_display($load_values) {
             }
 
             if (is_null($value)) {
-                return 'N/A';
+                return $not_available_label;
             }
 
             if (is_scalar($value)) {
                 return (string) $value;
             }
 
-            return 'N/A';
+            return $not_available_label;
         },
         array_slice(array_values((array) $load_values), 0, 3)
     );
 
-    $normalized_values = array_pad($normalized_values, 3, 'N/A');
+    $normalized_values = array_pad($normalized_values, 3, $not_available_label);
 
     return implode(' / ', $normalized_values);
 }
@@ -89,7 +91,8 @@ function sitepulse_resource_monitor_get_snapshot() {
     }
 
     $notices = [];
-    $load = ['N/A', 'N/A', 'N/A'];
+    $not_available_label = __('N/A', 'sitepulse');
+    $load = [$not_available_label, $not_available_label, $not_available_label];
     $load_display = sitepulse_resource_monitor_format_load_display($load);
 
     if (function_exists('sys_getloadavg')) {
@@ -152,7 +155,7 @@ function sitepulse_resource_monitor_get_snapshot() {
         }
     }
 
-    $disk_free = 'N/A';
+    $disk_free = $not_available_label;
 
     if (function_exists('disk_free_space')) {
         $disk_free_error = null;
@@ -202,7 +205,7 @@ function sitepulse_resource_monitor_get_snapshot() {
         }
     }
 
-    $disk_total = 'N/A';
+    $disk_total = $not_available_label;
 
     if (function_exists('disk_total_space')) {
         $disk_total_error = null;

--- a/tests/phpunit/test-resource-monitor.php
+++ b/tests/phpunit/test-resource-monitor.php
@@ -167,8 +167,8 @@ class Sitepulse_Resource_Monitor_Test extends WP_UnitTestCase {
             'Failure to calculate total disk space should add a warning notice.'
         );
 
-        $this->assertSame('N/A', $snapshot['disk_free'], 'Disk free display should remain N/A after failure.');
-        $this->assertSame('N/A', $snapshot['disk_total'], 'Disk total display should remain N/A after failure.');
+        $this->assertSame(__('N/A', 'sitepulse'), $snapshot['disk_free'], 'Disk free display should remain N/A after failure.');
+        $this->assertSame(__('N/A', 'sitepulse'), $snapshot['disk_total'], 'Disk total display should remain N/A after failure.');
 
         $this->assertNotEmpty($GLOBALS['sitepulse_logger'], 'Failures should be logged as notices.');
         $logged_messages = wp_list_pluck($GLOBALS['sitepulse_logger'], 'message');
@@ -205,13 +205,16 @@ class Sitepulse_Resource_Monitor_Test extends WP_UnitTestCase {
 
         $generated_at = gmmktime(12, 0, 0, 1, 1, 2024);
 
+        $not_available_label = __('N/A', 'sitepulse');
+        $load_placeholder = [$not_available_label, $not_available_label, $not_available_label];
+
         $snapshot = [
-            'load'         => ['N/A', 'N/A', 'N/A'],
-            'load_display' => 'N/A / N/A / N/A',
+            'load'         => $load_placeholder,
+            'load_display' => sitepulse_resource_monitor_format_load_display($load_placeholder),
             'memory_usage' => '0 MB',
             'memory_limit' => '128M',
-            'disk_free'    => 'N/A',
-            'disk_total'   => 'N/A',
+            'disk_free'    => $not_available_label,
+            'disk_total'   => $not_available_label,
             'notices'      => [],
             'generated_at' => $generated_at,
         ];


### PR DESCRIPTION
## Summary
- replace hard-coded `N/A` placeholders in the resource monitor with localized strings reused across derived values
- ensure disk space fallbacks share the translated placeholder when metrics cannot be retrieved
- update the resource monitor PHPUnit expectations to match the localized placeholders

## Testing
- Not run (phpunit executable is not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd2083daf4832ea2e201f020e5a313