### PR TITLE
Ensure plugin dir scan cron is cleaned up on shutdown

### DIFF
--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -1383,6 +1383,14 @@ function sitepulse_deactivate_site() {
         wp_clear_scheduled_hook($hook);
     }
 
+    wp_clear_scheduled_hook('sitepulse_queue_plugin_dir_scan');
+
+    if (defined('SITEPULSE_PLUGIN_DIR_SCAN_QUEUE_OPTION')) {
+        delete_option(SITEPULSE_PLUGIN_DIR_SCAN_QUEUE_OPTION);
+    } else {
+        delete_option('sitepulse_plugin_dir_scan_queue');
+    }
+
     sitepulse_remove_administrator_capability();
 
     if (!sitepulse_is_plugin_active_anywhere()) {

--- a/sitepulse_FR/uninstall.php
+++ b/sitepulse_FR/uninstall.php
@@ -34,6 +34,7 @@ $sitepulse_constants = [
     'SITEPULSE_TRANSIENT_RESOURCE_MONITOR_SNAPSHOT' => 'sitepulse_resource_monitor_snapshot',
     'SITEPULSE_PLUGIN_IMPACT_OPTION'              => 'sitepulse_plugin_impact_stats',
     'SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE'    => 'sitepulse_impact_loader_signature',
+    'SITEPULSE_PLUGIN_DIR_SCAN_QUEUE_OPTION'      => 'sitepulse_plugin_dir_scan_queue',
 ];
 
 foreach ($sitepulse_constants as $constant => $value) {
@@ -94,6 +95,7 @@ $options = [
     SITEPULSE_OPTION_CRON_WARNINGS,
     SITEPULSE_PLUGIN_IMPACT_OPTION,
     SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE,
+    SITEPULSE_PLUGIN_DIR_SCAN_QUEUE_OPTION,
 ];
 
 $transients = [
@@ -192,6 +194,8 @@ $cron_hooks = require __DIR__ . '/includes/cron-hooks.php';
 if (!is_array($cron_hooks)) {
     $cron_hooks = [];
 }
+
+wp_clear_scheduled_hook('sitepulse_queue_plugin_dir_scan');
 
 /**
  * Removes plugin data for a single site.


### PR DESCRIPTION
## Summary
- clear the sitepulse_queue_plugin_dir_scan cron hook and delete the associated queue option during plugin deactivation
- include the plugin directory scan queue option in uninstall cleanup and explicitly remove the cron hook before running the uninstall routines

## Testing
- wp cron event list *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dda21e2934832eb45c2b84260e4a0b