### PR TITLE
Add shared module selector navigation for module pages

### DIFF
--- a/sitepulse_FR/includes/module-selector.php
+++ b/sitepulse_FR/includes/module-selector.php
@@ -1,0 +1,183 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Returns the definitions for SitePulse module pages that should appear in the selector.
+ *
+ * @return array<string, array{page:string,label:string}>
+ */
+function sitepulse_get_module_selector_definitions() {
+    $definitions = [
+        'speed_analyzer' => [
+            'page'  => 'sitepulse-speed',
+            'label' => __('Speed Analyzer', 'sitepulse'),
+        ],
+        'uptime_tracker' => [
+            'page'  => 'sitepulse-uptime',
+            'label' => __('Uptime Tracker', 'sitepulse'),
+        ],
+        'plugin_impact_scanner' => [
+            'page'  => 'sitepulse-plugins',
+            'label' => __('Plugin Impact Scanner', 'sitepulse'),
+        ],
+        'resource_monitor' => [
+            'page'  => 'sitepulse-resources',
+            'label' => __('Resource Monitor', 'sitepulse'),
+        ],
+        'database_optimizer' => [
+            'page'  => 'sitepulse-db',
+            'label' => __('Database Optimizer', 'sitepulse'),
+        ],
+        'maintenance_advisor' => [
+            'page'  => 'sitepulse-maintenance',
+            'label' => __('Maintenance Advisor', 'sitepulse'),
+        ],
+        'log_analyzer' => [
+            'page'  => 'sitepulse-logs',
+            'label' => __('Log Analyzer', 'sitepulse'),
+        ],
+        'ai_insights' => [
+            'page'  => 'sitepulse-ai',
+            'label' => __('AI Insights', 'sitepulse'),
+        ],
+    ];
+
+    /**
+     * Filters the module selector definitions.
+     *
+     * @param array $definitions The list of module definitions keyed by module slug.
+     */
+    return apply_filters('sitepulse_module_selector_definitions', $definitions);
+}
+
+/**
+ * Builds the list of enabled module selector items including URLs.
+ *
+ * @return array<int, array{slug:string,label:string,url:string}>
+ */
+function sitepulse_get_module_selector_items() {
+    $active_modules = array_map('strval', (array) get_option(SITEPULSE_OPTION_ACTIVE_MODULES, []));
+    $definitions    = sitepulse_get_module_selector_definitions();
+    $items          = [];
+
+    foreach ($active_modules as $module_key) {
+        if (!isset($definitions[$module_key])) {
+            continue;
+        }
+
+        $definition = $definitions[$module_key];
+        $page_slug  = isset($definition['page']) ? (string) $definition['page'] : '';
+        $label      = isset($definition['label']) ? $definition['label'] : '';
+
+        if ($page_slug === '' || $label === '') {
+            continue;
+        }
+
+        $items[] = [
+            'slug'  => $page_slug,
+            'label' => $label,
+            'url'   => admin_url('admin.php?page=' . $page_slug),
+        ];
+    }
+
+    /**
+     * Filters the rendered selector items.
+     *
+     * @param array $items          Prepared selector entries.
+     * @param array $active_modules Active module identifiers from the settings option.
+     * @param array $definitions    Module selector definitions keyed by module slug.
+     */
+    return apply_filters('sitepulse_module_selector_items', $items, $active_modules, $definitions);
+}
+
+/**
+ * Enqueues the shared module selector stylesheet when viewing a SitePulse module screen.
+ *
+ * @param string $hook_suffix Current admin page identifier.
+ * @return void
+ */
+function sitepulse_module_selector_enqueue_style($hook_suffix) {
+    $definitions = sitepulse_get_module_selector_definitions();
+    $valid_hooks = [];
+
+    foreach ($definitions as $definition) {
+        if (!isset($definition['page'])) {
+            continue;
+        }
+
+        $page_slug = (string) $definition['page'];
+
+        if ($page_slug === '') {
+            continue;
+        }
+
+        $valid_hooks[] = 'sitepulse-dashboard_page_' . $page_slug;
+    }
+
+    if (!in_array($hook_suffix, $valid_hooks, true)) {
+        return;
+    }
+
+    wp_enqueue_style(
+        'sitepulse-module-selector',
+        SITEPULSE_URL . 'modules/css/module-selector.css',
+        [],
+        SITEPULSE_VERSION
+    );
+}
+add_action('admin_enqueue_scripts', 'sitepulse_module_selector_enqueue_style');
+
+/**
+ * Outputs the module selector navigation component.
+ *
+ * @param string $current_page Current module page slug (e.g. "sitepulse-speed").
+ * @return void
+ */
+function sitepulse_render_module_selector($current_page = '') {
+    $items = sitepulse_get_module_selector_items();
+
+    if (empty($items)) {
+        return;
+    }
+
+    $current_page = is_string($current_page) ? $current_page : '';
+
+    static $instance = 0;
+    $instance++;
+
+    $select_id = 'sitepulse-module-selector-' . $instance;
+    $label_id  = $select_id . '-label';
+    $action    = admin_url('admin.php');
+    ?>
+    <nav class="sitepulse-module-selector" aria-label="<?php echo esc_attr__('SitePulse module navigation', 'sitepulse'); ?>">
+        <form class="sitepulse-module-selector__form" action="<?php echo esc_url($action); ?>" method="get">
+            <label id="<?php echo esc_attr($label_id); ?>" for="<?php echo esc_attr($select_id); ?>">
+                <?php esc_html_e('Jump to module', 'sitepulse'); ?>
+            </label>
+            <div class="sitepulse-module-selector__controls">
+                <select
+                    name="page"
+                    id="<?php echo esc_attr($select_id); ?>"
+                    class="sitepulse-module-selector__select"
+                    aria-describedby="<?php echo esc_attr($label_id); ?>"
+                    onchange="if(this.value){this.form.submit();}"
+                >
+                    <option value="">
+                        <?php esc_html_e('Select a module', 'sitepulse'); ?>
+                    </option>
+                    <?php foreach ($items as $item) : ?>
+                        <option value="<?php echo esc_attr($item['slug']); ?>" <?php selected($current_page, $item['slug']); ?>>
+                            <?php echo esc_html($item['label']); ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+                <button type="submit" class="sitepulse-module-selector__submit">
+                    <?php esc_html_e('Open module', 'sitepulse'); ?>
+                </button>
+            </div>
+        </form>
+    </nav>
+    <?php
+}

