### PR TITLE
Add dashboard preview block

### DIFF
--- a/sitepulse_FR/blocks/dashboard-preview/README.md
+++ b/sitepulse_FR/blocks/dashboard-preview/README.md
@@ -1,0 +1,28 @@
+# Bloc "Aperçu du tableau de bord"
+
+Ce bloc Gutenberg affiche une synthèse des principales cartes SitePulse (Vitesse, Uptime, Base de données et Journal d’erreurs) directement dans vos contenus.
+
+## Fonctionnement
+
+- Les données affichées proviennent des modules existants (Speed Analyzer, Uptime Tracker, Database Optimizer et Log Analyzer).
+- Le rendu est généré côté serveur afin de refléter fidèlement les valeurs visibles dans l’interface d’administration.
+- Dans l’éditeur, une prévisualisation temps réel est fournie à l’aide du composant `ServerSideRender`.
+
+## Options du bloc
+
+Chaque carte peut être masquée depuis la colonne latérale :
+
+- **Vitesse** – affiche le dernier temps de traitement côté serveur et son statut associé.
+- **Disponibilité** – montre le pourcentage de disponibilité calculé sur les dernières vérifications.
+- **Base de données** – compare le nombre de révisions à la limite recommandée.
+- **Journal d’erreurs** – résume les derniers évènements critiques détectés dans le fichier `debug.log`.
+
+## États dégradés
+
+Lorsque l’un des modules requis est désactivé, une notice informative s’affiche dans l’éditeur et le rendu serveur masque automatiquement la carte correspondante.
+
+Si aucune métrique n’est disponible (par exemple sur un nouveau site), le bloc affiche un message neutre plutôt qu’un graphique vide.
+
+## Dépendances
+
+Pour garantir le style et l’accessibilité, le bloc réutilise les mêmes feuilles de style que le tableau de bord SitePulse (`modules/css/custom-dashboard.css`).

--- a/sitepulse_FR/blocks/dashboard-preview/block.json
+++ b/sitepulse_FR/blocks/dashboard-preview/block.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 3,
+  "name": "sitepulse/dashboard-preview",
+  "title": "Aperçu du tableau de bord SitePulse",
+  "category": "widgets",
+  "icon": "dashboard",
+  "description": "Affiche un résumé des cartes SitePulse directement dans le contenu.",
+  "textdomain": "sitepulse",
+  "supports": {
+    "html": false
+  },
+  "attributes": {
+    "showSpeed": {
+      "type": "boolean",
+      "default": true
+    },
+    "showUptime": {
+      "type": "boolean",
+      "default": true
+    },
+    "showDatabase": {
+      "type": "boolean",
+      "default": true
+    },
+    "showLogs": {
+      "type": "boolean",
+      "default": true
+    }
+  }
+}

