### PR TITLE
Improve accessibility of status indicators

### DIFF
--- a/sitepulse_FR/modules/css/speed-analyzer.css
+++ b/sitepulse_FR/modules/css/speed-analyzer.css
@@ -53,20 +53,14 @@
 .health-list .metric-value {
     font-weight: bold;
     display: inline-flex;
-    align-items: baseline;
-    gap: 0.5em;
+    align-items: center;
+    gap: 0.75em;
 }
 
-.health-list .description {
-    flex-basis: 100%;
-    margin-top: 6px;
-}
-
-.status-ok,
-.status-warn,
-.status-bad {
+.status-badge {
     display: inline-flex;
-    align-items: baseline;
+    align-items: center;
+    gap: 0.35em;
     padding: 0.15em 0.65em;
     border-radius: 999px;
     font-weight: 600;
@@ -74,16 +68,42 @@
     color: #fff;
 }
 
-.status-ok {
+.status-icon {
+    font-size: 1em;
+    line-height: 1;
+}
+
+.status-reading {
+    font-weight: 600;
+}
+
+.health-list .description {
+    flex-basis: 100%;
+    margin-top: 6px;
+}
+
+.status-badge.status-ok {
     background-color: #0b6d2a;
 }
 
-.status-warn {
+.status-badge.status-warn {
     background-color: #8a6100;
 }
 
-.status-bad {
+.status-badge.status-bad {
     background-color: #a0141e;
+}
+
+.screen-reader-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 @media (max-width: 782px) {

--- a/sitepulse_FR/modules/custom_dashboards.php
+++ b/sitepulse_FR/modules/custom_dashboards.php
@@ -157,6 +157,32 @@ function sitepulse_custom_dashboards_page() {
         'purple'   => '#9C27B0',
     ];
 
+    $status_labels = [
+        'status-ok'   => [
+            'label' => __('Bon', 'sitepulse'),
+            'sr'    => __('Statut : bon', 'sitepulse'),
+            'icon'  => '✔️',
+        ],
+        'status-warn' => [
+            'label' => __('Attention', 'sitepulse'),
+            'sr'    => __('Statut : attention', 'sitepulse'),
+            'icon'  => '⚠️',
+        ],
+        'status-bad'  => [
+            'label' => __('Critique', 'sitepulse'),
+            'sr'    => __('Statut : critique', 'sitepulse'),
+            'icon'  => '⛔',
+        ],
+    ];
+
+    $get_status_meta = static function ($status) use ($status_labels) {
+        if (isset($status_labels[$status])) {
+            return $status_labels[$status];
+        }
+
+        return $status_labels['status-warn'];
+    };
+
     $charts_payload = [];
     $speed_card = null;
 
@@ -509,22 +535,15 @@ function sitepulse_custom_dashboards_page() {
         .sitepulse-chart-container { position: relative; height: 220px; margin: 0 0 16px; }
         .sitepulse-chart-container canvas { width: 100% !important; height: 100% !important; }
         .sitepulse-chart-empty { text-align: center; color: #666; padding: 48px 16px; border: 1px dashed #d9d9d9; border-radius: 6px; font-size: 13px; }
-        .sitepulse-metric { margin: 0; font-size: 28px; font-weight: 600; display: inline-flex; align-items: baseline; }
-        .sitepulse-metric-unit { font-size: 12px; text-transform: uppercase; margin-left: 6px; color: #757575; letter-spacing: 0.05em; }
-        .sitepulse-card .status-ok,
-        .sitepulse-card .status-warn,
-        .sitepulse-card .status-bad {
-            display: inline-flex;
-            align-items: baseline;
-            padding: 0.2em 0.75em;
-            border-radius: 999px;
-            font-weight: 600;
-            line-height: 1.4;
-            color: #fff;
-        }
-        .sitepulse-card .status-ok { background-color: <?php echo esc_attr($palette['green']); ?>; }
-        .sitepulse-card .status-warn { background-color: <?php echo esc_attr($palette['amber']); ?>; }
-        .sitepulse-card .status-bad { background-color: <?php echo esc_attr($palette['red']); ?>; }
+        .sitepulse-metric { margin: 0; font-size: 28px; font-weight: 600; display: inline-flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+        .sitepulse-metric-value { display: inline-flex; align-items: baseline; gap: 6px; }
+        .sitepulse-metric-unit { font-size: 12px; text-transform: uppercase; color: #757575; letter-spacing: 0.05em; }
+        .status-badge { display: inline-flex; align-items: center; gap: 0.35em; padding: 0.2em 0.75em; border-radius: 999px; font-size: 13px; font-weight: 600; line-height: 1.4; color: #fff; }
+        .status-icon { font-size: 1em; line-height: 1; }
+        .status-badge.status-ok { background-color: <?php echo esc_attr($palette['green']); ?>; }
+        .status-badge.status-warn { background-color: <?php echo esc_attr($palette['amber']); ?>; }
+        .status-badge.status-bad { background-color: <?php echo esc_attr($palette['red']); ?>; }
+        .screen-reader-text { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
         .sitepulse-legend { list-style: none; margin: 12px 0 0; padding: 0; display: grid; gap: 6px; font-size: 13px; }
         .sitepulse-legend li { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
         .sitepulse-legend .label { display: flex; align-items: center; gap: 8px; }
@@ -547,7 +566,15 @@ function sitepulse_custom_dashboards_page() {
                     <div class="sitepulse-chart-container">
                         <canvas id="sitepulse-speed-chart" aria-describedby="sitepulse-speed-description"></canvas>
                     </div>
-                    <p class="sitepulse-metric <?php echo esc_attr($speed_card['status']); ?>"><?php echo esc_html($speed_card['display']); ?></p>
+                    <?php $speed_status_meta = $get_status_meta($speed_card['status']); ?>
+                    <p class="sitepulse-metric">
+                        <span class="status-badge <?php echo esc_attr($speed_card['status']); ?>" aria-hidden="true">
+                            <span class="status-icon"><?php echo esc_html($speed_status_meta['icon']); ?></span>
+                            <span class="status-text"><?php echo esc_html($speed_status_meta['label']); ?></span>
+                        </span>
+                        <span class="screen-reader-text"><?php echo esc_html($speed_status_meta['sr']); ?></span>
+                        <span class="sitepulse-metric-value"><?php echo esc_html($speed_card['display']); ?></span>
+                    </p>
                     <p id="sitepulse-speed-description" class="description"><?php esc_html_e('Under 200ms indicates an excellent PHP response. Above 500ms suggests investigating plugins or hosting performance.', 'sitepulse'); ?></p>
                 </div>
             <?php endif; ?>
@@ -562,7 +589,15 @@ function sitepulse_custom_dashboards_page() {
                     <div class="sitepulse-chart-container">
                         <canvas id="sitepulse-uptime-chart" aria-describedby="sitepulse-uptime-description"></canvas>
                     </div>
-                    <p class="sitepulse-metric <?php echo esc_attr($uptime_card['status']); ?>"><?php echo esc_html(round($uptime_card['percentage'], 2)); ?>%</p>
+                    <?php $uptime_status_meta = $get_status_meta($uptime_card['status']); ?>
+                    <p class="sitepulse-metric">
+                        <span class="status-badge <?php echo esc_attr($uptime_card['status']); ?>" aria-hidden="true">
+                            <span class="status-icon"><?php echo esc_html($uptime_status_meta['icon']); ?></span>
+                            <span class="status-text"><?php echo esc_html($uptime_status_meta['label']); ?></span>
+                        </span>
+                        <span class="screen-reader-text"><?php echo esc_html($uptime_status_meta['sr']); ?></span>
+                        <span class="sitepulse-metric-value"><?php echo esc_html(round($uptime_card['percentage'], 2)); ?><span class="sitepulse-metric-unit"><?php esc_html_e('%', 'sitepulse'); ?></span></span>
+                    </p>
                     <p id="sitepulse-uptime-description" class="description"><?php esc_html_e('Each bar shows whether the site responded during the scheduled availability probe.', 'sitepulse'); ?></p>
                 </div>
             <?php endif; ?>
@@ -577,9 +612,17 @@ function sitepulse_custom_dashboards_page() {
                     <div class="sitepulse-chart-container">
                         <canvas id="sitepulse-database-chart" aria-describedby="sitepulse-database-description"></canvas>
                     </div>
-                    <p class="sitepulse-metric <?php echo esc_attr($database_card['status']); ?>">
-                        <?php echo esc_html(number_format_i18n($database_card['revisions'])); ?>
-                        <span class="sitepulse-metric-unit"><?php esc_html_e('revisions', 'sitepulse'); ?></span>
+                    <?php $database_status_meta = $get_status_meta($database_card['status']); ?>
+                    <p class="sitepulse-metric">
+                        <span class="status-badge <?php echo esc_attr($database_card['status']); ?>" aria-hidden="true">
+                            <span class="status-icon"><?php echo esc_html($database_status_meta['icon']); ?></span>
+                            <span class="status-text"><?php echo esc_html($database_status_meta['label']); ?></span>
+                        </span>
+                        <span class="screen-reader-text"><?php echo esc_html($database_status_meta['sr']); ?></span>
+                        <span class="sitepulse-metric-value">
+                            <?php echo esc_html(number_format_i18n($database_card['revisions'])); ?>
+                            <span class="sitepulse-metric-unit"><?php esc_html_e('revisions', 'sitepulse'); ?></span>
+                        </span>
                     </p>
                     <p id="sitepulse-database-description" class="description"><?php printf(esc_html__('Keep revisions under %d to avoid bloating the posts table. Cleaning them is safe and reversible with backups.', 'sitepulse'), (int) $database_card['limit']); ?></p>
                 </div>
@@ -595,7 +638,15 @@ function sitepulse_custom_dashboards_page() {
                     <div class="sitepulse-chart-container">
                         <canvas id="sitepulse-log-chart" aria-describedby="sitepulse-log-description"></canvas>
                     </div>
-                    <p class="sitepulse-metric <?php echo esc_attr($logs_card['status']); ?>"><?php echo esc_html($logs_card['summary']); ?></p>
+                    <?php $logs_status_meta = $get_status_meta($logs_card['status']); ?>
+                    <p class="sitepulse-metric">
+                        <span class="status-badge <?php echo esc_attr($logs_card['status']); ?>" aria-hidden="true">
+                            <span class="status-icon"><?php echo esc_html($logs_status_meta['icon']); ?></span>
+                            <span class="status-text"><?php echo esc_html($logs_status_meta['label']); ?></span>
+                        </span>
+                        <span class="screen-reader-text"><?php echo esc_html($logs_status_meta['sr']); ?></span>
+                        <span class="sitepulse-metric-value"><?php echo esc_html($logs_card['summary']); ?></span>
+                    </p>
                     <ul class="sitepulse-legend">
                         <li>
                             <span class="label"><span class="badge" style="background-color: <?php echo esc_attr($palette['red']); ?>;"></span><?php esc_html_e('Fatal errors', 'sitepulse'); ?></span>

--- a/sitepulse_FR/modules/speed_analyzer.php
+++ b/sitepulse_FR/modules/speed_analyzer.php
@@ -78,6 +78,32 @@ function sitepulse_speed_analyzer_page() {
     $object_cache_active = wp_using_ext_object_cache();
     $php_version = PHP_VERSION;
 
+    $status_labels = [
+        'status-ok'   => [
+            'label' => __('Bon', 'sitepulse'),
+            'sr'    => __('Statut : bon', 'sitepulse'),
+            'icon'  => '✔️',
+        ],
+        'status-warn' => [
+            'label' => __('Attention', 'sitepulse'),
+            'sr'    => __('Statut : attention', 'sitepulse'),
+            'icon'  => '⚠️',
+        ],
+        'status-bad'  => [
+            'label' => __('Critique', 'sitepulse'),
+            'sr'    => __('Statut : critique', 'sitepulse'),
+            'icon'  => '⛔',
+        ],
+    ];
+
+    $get_status_meta = static function ($status) use ($status_labels) {
+        if (isset($status_labels[$status])) {
+            return $status_labels[$status];
+        }
+
+        return $status_labels['status-warn'];
+    };
+
     ?>
     <div class="wrap">
         <h1><span class="dashicons-before dashicons-performance"></span> Analyseur de Vitesse</h1>
@@ -94,7 +120,15 @@ function sitepulse_speed_analyzer_page() {
                     ?>
                     <li>
                         <span class="metric-name">Temps de Génération de la Page</span>
-                        <span class="metric-value <?php echo esc_attr($gen_time_status); ?>"><?php echo esc_html(round($page_generation_time) . ' ms'); ?></span>
+                        <?php $gen_time_meta = $get_status_meta($gen_time_status); ?>
+                        <span class="metric-value">
+                            <span class="status-badge <?php echo esc_attr($gen_time_status); ?>" aria-hidden="true">
+                                <span class="status-icon"><?php echo esc_html($gen_time_meta['icon']); ?></span>
+                                <span class="status-text"><?php echo esc_html($gen_time_meta['label']); ?></span>
+                            </span>
+                            <span class="screen-reader-text"><?php echo esc_html($gen_time_meta['sr']); ?></span>
+                            <span class="status-reading"><?php echo esc_html(round($page_generation_time) . ' ms'); ?></span>
+                        </span>
                         <p class="description">C'est le temps total que met votre serveur pour préparer cette page. Un temps élevé (&gt;1s) peut indiquer un hébergement lent ou un plugin qui consomme beaucoup de ressources.</p>
                     </li>
                 </ul>
@@ -112,7 +146,15 @@ function sitepulse_speed_analyzer_page() {
                         ?>
                         <li>
                             <span class="metric-name">Temps Total des Requêtes BDD</span>
-                            <span class="metric-value <?php echo esc_attr($db_time_status); ?>"><?php echo esc_html(round($db_query_total_time) . ' ms'); ?></span>
+                            <?php $db_time_meta = $get_status_meta($db_time_status); ?>
+                            <span class="metric-value">
+                                <span class="status-badge <?php echo esc_attr($db_time_status); ?>" aria-hidden="true">
+                                    <span class="status-icon"><?php echo esc_html($db_time_meta['icon']); ?></span>
+                                    <span class="status-text"><?php echo esc_html($db_time_meta['label']); ?></span>
+                                </span>
+                                <span class="screen-reader-text"><?php echo esc_html($db_time_meta['sr']); ?></span>
+                                <span class="status-reading"><?php echo esc_html(round($db_query_total_time) . ' ms'); ?></span>
+                            </span>
                             <p class="description">Le temps total passé à attendre la base de données. S'il est élevé, cela peut indiquer des requêtes complexes ou une base de données surchargée.</p>
                         </li>
                         <?php
@@ -120,7 +162,15 @@ function sitepulse_speed_analyzer_page() {
                         ?>
                         <li>
                             <span class="metric-name">Temps Total des Requêtes BDD</span>
-                            <span class="metric-value status-warn">N/A</span>
+                            <?php $db_time_meta = $get_status_meta('status-warn'); ?>
+                            <span class="metric-value">
+                                <span class="status-badge status-warn" aria-hidden="true">
+                                    <span class="status-icon"><?php echo esc_html($db_time_meta['icon']); ?></span>
+                                    <span class="status-text"><?php echo esc_html($db_time_meta['label']); ?></span>
+                                </span>
+                                <span class="screen-reader-text"><?php echo esc_html($db_time_meta['sr']); ?></span>
+                                <span class="status-reading">N/A</span>
+                            </span>
                             <p class="description">Pour activer cette mesure, ajoutez <code>define('SAVEQUERIES', true);</code> à votre fichier <code>wp-config.php</code>. <strong>Note:</strong> N'utilisez ceci que pour le débogage, car cela peut ralentir votre site.</p>
                         </li>
                         <?php
@@ -131,7 +181,15 @@ function sitepulse_speed_analyzer_page() {
                     ?>
                     <li>
                         <span class="metric-name">Nombre de Requêtes BDD</span>
-                        <span class="metric-value <?php echo esc_attr($db_count_status); ?>"><?php echo esc_html($db_query_count); ?></span>
+                        <?php $db_count_meta = $get_status_meta($db_count_status); ?>
+                        <span class="metric-value">
+                            <span class="status-badge <?php echo esc_attr($db_count_status); ?>" aria-hidden="true">
+                                <span class="status-icon"><?php echo esc_html($db_count_meta['icon']); ?></span>
+                                <span class="status-text"><?php echo esc_html($db_count_meta['label']); ?></span>
+                            </span>
+                            <span class="screen-reader-text"><?php echo esc_html($db_count_meta['sr']); ?></span>
+                            <span class="status-reading"><?php echo esc_html($db_query_count); ?></span>
+                        </span>
                         <p class="description">Le nombre de fois que WordPress a interrogé la base de données. Un nombre élevé (&gt;100) peut être le signe d'un plugin ou d'un thème mal optimisé.</p>
                     </li>
                 </ul>
@@ -148,7 +206,15 @@ function sitepulse_speed_analyzer_page() {
                     ?>
                     <li>
                         <span class="metric-name">Object Cache</span>
-                        <span class="metric-value <?php echo esc_attr($cache_status_class); ?>"><?php echo esc_html($cache_text); ?></span>
+                        <?php $cache_meta = $get_status_meta($cache_status_class); ?>
+                        <span class="metric-value">
+                            <span class="status-badge <?php echo esc_attr($cache_status_class); ?>" aria-hidden="true">
+                                <span class="status-icon"><?php echo esc_html($cache_meta['icon']); ?></span>
+                                <span class="status-text"><?php echo esc_html($cache_meta['label']); ?></span>
+                            </span>
+                            <span class="screen-reader-text"><?php echo esc_html($cache_meta['sr']); ?></span>
+                            <span class="status-reading"><?php echo esc_html($cache_text); ?></span>
+                        </span>
                         <p class="description">Un cache d'objets persistant (ex: Redis, Memcached) accélère énormément les requêtes répétitives. Fortement recommandé.</p>
                     </li>
                     <?php
@@ -157,7 +223,15 @@ function sitepulse_speed_analyzer_page() {
                     ?>
                     <li>
                         <span class="metric-name">Version de PHP</span>
-                        <span class="metric-value <?php echo esc_attr($php_status); ?>"><?php echo esc_html($php_version); ?></span>
+                        <?php $php_meta = $get_status_meta($php_status); ?>
+                        <span class="metric-value">
+                            <span class="status-badge <?php echo esc_attr($php_status); ?>" aria-hidden="true">
+                                <span class="status-icon"><?php echo esc_html($php_meta['icon']); ?></span>
+                                <span class="status-text"><?php echo esc_html($php_meta['label']); ?></span>
+                            </span>
+                            <span class="screen-reader-text"><?php echo esc_html($php_meta['sr']); ?></span>
+                            <span class="status-reading"><?php echo esc_html($php_version); ?></span>
+                        </span>
                         <p class="description">Les versions modernes de PHP (8.0+) sont beaucoup plus rapides et sécurisées. Demandez à votre hébergeur de mettre à jour si nécessaire.</p>
                     </li>
                 </ul>


### PR DESCRIPTION
## Summary
- add screen reader status labels and visible icons to the speed analyzer metrics
- update dashboard cards with accessible status badges to expose textual labels for each state
- tweak CSS so the new badges retain the existing look while remaining readable for assistive tech

## Testing
- php -l sitepulse_FR/modules/speed_analyzer.php
- php -l sitepulse_FR/modules/custom_dashboards.php

------
https://chatgpt.com/codex/tasks/task_e_68dd205281c0832e8b261f19ce8b03c8