### PR TITLE
Add uptime configuration controls and coverage

### DIFF
--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -27,6 +27,8 @@ define('SITEPULSE_OPTION_AI_RATE_LIMIT', 'sitepulse_ai_rate_limit');
 define('SITEPULSE_OPTION_AI_LAST_RUN', 'sitepulse_ai_last_run');
 define('SITEPULSE_DEFAULT_AI_MODEL', 'gemini-1.5-flash');
 define('SITEPULSE_OPTION_UPTIME_LOG', 'sitepulse_uptime_log');
+define('SITEPULSE_OPTION_UPTIME_URL', 'sitepulse_uptime_url');
+define('SITEPULSE_OPTION_UPTIME_TIMEOUT', 'sitepulse_uptime_timeout');
 define('SITEPULSE_OPTION_LAST_LOAD_TIME', 'sitepulse_last_load_time');
 define('SITEPULSE_OPTION_CPU_ALERT_THRESHOLD', 'sitepulse_cpu_alert_threshold');
 define('SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES', 'sitepulse_alert_cooldown_minutes');
@@ -37,6 +39,8 @@ define('SITEPULSE_OPTION_PLUGIN_BASENAME', 'sitepulse_plugin_basename');
 define('SITEPULSE_OPTION_ERROR_ALERT_LOG_POINTER', 'sitepulse_error_alert_log_pointer');
 define('SITEPULSE_OPTION_CRON_WARNINGS', 'sitepulse_cron_warnings');
 define('SITEPULSE_OPTION_DEBUG_NOTICES', 'sitepulse_debug_notices');
+
+define('SITEPULSE_DEFAULT_UPTIME_TIMEOUT', 10);
 
 define('SITEPULSE_TRANSIENT_SPEED_SCAN_RESULTS', 'sitepulse_speed_scan_results');
 define('SITEPULSE_TRANSIENT_AI_INSIGHT', 'sitepulse_ai_insight');

--- a/tests/phpunit/test-admin-settings-cleanup.php
+++ b/tests/phpunit/test-admin-settings-cleanup.php
@@ -38,6 +38,15 @@ class Sitepulse_Admin_Settings_Cleanup_Test extends WP_UnitTestCase {
         if (!defined('SITEPULSE_OPTION_LAST_LOAD_TIME')) {
             define('SITEPULSE_OPTION_LAST_LOAD_TIME', 'sitepulse_last_load_time');
         }
+        if (!defined('SITEPULSE_OPTION_UPTIME_URL')) {
+            define('SITEPULSE_OPTION_UPTIME_URL', 'sitepulse_uptime_url');
+        }
+        if (!defined('SITEPULSE_OPTION_UPTIME_TIMEOUT')) {
+            define('SITEPULSE_OPTION_UPTIME_TIMEOUT', 'sitepulse_uptime_timeout');
+        }
+        if (!defined('SITEPULSE_DEFAULT_UPTIME_TIMEOUT')) {
+            define('SITEPULSE_DEFAULT_UPTIME_TIMEOUT', 10);
+        }
         if (!defined('SITEPULSE_OPTION_CPU_ALERT_THRESHOLD')) {
             define('SITEPULSE_OPTION_CPU_ALERT_THRESHOLD', 'sitepulse_cpu_alert_threshold');
         }
@@ -137,6 +146,8 @@ class Sitepulse_Admin_Settings_Cleanup_Test extends WP_UnitTestCase {
             SITEPULSE_OPTION_DEBUG_MODE             => '1',
             SITEPULSE_OPTION_GEMINI_API_KEY         => 'key',
             SITEPULSE_OPTION_UPTIME_LOG             => ['bar'],
+            SITEPULSE_OPTION_UPTIME_URL             => 'https://status.example.test/ping',
+            SITEPULSE_OPTION_UPTIME_TIMEOUT         => 42,
             SITEPULSE_OPTION_LAST_LOAD_TIME         => 123,
             SITEPULSE_OPTION_CPU_ALERT_THRESHOLD    => 42,
             SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES => 15,


### PR DESCRIPTION
## Summary
- add plugin constants and admin settings for configurable uptime URL and timeout
- render uptime availability fields in the settings UI
- update the uptime tracker to honour saved options with safe fallbacks
- extend unit tests for uptime tracker behaviour and admin cleanup coverage

## Testing
- php -l sitepulse_FR/includes/admin-settings.php
- php -l sitepulse_FR/modules/uptime_tracker.php
- php -l sitepulse_FR/sitepulse.php
- php -l tests/phpunit/test-uptime-tracker.php
- php -l tests/phpunit/test-admin-settings-cleanup.php

------
https://chatgpt.com/codex/tasks/task_e_68dd2ed939b8832eacdf8a35564c5ded