--- a/sitepulse_FR/blocks/dashboard-preview/editor.js
+++ b/sitepulse_FR/blocks/dashboard-preview/editor.js
@@ -1,0 +1,121 @@
+(function (wp) {
+    if (!wp || !wp.blocks) {
+        return;
+    }
+
+    var __ = wp.i18n.__;
+    var sprintf = wp.i18n.sprintf;
+    var useMemo = wp.element.useMemo;
+    var Fragment = wp.element.Fragment;
+    var registerBlockType = wp.blocks.registerBlockType;
+    var InspectorControls = wp.blockEditor.InspectorControls || wp.editor.InspectorControls;
+    var useBlockProps = wp.blockEditor.useBlockProps || wp.editor.useBlockProps;
+    var PanelBody = wp.components.PanelBody;
+    var ToggleControl = wp.components.ToggleControl;
+    var Notice = wp.components.Notice;
+    var ServerSideRender = wp.serverSideRender;
+
+    var BLOCK_NAME = 'sitepulse/dashboard-preview';
+    var MODULE_KEYS = ['speed', 'uptime', 'database', 'logs'];
+
+    function getConfig() {
+        var config = window.SitePulseDashboardPreviewData || {};
+        if (!config.modules) {
+            config.modules = {};
+        }
+        if (!config.strings) {
+            config.strings = {};
+        }
+        return config;
+    }
+
+    registerBlockType(BLOCK_NAME, {
+        edit: function (props) {
+            props = props || {};
+            var attributes = props.attributes || {};
+            var setAttributes = props.setAttributes || function () {};
+            var blockProps = useBlockProps();
+            var config = getConfig();
+            var modules = config.modules;
+
+            var inactiveNotice = useMemo(function () {
+                var inactive = MODULE_KEYS.filter(function (key) {
+                    return modules[key] && modules[key].enabled === false;
+                });
+
+                if (!inactive.length) {
+                    return null;
+                }
+
+                var labels = inactive.map(function (key) {
+                    return modules[key].label || key;
+                });
+
+                var template = config.strings.inactiveNotice || __('Les modules suivants sont désactivés : %s', 'sitepulse');
+
+                return sprintf(template, labels.join(', '));
+            }, [modules]);
+
+            return wp.element.createElement(
+                Fragment,
+                null,
+                wp.element.createElement(
+                    InspectorControls,
+                    null,
+                    wp.element.createElement(
+                        PanelBody,
+                        { title: __('Affichage des modules', 'sitepulse'), initialOpen: true },
+                        MODULE_KEYS.map(function (key) {
+                            var attributeKey = 'show' + key.charAt(0).toUpperCase() + key.slice(1);
+                            var isEnabled = attributes.hasOwnProperty(attributeKey) ? attributes[attributeKey] : true;
+                            var label = (modules[key] && modules[key].controlLabel) || (modules[key] && modules[key].label) || key;
+
+                            return wp.element.createElement(ToggleControl, {
+                                key: key,
+                                label: label,
+                                checked: !!isEnabled,
+                                onChange: function (value) {
+                                    var next = {};
+                                    next[attributeKey] = !!value;
+                                    setAttributes(next);
+                                },
+                                disabled: modules[key] && modules[key].enabled === false
+                            });
+                        })
+                    ),
+                    wp.element.createElement(
+                        PanelBody,
+                        { title: __('Aide', 'sitepulse'), initialOpen: false },
+                        wp.element.createElement(
+                            'p',
+                            null,
+                            __('Ce bloc affiche un aperçu des principales métriques suivies par SitePulse.', 'sitepulse')
+                        ),
+                        wp.element.createElement(
+                            'p',
+                            null,
+                            __('Les données proviennent des derniers relevés enregistrés. Utilisez les options ci-dessus pour masquer les cartes non pertinentes.', 'sitepulse')
+                        )
+                    )
+                ),
+                wp.element.createElement(
+                    'div',
+                    blockProps,
+                    inactiveNotice &&
+                        wp.element.createElement(
+                            Notice,
+                            { status: 'warning', isDismissible: false, className: 'sitepulse-dashboard-preview-block__notice' },
+                            inactiveNotice
+                        ),
+                    wp.element.createElement(ServerSideRender, {
+                        block: BLOCK_NAME,
+                        attributes: attributes
+                    })
+                )
+            );
+        },
+        save: function () {
+            return null;
+        }
+    });
+})(window.wp);

