### PR TITLE
Improve dashboard grid responsiveness

### DIFF
--- a/sitepulse_FR/modules/css/custom-dashboard.css
+++ b/sitepulse_FR/modules/css/custom-dashboard.css
@@ -1,6 +1,6 @@
 .sitepulse-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: 20px;
     margin-top: 20px;
 }
@@ -157,6 +157,12 @@
     justify-content: space-between;
     align-items: center;
     gap: 12px;
+}
+
+@media (max-width: 600px) {
+    .sitepulse-grid {
+        grid-template-columns: 1fr;
+    }
 }
 
 .sitepulse-legend .label {


### PR DESCRIPTION
## Summary
- reduce the dashboard grid column minimum width to better fit smaller viewports
- add a mobile breakpoint that forces a single column layout below 600px to prevent horizontal scrolling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd919eabe4832eb40d06b385108b83