--- a/sitepulse_FR/modules/ai_insights.php
+++ b/sitepulse_FR/modules/ai_insights.php
@@ -1378,6 +1378,11 @@ function sitepulse_ai_insights_page() {
     }
 
     ?>
+    <?php
+    if (function_exists('sitepulse_render_module_selector')) {
+        sitepulse_render_module_selector('sitepulse-ai');
+    }
+    ?>
     <div class="wrap">
         <h1><span class="dashicons-before dashicons-superhero"></span> <?php esc_html_e('Analyses par IA', 'sitepulse'); ?></h1>
         <p><?php esc_html_e("Obtenez des recommandations personnalisées pour votre site en analysant ses données de performance avec l'IA Gemini de Google.", 'sitepulse'); ?></p>

--- a/sitepulse_FR/modules/css/module-selector.css
+++ b/sitepulse_FR/modules/css/module-selector.css
@@ -1,0 +1,116 @@
+.sitepulse-module-selector {
+    position: sticky;
+    top: 32px;
+    z-index: 100;
+    display: block;
+    margin: 16px 0;
+    padding: 12px 16px;
+    background: var(--wp-admin-color-gray-0, #ffffff);
+    border: 1px solid var(--wp-admin-color-gray-200, #c3c4c7);
+    border-radius: 6px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.sitepulse-module-selector__form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin: 0;
+}
+
+.sitepulse-module-selector__form label {
+    font-weight: 600;
+    font-size: 14px;
+}
+
+.sitepulse-module-selector__controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.sitepulse-module-selector__select {
+    flex: 1 1 220px;
+    min-width: 200px;
+    max-width: 100%;
+    padding: 0.6em 2.6em 0.6em 0.75em;
+    font-size: 15px;
+    line-height: 1.4;
+    border: 1px solid var(--wp-admin-color-gray-300, #a7aaad);
+    border-radius: 4px;
+    background-color: var(--wp-admin-color-gray-0, #ffffff);
+    color: inherit;
+    min-height: 44px;
+}
+
+.sitepulse-module-selector__select:focus {
+    outline: 2px solid var(--wp-admin-theme-color, #2271b1);
+    outline-offset: 2px;
+}
+
+.sitepulse-module-selector__submit {
+    flex: 0 0 auto;
+    padding: 0.6em 1.2em;
+    font-size: 15px;
+    line-height: 1.4;
+    border-radius: 4px;
+    border: 1px solid var(--wp-admin-theme-color, #2271b1);
+    background-color: var(--wp-admin-theme-color, #2271b1);
+    color: var(--wp-admin-color-gray-0, #ffffff);
+    cursor: pointer;
+    min-height: 44px;
+}
+
+.sitepulse-module-selector__submit:focus {
+    outline: 2px solid var(--wp-admin-theme-color-darker-20, #1e5a8a);
+    outline-offset: 2px;
+}
+
+.sitepulse-module-selector__submit:hover,
+.sitepulse-module-selector__submit:focus-visible {
+    background-color: var(--wp-admin-theme-color-darker-20, #1e5a8a);
+    border-color: var(--wp-admin-theme-color-darker-20, #1e5a8a);
+}
+
+@media (max-width: 782px) {
+    .sitepulse-module-selector {
+        top: 0;
+        margin: 12px -16px 16px;
+        border-radius: 0;
+    }
+
+    .sitepulse-module-selector__controls {
+        flex-direction: column;
+    }
+
+    .sitepulse-module-selector__select,
+    .sitepulse-module-selector__submit {
+        width: 100%;
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    .sitepulse-module-selector {
+        background: var(--wp-admin-color-gray-900, #1d2327);
+        border-color: var(--wp-admin-color-gray-700, #50575e);
+        box-shadow: none;
+    }
+
+    .sitepulse-module-selector__select {
+        background-color: var(--wp-admin-color-gray-900, #1d2327);
+        border-color: var(--wp-admin-color-gray-600, #6c7781);
+        color: var(--wp-admin-color-gray-0, #ffffff);
+    }
+
+    .sitepulse-module-selector__submit {
+        color: var(--wp-admin-color-gray-0, #ffffff);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .sitepulse-module-selector,
+    .sitepulse-module-selector__select,
+    .sitepulse-module-selector__submit {
+        transition: none;
+    }
+}

--- a/sitepulse_FR/modules/database_optimizer.php
+++ b/sitepulse_FR/modules/database_optimizer.php
@@ -208,7 +208,12 @@ function sitepulse_database_optimizer_page() {
         );
         $transients += $network_transients;
     }
-  ?>
+    ?>
+    <?php
+    if (function_exists('sitepulse_render_module_selector')) {
+        sitepulse_render_module_selector('sitepulse-db');
+    }
+    ?>
       <div class="wrap">
         <h1><span class="dashicons-before dashicons-database"></span> <?php esc_html_e('Database Optimizer', 'sitepulse'); ?></h1>
         <p><?php esc_html_e('Over time, your database can accumulate data that is no longer necessary. This tool helps you clean it up safely.', 'sitepulse'); ?></p>

--- a/sitepulse_FR/modules/log_analyzer.php
+++ b/sitepulse_FR/modules/log_analyzer.php
@@ -36,6 +36,11 @@ function sitepulse_log_analyzer_page() {
         $recent_log_lines = sitepulse_get_recent_log_lines($log_file, 100, 131072);
     }
     ?>
+    <?php
+    if (function_exists('sitepulse_render_module_selector')) {
+        sitepulse_render_module_selector('sitepulse-logs');
+    }
+    ?>
     <div class="wrap">
         <h1><span class="dashicons-before dashicons-hammer"></span> Analyseur de Logs</h1>
         <p><?php printf(esc_html__('Cet outil scanne le fichier %s de WordPress pour vous aider à trouver et corriger les problèmes sur votre site.', 'sitepulse'), $log_file_display); ?></p>

--- a/sitepulse_FR/modules/maintenance_advisor.php
+++ b/sitepulse_FR/modules/maintenance_advisor.php
@@ -37,6 +37,11 @@ function sitepulse_maintenance_advisor_page() {
         $plugin_updates_count = count($plugin_updates);
     }
     ?>
+    <?php
+    if (function_exists('sitepulse_render_module_selector')) {
+        sitepulse_render_module_selector('sitepulse-maintenance');
+    }
+    ?>
     <div class="wrap">
         <h1><span class="dashicons-before dashicons-update"></span> <?php esc_html_e('Conseiller de Maintenance', 'sitepulse'); ?></h1>
         <?php if (!$has_update_data) : ?>

--- a/sitepulse_FR/modules/plugin_impact_scanner.php
+++ b/sitepulse_FR/modules/plugin_impact_scanner.php
@@ -383,6 +383,11 @@ function sitepulse_plugin_impact_scanner_page() {
         sitepulse_plugin_impact_format_interval($interval)
     );
     ?>
+    <?php
+    if (function_exists('sitepulse_render_module_selector')) {
+        sitepulse_render_module_selector('sitepulse-plugins');
+    }
+    ?>
     <div class="wrap">
         <h1><span class="dashicons-before dashicons-filter"></span> <?php esc_html_e("Analyseur d'Impact des Plugins", 'sitepulse'); ?></h1>
 

--- a/sitepulse_FR/modules/resource_monitor.php
+++ b/sitepulse_FR/modules/resource_monitor.php
@@ -346,6 +346,11 @@ function sitepulse_resource_monitor_page() {
         $age = human_time_diff($generated_at, (int) current_time('timestamp', true));
     }
     ?>
+    <?php
+    if (function_exists('sitepulse_render_module_selector')) {
+        sitepulse_render_module_selector('sitepulse-resources');
+    }
+    ?>
     <div class="wrap sitepulse-resource-monitor">
         <h1><span class="dashicons-before dashicons-performance"></span> <?php esc_html_e('Moniteur de Ressources', 'sitepulse'); ?></h1>
         <?php if (!empty($resource_monitor_notices)) : ?>

--- a/sitepulse_FR/modules/speed_analyzer.php
+++ b/sitepulse_FR/modules/speed_analyzer.php
@@ -146,6 +146,11 @@ function sitepulse_speed_analyzer_page() {
     };
 
     ?>
+    <?php
+    if (function_exists('sitepulse_render_module_selector')) {
+        sitepulse_render_module_selector('sitepulse-speed');
+    }
+    ?>
     <div class="wrap">
         <h1><span class="dashicons-before dashicons-performance"></span> <?php esc_html_e('Analyseur de Vitesse', 'sitepulse'); ?></h1>
         <p><?php esc_html_e('Cet outil analyse la performance interne de votre serveur et de votre base de données à chaque chargement de page.', 'sitepulse'); ?></p>

--- a/sitepulse_FR/modules/uptime_tracker.php
+++ b/sitepulse_FR/modules/uptime_tracker.php
@@ -359,6 +359,11 @@ function sitepulse_uptime_tracker_page() {
     $thirty_day_metrics = sitepulse_calculate_uptime_window_metrics($uptime_archive, 30);
 
     ?>
+    <?php
+    if (function_exists('sitepulse_render_module_selector')) {
+        sitepulse_render_module_selector('sitepulse-uptime');
+    }
+    ?>
     <div class="wrap">
         <h1><span class="dashicons-before dashicons-chart-bar"></span> Suivi de Disponibilité</h1>
         <p>Cet outil vérifie la disponibilité de votre site toutes les heures. Voici le statut des <?php echo esc_html($total_checks); ?> dernières vérifications.</p>

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -1149,6 +1149,7 @@ sitepulse_log('SitePulse loaded. Version: ' . SITEPULSE_VERSION);
 
 // Include core files
 require_once SITEPULSE_PATH . 'includes/functions.php';
+require_once SITEPULSE_PATH . 'includes/module-selector.php';
 require_once SITEPULSE_PATH . 'includes/admin-settings.php';
 require_once SITEPULSE_PATH . 'includes/integrations.php';
 require_once SITEPULSE_PATH . 'blocks/dashboard-preview/render.php';


### PR DESCRIPTION
## Summary
- add a reusable helper that builds a SitePulse module selector and enqueues its assets
- render the selector at the top of each module admin page so users can switch sections quickly
- introduce a shared, touch-friendly stylesheet for the selector that works across modules

## Testing
- php -l sitepulse_FR/includes/module-selector.php
- for file in sitepulse_FR/modules/speed_analyzer.php sitepulse_FR/modules/uptime_tracker.php sitepulse_FR/modules/plugin_impact_scanner.php sitepulse_FR/modules/resource_monitor.php sitepulse_FR/modules/database_optimizer.php sitepulse_FR/modules/maintenance_advisor.php sitepulse_FR/modules/log_analyzer.php sitepulse_FR/modules/ai_insights.php; do
  php -l "$file" || exit 1
done


------
https://chatgpt.com/codex/tasks/task_e_68dee7ce5a70832eb7ccb64554f28ddf