--- a/sitepulse_FR/blocks/dashboard-preview/render.php
+++ b/sitepulse_FR/blocks/dashboard-preview/render.php
@@ -1,0 +1,309 @@
+<?php
+/**
+ * Render callback for the SitePulse dashboard preview block.
+ *
+ * @package SitePulse
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!function_exists('sitepulse_render_dashboard_preview_block')) {
+    /**
+     * Builds a human readable summary list for a chart configuration.
+     *
+     * @param array|null $chart Chart configuration as assembled by the dashboard module.
+     *
+     * @return string HTML list.
+     */
+    function sitepulse_dashboard_preview_render_dataset_summary($chart) {
+        if (!is_array($chart)) {
+            return '';
+        }
+
+        $labels = isset($chart['labels']) && is_array($chart['labels']) ? $chart['labels'] : [];
+        $datasets = isset($chart['datasets']) && is_array($chart['datasets']) ? $chart['datasets'] : [];
+
+        if (empty($labels) || empty($datasets)) {
+            return '';
+        }
+
+        $items = [];
+
+        foreach ($labels as $index => $label) {
+            $values = [];
+
+            foreach ($datasets as $dataset) {
+                if (!is_array($dataset) || !isset($dataset['data']) || !is_array($dataset['data'])) {
+                    continue;
+                }
+
+                if (!array_key_exists($index, $dataset['data'])) {
+                    continue;
+                }
+
+                $value = $dataset['data'][$index];
+
+                if (is_numeric($value)) {
+                    $numeric_value = (float) $value;
+                    $precision = (floor($numeric_value) === $numeric_value) ? 0 : 2;
+                    $values[] = number_format_i18n($numeric_value, $precision);
+                } elseif (is_scalar($value)) {
+                    $values[] = (string) $value;
+                }
+            }
+
+            if (empty($values)) {
+                continue;
+            }
+
+            $items[] = sprintf(
+                '<li><span class="sitepulse-preview-list__label">%1$s</span><span class="sitepulse-preview-list__value">%2$s</span></li>',
+                esc_html(wp_strip_all_tags((string) $label)),
+                esc_html(implode(', ', $values))
+            );
+        }
+
+        if (empty($items)) {
+            return '';
+        }
+
+        return '<ul class="sitepulse-preview-list">' . implode('', $items) . '</ul>';
+    }
+
+    /**
+     * Renders the chart container for the preview block.
+     *
+     * @param string     $canvas_id Unique identifier for the canvas element.
+     * @param array|null $chart     Chart payload.
+     *
+     * @return string HTML markup for the chart area.
+     */
+    function sitepulse_dashboard_preview_render_chart_area($canvas_id, $chart) {
+        $has_chart = is_array($chart) && !empty($chart) && empty($chart['empty']) && !empty($chart['datasets']);
+
+        if ($has_chart) {
+            $chart_data = wp_json_encode($chart);
+            $chart_attribute = is_string($chart_data) ? $chart_data : '';
+            $summary = sitepulse_dashboard_preview_render_dataset_summary($chart);
+
+            return sprintf(
+                '<div class="sitepulse-chart-container"><canvas id="%1$s" data-sitepulse-chart="%2$s"></canvas>%3$s</div>',
+                esc_attr($canvas_id),
+                esc_attr($chart_attribute),
+                $summary
+            );
+        }
+
+        return sprintf(
+            '<div class="sitepulse-chart-container"><div class="sitepulse-chart-placeholder">%s</div></div>',
+            esc_html__('Pas encore de mesures disponibles pour ce graphique.', 'sitepulse')
+        );
+    }
+
+    /**
+     * Retrieves status metadata (label, accessible text, icon) for a given status key.
+     *
+     * @param string $status        Status key.
+     * @param array  $status_labels Map of status labels.
+     *
+     * @return array
+     */
+    function sitepulse_dashboard_preview_get_status_meta($status, $status_labels) {
+        if (is_array($status_labels) && isset($status_labels[$status])) {
+            return $status_labels[$status];
+        }
+
+        if (is_array($status_labels) && isset($status_labels['status-warn'])) {
+            return $status_labels['status-warn'];
+        }
+
+        return [
+            'label' => __('Indisponible', 'sitepulse'),
+            'sr'    => __('Statut non disponible', 'sitepulse'),
+            'icon'  => 'ℹ️',
+        ];
+    }
+
+    /**
+     * Server-side render callback for the dashboard preview block.
+     *
+     * @param array  $attributes Block attributes.
+     * @param string $content    Saved content (unused).
+     * @param object $block      Block instance (unused).
+     *
+     * @return string
+     */
+    function sitepulse_render_dashboard_preview_block($attributes, $content = '', $block = null) {
+        unset($content, $block);
+
+        $defaults = [
+            'showSpeed'    => true,
+            'showUptime'   => true,
+            'showDatabase' => true,
+            'showLogs'     => true,
+        ];
+
+        $attributes = is_array($attributes) ? $attributes : [];
+        $attributes = wp_parse_args($attributes, $defaults);
+
+        $show_speed = !empty($attributes['showSpeed']);
+        $show_uptime = !empty($attributes['showUptime']);
+        $show_database = !empty($attributes['showDatabase']);
+        $show_logs = !empty($attributes['showLogs']);
+
+        if (!function_exists('sitepulse_get_dashboard_preview_context')) {
+            return '<div class="wp-block-sitepulse-dashboard-preview sitepulse-dashboard-preview__empty">'
+                . esc_html__('Activez le module « Tableaux de bord personnalisés » pour utiliser ce bloc.', 'sitepulse')
+                . '</div>';
+        }
+
+        $context = sitepulse_get_dashboard_preview_context();
+        $modules = isset($context['modules']) && is_array($context['modules']) ? $context['modules'] : [];
+        $status_labels = isset($context['status_labels']) ? $context['status_labels'] : [];
+
+        $cards = [];
+        $unique_prefix = sanitize_html_class('sitepulse-preview-' . uniqid());
+
+        // Speed card.
+        if ($show_speed && isset($modules['speed']) && !empty($modules['speed']['enabled']) && isset($modules['speed']['card'])) {
+            $card = $modules['speed']['card'];
+            $chart = isset($modules['speed']['chart']) ? $modules['speed']['chart'] : null;
+            $thresholds = isset($modules['speed']['thresholds']) ? $modules['speed']['thresholds'] : [];
+            $warning_threshold = isset($thresholds['warning']) ? (int) $thresholds['warning'] : (defined('SITEPULSE_DEFAULT_SPEED_WARNING_MS') ? (int) SITEPULSE_DEFAULT_SPEED_WARNING_MS : 200);
+            $critical_threshold = isset($thresholds['critical']) ? (int) $thresholds['critical'] : (defined('SITEPULSE_DEFAULT_SPEED_CRITICAL_MS') ? (int) SITEPULSE_DEFAULT_SPEED_CRITICAL_MS : 500);
+            $status_meta = sitepulse_dashboard_preview_get_status_meta(isset($card['status']) ? $card['status'] : '', $status_labels);
+            $canvas_id = $unique_prefix . '-speed-chart';
+
+            $cards[] = sprintf(
+                '<section class="sitepulse-card sitepulse-card--speed"><div class="sitepulse-card-header"><h3>%1$s</h3></div><p class="sitepulse-card-subtitle">%2$s</p>%3$s<p class="sitepulse-metric"><span class="status-badge %4$s" aria-hidden="true"><span class="status-icon">%5$s</span><span class="status-text">%6$s</span></span><span class="screen-reader-text">%7$s</span><span class="sitepulse-metric-value">%8$s</span></p><p class="description">%9$s</p></section>',
+                esc_html__('Performance PHP', 'sitepulse'),
+                esc_html__('Dernier temps de traitement mesuré lors d’un scan récent.', 'sitepulse'),
+                sitepulse_dashboard_preview_render_chart_area($canvas_id, $chart),
+                esc_attr(isset($card['status']) ? $card['status'] : ''),
+                esc_html($status_meta['icon']),
+                esc_html($status_meta['label']),
+                esc_html($status_meta['sr']),
+                esc_html(isset($card['display']) ? $card['display'] : __('N/A', 'sitepulse')),
+                esc_html(sprintf(
+                    /* translators: 1: warning threshold in ms, 2: critical threshold in ms */
+                    __('En dessous de %1$d ms, tout va bien. Au-delà de %2$d ms, investiguez les plugins ou l’hébergement.', 'sitepulse'),
+                    $warning_threshold,
+                    $critical_threshold
+                ))
+            );
+        }
+
+        // Uptime card.
+        if ($show_uptime && isset($modules['uptime']) && !empty($modules['uptime']['enabled']) && isset($modules['uptime']['card'])) {
+            $card = $modules['uptime']['card'];
+            $chart = isset($modules['uptime']['chart']) ? $modules['uptime']['chart'] : null;
+            $status_meta = sitepulse_dashboard_preview_get_status_meta(isset($card['status']) ? $card['status'] : '', $status_labels);
+            $canvas_id = $unique_prefix . '-uptime-chart';
+            $percentage = isset($card['percentage']) ? round((float) $card['percentage'], 2) : 0;
+
+            $cards[] = sprintf(
+                '<section class="sitepulse-card sitepulse-card--uptime"><div class="sitepulse-card-header"><h3>%1$s</h3></div><p class="sitepulse-card-subtitle">%2$s</p>%3$s<p class="sitepulse-metric"><span class="status-badge %4$s" aria-hidden="true"><span class="status-icon">%5$s</span><span class="status-text">%6$s</span></span><span class="screen-reader-text">%7$s</span><span class="sitepulse-metric-value">%8$s<span class="sitepulse-metric-unit">%9$s</span></span></p><p class="description">%10$s</p></section>',
+                esc_html__('Disponibilité', 'sitepulse'),
+                esc_html__('Taux de réussite des 30 dernières vérifications horaires.', 'sitepulse'),
+                sitepulse_dashboard_preview_render_chart_area($canvas_id, $chart),
+                esc_attr(isset($card['status']) ? $card['status'] : ''),
+                esc_html($status_meta['icon']),
+                esc_html($status_meta['label']),
+                esc_html($status_meta['sr']),
+                esc_html(number_format_i18n($percentage, 2)),
+                esc_html__('%', 'sitepulse'),
+                esc_html__('Chaque barre représente une vérification de disponibilité programmée.', 'sitepulse')
+            );
+        }
+
+        // Database card.
+        if ($show_database && isset($modules['database']) && !empty($modules['database']['enabled']) && isset($modules['database']['card'])) {
+            $card = $modules['database']['card'];
+            $chart = isset($modules['database']['chart']) ? $modules['database']['chart'] : null;
+            $status_meta = sitepulse_dashboard_preview_get_status_meta(isset($card['status']) ? $card['status'] : '', $status_labels);
+            $canvas_id = $unique_prefix . '-database-chart';
+            $limit = isset($card['limit']) ? (int) $card['limit'] : 0;
+            $revision_count = isset($card['revisions']) ? (int) $card['revisions'] : 0;
+
+            $cards[] = sprintf(
+                '<section class="sitepulse-card sitepulse-card--database"><div class="sitepulse-card-header"><h3>%1$s</h3></div><p class="sitepulse-card-subtitle">%2$s</p>%3$s<p class="sitepulse-metric"><span class="status-badge %4$s" aria-hidden="true"><span class="status-icon">%5$s</span><span class="status-text">%6$s</span></span><span class="screen-reader-text">%7$s</span><span class="sitepulse-metric-value">%8$s<span class="sitepulse-metric-unit">%9$s</span></span></p><p class="description">%10$s</p></section>',
+                esc_html__('Santé de la base', 'sitepulse'),
+                esc_html__('Volume des révisions par rapport au budget défini.', 'sitepulse'),
+                sitepulse_dashboard_preview_render_chart_area($canvas_id, $chart),
+                esc_attr(isset($card['status']) ? $card['status'] : ''),
+                esc_html($status_meta['icon']),
+                esc_html($status_meta['label']),
+                esc_html($status_meta['sr']),
+                esc_html(number_format_i18n($revision_count)),
+                esc_html__('révisions', 'sitepulse'),
+                esc_html(sprintf(
+                    /* translators: %d: recommended revision limit */
+                    __('Essayez de rester sous la barre des %d révisions pour éviter de gonfler la table des articles.', 'sitepulse'),
+                    $limit
+                ))
+            );
+        }
+
+        // Logs card.
+        if ($show_logs && isset($modules['logs']) && !empty($modules['logs']['enabled']) && isset($modules['logs']['card'])) {
+            $card = $modules['logs']['card'];
+            $chart = isset($modules['logs']['chart']) ? $modules['logs']['chart'] : null;
+            $status_meta = sitepulse_dashboard_preview_get_status_meta(isset($card['status']) ? $card['status'] : '', $status_labels);
+            $canvas_id = $unique_prefix . '-logs-chart';
+            $counts = isset($card['counts']) && is_array($card['counts']) ? $card['counts'] : [];
+
+            $legend_items = [
+                [__('Erreurs fatales', 'sitepulse'), 'fatal', '#a0141e'],
+                [__('Avertissements', 'sitepulse'), 'warning', '#8a6100'],
+                [__('Notices', 'sitepulse'), 'notice', '#2196F3'],
+                [__('Obsolescences', 'sitepulse'), 'deprecated', '#9C27B0'],
+            ];
+
+            $legend_html_parts = [];
+
+            foreach ($legend_items as $item) {
+                list($label, $key, $color) = $item;
+                $value = isset($counts[$key]) ? (int) $counts[$key] : 0;
+                $legend_html_parts[] = sprintf(
+                    '<li><span class="label"><span class="badge" style="background-color: %1$s;"></span>%2$s</span><span class="value">%3$s</span></li>',
+                    esc_attr($color),
+                    esc_html($label),
+                    esc_html(number_format_i18n($value))
+                );
+            }
+
+            $legend_html = '<ul class="sitepulse-legend">' . implode('', $legend_html_parts) . '</ul>';
+
+            $cards[] = sprintf(
+                '<section class="sitepulse-card sitepulse-card--logs"><div class="sitepulse-card-header"><h3>%1$s</h3></div><p class="sitepulse-card-subtitle">%2$s</p>%3$s<p class="sitepulse-metric"><span class="status-badge %4$s" aria-hidden="true"><span class="status-icon">%5$s</span><span class="status-text">%6$s</span></span><span class="screen-reader-text">%7$s</span><span class="sitepulse-metric-value">%8$s</span></p>%9$s<p class="description">%10$s</p></section>',
+                esc_html__('Journal d’erreurs', 'sitepulse'),
+                esc_html__('Répartition des évènements récents trouvés dans le fichier debug.log.', 'sitepulse'),
+                sitepulse_dashboard_preview_render_chart_area($canvas_id, $chart),
+                esc_attr(isset($card['status']) ? $card['status'] : ''),
+                esc_html($status_meta['icon']),
+                esc_html($status_meta['label']),
+                esc_html($status_meta['sr']),
+                esc_html(isset($card['summary']) ? $card['summary'] : __('Aucune donnée disponible.', 'sitepulse')),
+                $legend_html,
+                esc_html__('Analysez le journal complet depuis l’interface SitePulse pour plus de détails.', 'sitepulse')
+            );
+        }
+
+        if (empty($cards)) {
+            return '<div class="wp-block-sitepulse-dashboard-preview sitepulse-dashboard-preview__empty">'
+                . esc_html__('Aucune carte à afficher pour le moment. Activez les modules souhaités ou collectez davantage de données.', 'sitepulse')
+                . '</div>';
+        }
+
+        $header = sprintf(
+            '<div class="sitepulse-dashboard-preview__header"><h3>%1$s</h3><p>%2$s</p></div>',
+            esc_html__('Aperçu SitePulse', 'sitepulse'),
+            esc_html__('Dernières mesures agrégées par vos modules actifs.', 'sitepulse')
+        );
+
+        return '<div class="wp-block-sitepulse-dashboard-preview">' . $header
+            . '<div class="sitepulse-grid">' . implode('', $cards) . '</div></div>';
+    }
+}

