### PR TITLE
Adjust dashboard preview list layout for small screens

### DIFF
--- a/sitepulse_FR/blocks/dashboard-preview/style.css
+++ b/sitepulse_FR/blocks/dashboard-preview/style.css
@@ -69,6 +69,9 @@
     display: flex;
     justify-content: space-between;
     gap: 12px;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    row-gap: 6px;
     padding: 8px 12px;
     border-bottom: 1px solid var(--wp-admin-color-gray-100, #dcdcde);
 }
@@ -84,4 +87,17 @@
 
 .wp-block-sitepulse-dashboard-preview .sitepulse-preview-list__value {
     color: var(--wp-admin-color-gray-800, #2c3338);
+}
+
+@media (max-width: 480px) {
+    .wp-block-sitepulse-dashboard-preview .sitepulse-preview-list li {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 6px;
+    }
+
+    .wp-block-sitepulse-dashboard-preview .sitepulse-preview-list__label,
+    .wp-block-sitepulse-dashboard-preview .sitepulse-preview-list__value {
+        width: 100%;
+    }
 }


### PR DESCRIPTION
## Summary
- allow dashboard preview list items to wrap content and align values from the top
- add a mobile breakpoint to stack labels and values for improved readability on narrow screens

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dec533a538832e8fa72f0fa7f32554