### PR TITLE
Fix resource monitor fallback label binding

### DIFF
--- a/sitepulse_FR/modules/resource_monitor.php
+++ b/sitepulse_FR/modules/resource_monitor.php
@@ -38,7 +38,7 @@ function sitepulse_resource_monitor_format_load_display($load_values) {
     }
 
     $normalized_values = array_map(
-        static function ($value) {
+        function ($value) use ($not_available_label) {
             if (is_numeric($value)) {
                 return number_format_i18n((float) $value, 2);
             }


### PR DESCRIPTION
## Summary
- ensure the resource monitor load display callback imports the fallback label when normalizing values

## Testing
- phpunit --filter Sitepulse_Resource_Monitor_Test *(fails: phpunit binary not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7f03015c832ebc15444cbc280cd1