--- a/sitepulse_FR/blocks/dashboard-preview/style.css
+++ b/sitepulse_FR/blocks/dashboard-preview/style.css
@@ -1,0 +1,87 @@
+.wp-block-sitepulse-dashboard-preview {
+    margin: 0 auto;
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-grid {
+    margin-top: 0;
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-card {
+    height: 100%;
+}
+
+.sitepulse-dashboard-preview-block__notice {
+    margin-bottom: 16px;
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-chart-container {
+    min-height: 180px;
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-chart-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    text-align: center;
+    padding: 32px 16px;
+    border: 1px dashed var(--wp-admin-color-gray-200, #c3c4c7);
+    border-radius: 6px;
+    color: var(--wp-admin-color-gray-700, #50575e);
+    font-size: 13px;
+    background: rgba(255, 255, 255, 0.7);
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-chart-container canvas + .sitepulse-preview-list {
+    margin-top: 12px;
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-dashboard-preview__header {
+    text-align: center;
+    margin-bottom: 24px;
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-dashboard-preview__header h3 {
+    margin: 0;
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-dashboard-preview__empty {
+    text-align: center;
+    padding: 24px;
+    border: 1px dashed var(--wp-admin-color-gray-200, #c3c4c7);
+    border-radius: 6px;
+    color: var(--wp-admin-color-gray-700, #50575e);
+    background: var(--wp-admin-color-gray-0, #ffffff);
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-preview-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    font-size: 13px;
+    max-height: 220px;
+    overflow-y: auto;
+    border: 1px solid var(--wp-admin-color-gray-200, #c3c4c7);
+    border-radius: 6px;
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-preview-list li {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--wp-admin-color-gray-100, #dcdcde);
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-preview-list li:last-child {
+    border-bottom: none;
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-preview-list__label {
+    font-weight: 600;
+    color: var(--wp-admin-color-gray-700, #50575e);
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-preview-list__value {
+    color: var(--wp-admin-color-gray-800, #2c3338);
+}


### PR DESCRIPTION
## Summary
- extract reusable dashboard snapshot helper so both the admin page and new block consume the same cards and charts
- add a server-rendered Gutenberg block (sitepulse/dashboard-preview) with editor UI, styles, and documentation for displaying SitePulse metrics on the front-end
- register the block and its assets during init and expose module availability to the editor for inline notices

## Testing
- php -l sitepulse_FR/modules/custom_dashboards.php
- php -l sitepulse_FR/sitepulse.php
- php -l sitepulse_FR/blocks/dashboard-preview/render.php

------
https://chatgpt.com/codex/tasks/task_e_68de9f36b184832ebed21e7190f3366f