### PR TITLE
Clear plugin dir scan queue during deactivation and uninstall

### DIFF
--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -1383,6 +1383,14 @@ function sitepulse_deactivate_site() {
         wp_clear_scheduled_hook($hook);
     }
 
+    wp_clear_scheduled_hook('sitepulse_queue_plugin_dir_scan');
+
+    $queue_option = defined('SITEPULSE_PLUGIN_DIR_SCAN_QUEUE_OPTION')
+        ? SITEPULSE_PLUGIN_DIR_SCAN_QUEUE_OPTION
+        : 'sitepulse_plugin_dir_scan_queue';
+
+    delete_option($queue_option);
+
     sitepulse_remove_administrator_capability();
 
     if (!sitepulse_is_plugin_active_anywhere()) {

--- a/sitepulse_FR/uninstall.php
+++ b/sitepulse_FR/uninstall.php
@@ -34,6 +34,7 @@ $sitepulse_constants = [
     'SITEPULSE_TRANSIENT_RESOURCE_MONITOR_SNAPSHOT' => 'sitepulse_resource_monitor_snapshot',
     'SITEPULSE_PLUGIN_IMPACT_OPTION'              => 'sitepulse_plugin_impact_stats',
     'SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE'    => 'sitepulse_impact_loader_signature',
+    'SITEPULSE_PLUGIN_DIR_SCAN_QUEUE_OPTION'       => 'sitepulse_plugin_dir_scan_queue',
 ];
 
 foreach ($sitepulse_constants as $constant => $value) {
@@ -94,6 +95,7 @@ $options = [
     SITEPULSE_OPTION_CRON_WARNINGS,
     SITEPULSE_PLUGIN_IMPACT_OPTION,
     SITEPULSE_OPTION_IMPACT_LOADER_SIGNATURE,
+    SITEPULSE_PLUGIN_DIR_SCAN_QUEUE_OPTION,
 ];
 
 $transients = [
@@ -192,6 +194,8 @@ $cron_hooks = require __DIR__ . '/includes/cron-hooks.php';
 if (!is_array($cron_hooks)) {
     $cron_hooks = [];
 }
+
+wp_clear_scheduled_hook('sitepulse_queue_plugin_dir_scan');
 
 /**
  * Removes plugin data for a single site.

--- a/tests/phpunit/includes/stubs.php
+++ b/tests/phpunit/includes/stubs.php
@@ -31,6 +31,10 @@ if (!defined('SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES')) {
     define('SITEPULSE_OPTION_ALERT_COOLDOWN_MINUTES', 'sitepulse_alert_cooldown_minutes');
 }
 
+if (!defined('SITEPULSE_PLUGIN_DIR_SCAN_QUEUE_OPTION')) {
+    define('SITEPULSE_PLUGIN_DIR_SCAN_QUEUE_OPTION', 'sitepulse_plugin_dir_scan_queue');
+}
+
 if (!defined('SITEPULSE_OPTION_ERROR_ALERT_LOG_POINTER')) {
     define('SITEPULSE_OPTION_ERROR_ALERT_LOG_POINTER', 'sitepulse_error_alert_log_pointer');
 }

--- a/tests/phpunit/test-uninstall.php
+++ b/tests/phpunit/test-uninstall.php
@@ -57,5 +57,20 @@ class SitePulse_Uninstall_Test extends WP_UnitTestCase {
 
         remove_filter('sitepulse_required_capability', $filter);
     }
+
+    public function test_uninstall_clears_plugin_dir_scan_queue(): void {
+        wp_clear_scheduled_hook('sitepulse_queue_plugin_dir_scan');
+
+        wp_schedule_single_event(time() + MINUTE_IN_SECONDS, 'sitepulse_queue_plugin_dir_scan');
+        $this->assertNotFalse(wp_next_scheduled('sitepulse_queue_plugin_dir_scan'));
+
+        update_option(SITEPULSE_PLUGIN_DIR_SCAN_QUEUE_OPTION, ['plugin/plugin.php']);
+        $this->assertSame(['plugin/plugin.php'], get_option(SITEPULSE_PLUGIN_DIR_SCAN_QUEUE_OPTION));
+
+        $this->run_uninstall();
+
+        $this->assertFalse(wp_next_scheduled('sitepulse_queue_plugin_dir_scan'));
+        $this->assertFalse(get_option(SITEPULSE_PLUGIN_DIR_SCAN_QUEUE_OPTION));
+    }
 }
 


### PR DESCRIPTION
## Summary
- clear the scheduled plugin directory scan event and queue option during plugin deactivation
- ensure the uninstall routine removes the queue option and cron event
- cover the cleanup with new PHPUnit tests and shared test stubs

## Testing
- not run (phpunit not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dda1ff1300832eba1e168586a47b52