### PR TITLE
Refine performance thresholds and cover defaults in tests

### DIFF
--- a/sitepulse_FR/README.md
+++ b/sitepulse_FR/README.md
@@ -18,6 +18,14 @@ Sitepulse - JLG takes the pulse of your WordPress site, offering modules for:
 - Custom dashboards and multisite support
 - Customisable thresholds for speed alerts, uptime targets and revision cleanup suggestions
 
+### Key performance defaults
+
+- **Alerte de vitesse (avertissement / critique)** : 200 ms / 500 ms tant que vous n’avez pas défini vos propres seuils.
+- **Disponibilité minimale avant alerte** : 99 % par défaut, ajustable au dixième de point près.
+- **Limite de révisions recommandée** : 100 révisions avant que SitePulse ne signale un nettoyage.
+
+Ces valeurs peuvent être modifiées dans la page « Réglages » de SitePulse. Elles sont automatiquement utilisées par les modules concernés (analyseur de vitesse, tableaux de bord personnalisés, vérification de base de données) tout en conservant les anciennes valeurs si elles existent déjà.
+
 Toggle modules in the admin panel to keep it lightweight. Includes debug mode and cleanup options.
 
 ## Installation

--- a/sitepulse_FR/modules/speed_analyzer.php
+++ b/sitepulse_FR/modules/speed_analyzer.php
@@ -60,20 +60,35 @@ function sitepulse_speed_analyzer_page() {
 
     $default_speed_warning = defined('SITEPULSE_DEFAULT_SPEED_WARNING_MS') ? (int) SITEPULSE_DEFAULT_SPEED_WARNING_MS : 200;
     $default_speed_critical = defined('SITEPULSE_DEFAULT_SPEED_CRITICAL_MS') ? (int) SITEPULSE_DEFAULT_SPEED_CRITICAL_MS : 500;
+    $speed_warning_threshold = $default_speed_warning;
+    $speed_critical_threshold = $default_speed_critical;
 
     if (function_exists('sitepulse_get_speed_thresholds')) {
-        $speed_thresholds = sitepulse_get_speed_thresholds();
-        $speed_warning_threshold = isset($speed_thresholds['warning']) ? (int) $speed_thresholds['warning'] : $default_speed_warning;
-        $speed_critical_threshold = isset($speed_thresholds['critical']) ? (int) $speed_thresholds['critical'] : $default_speed_critical;
+        $fetched_thresholds = sitepulse_get_speed_thresholds();
+
+        if (is_array($fetched_thresholds)) {
+            if (isset($fetched_thresholds['warning']) && is_numeric($fetched_thresholds['warning'])) {
+                $speed_warning_threshold = (int) $fetched_thresholds['warning'];
+            }
+
+            if (isset($fetched_thresholds['critical']) && is_numeric($fetched_thresholds['critical'])) {
+                $speed_critical_threshold = (int) $fetched_thresholds['critical'];
+            }
+        }
     } else {
-        $speed_warning_threshold = (int) get_option(
-            defined('SITEPULSE_OPTION_SPEED_WARNING_MS') ? SITEPULSE_OPTION_SPEED_WARNING_MS : 'sitepulse_speed_warning_ms',
-            $default_speed_warning
-        );
-        $speed_critical_threshold = (int) get_option(
-            defined('SITEPULSE_OPTION_SPEED_CRITICAL_MS') ? SITEPULSE_OPTION_SPEED_CRITICAL_MS : 'sitepulse_speed_critical_ms',
-            $default_speed_critical
-        );
+        $warning_option_key = defined('SITEPULSE_OPTION_SPEED_WARNING_MS') ? SITEPULSE_OPTION_SPEED_WARNING_MS : 'sitepulse_speed_warning_ms';
+        $critical_option_key = defined('SITEPULSE_OPTION_SPEED_CRITICAL_MS') ? SITEPULSE_OPTION_SPEED_CRITICAL_MS : 'sitepulse_speed_critical_ms';
+
+        $stored_warning = get_option($warning_option_key, $default_speed_warning);
+        $stored_critical = get_option($critical_option_key, $default_speed_critical);
+
+        if (is_numeric($stored_warning)) {
+            $speed_warning_threshold = (int) $stored_warning;
+        }
+
+        if (is_numeric($stored_critical)) {
+            $speed_critical_threshold = (int) $stored_critical;
+        }
     }
 
     if ($speed_warning_threshold < 1) {

--- a/tests/phpunit/test-thresholds.php
+++ b/tests/phpunit/test-thresholds.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Tests for SitePulse threshold helpers and defaults.
+ */
+
+require_once __DIR__ . '/includes/stubs.php';
+
+class Sitepulse_Thresholds_Test extends WP_UnitTestCase {
+    public static function setUpBeforeClass(): void {
+        parent::setUpBeforeClass();
+
+        require_once dirname(__DIR__, 2) . '/sitepulse_FR/includes/functions.php';
+        require_once dirname(__DIR__, 2) . '/sitepulse_FR/includes/admin-settings.php';
+    }
+
+    protected function tearDown(): void {
+        delete_option(SITEPULSE_OPTION_SPEED_WARNING_MS);
+        delete_option(SITEPULSE_OPTION_SPEED_CRITICAL_MS);
+        delete_option(SITEPULSE_OPTION_UPTIME_WARNING_PERCENT);
+        delete_option(SITEPULSE_OPTION_REVISION_LIMIT);
+
+        parent::tearDown();
+    }
+
+    public function test_speed_thresholds_fall_back_to_defaults_when_missing(): void {
+        delete_option(SITEPULSE_OPTION_SPEED_WARNING_MS);
+        delete_option(SITEPULSE_OPTION_SPEED_CRITICAL_MS);
+
+        $thresholds = sitepulse_get_speed_thresholds();
+
+        $this->assertSame(SITEPULSE_DEFAULT_SPEED_WARNING_MS, $thresholds['warning']);
+        $this->assertSame(SITEPULSE_DEFAULT_SPEED_CRITICAL_MS, $thresholds['critical']);
+    }
+
+    public function test_speed_thresholds_use_configured_values(): void {
+        update_option(SITEPULSE_OPTION_SPEED_WARNING_MS, 325);
+        update_option(SITEPULSE_OPTION_SPEED_CRITICAL_MS, 780);
+
+        $thresholds = sitepulse_get_speed_thresholds();
+
+        $this->assertSame(325, $thresholds['warning']);
+        $this->assertSame(780, $thresholds['critical']);
+    }
+
+    public function test_speed_thresholds_enforce_relationship_and_defaults(): void {
+        update_option(SITEPULSE_OPTION_SPEED_WARNING_MS, 0);
+        update_option(SITEPULSE_OPTION_SPEED_CRITICAL_MS, 10);
+
+        $thresholds = sitepulse_get_speed_thresholds();
+
+        $this->assertSame(SITEPULSE_DEFAULT_SPEED_WARNING_MS, $thresholds['warning']);
+        $this->assertGreaterThan($thresholds['warning'], $thresholds['critical']);
+    }
+
+    public function test_uptime_warning_percentage_is_bounded(): void {
+        update_option(SITEPULSE_OPTION_UPTIME_WARNING_PERCENT, 150);
+        $this->assertSame(100.0, sitepulse_get_uptime_warning_percentage());
+
+        update_option(SITEPULSE_OPTION_UPTIME_WARNING_PERCENT, -10);
+        $this->assertSame(
+            (float) SITEPULSE_DEFAULT_UPTIME_WARNING_PERCENT,
+            sitepulse_get_uptime_warning_percentage()
+        );
+    }
+
+    public function test_revision_limit_respects_minimum_and_defaults(): void {
+        update_option(SITEPULSE_OPTION_REVISION_LIMIT, 0);
+        $this->assertSame(SITEPULSE_DEFAULT_REVISION_LIMIT, sitepulse_get_revision_limit());
+
+        update_option(SITEPULSE_OPTION_REVISION_LIMIT, 250);
+        $this->assertSame(250, sitepulse_get_revision_limit());
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the speed analyzer and custom dashboards read the saved threshold options with safe fallbacks to the legacy defaults
- document the default performance thresholds exposed in the settings screen
- add PHPUnit coverage for the helper functions that expose the speed, uptime and revision thresholds

## Testing
- php -l tests/phpunit/test-thresholds.php

------
https://chatgpt.com/codex/tasks/task_e_68de9f34d4a4832eb559f6ce621062da