### PR TITLE
Add manual speed scan trigger with AJAX history updates

### DIFF
--- a/sitepulse_FR/modules/js/speed-analyzer.js
+++ b/sitepulse_FR/modules/js/speed-analyzer.js
@@ -1,0 +1,327 @@
+(function (window, document) {
+    'use strict';
+
+    var settings = window.SitePulseSpeedAnalyzer || {};
+    var chartInstance = null;
+
+    function sanitizeHistory(history) {
+        if (!Array.isArray(history)) {
+            return [];
+        }
+
+        return history
+            .map(function (entry) {
+                if (!entry || typeof entry !== 'object') {
+                    return null;
+                }
+
+                var timestamp = parseInt(entry.timestamp, 10);
+                var value = typeof entry.server_processing_ms === 'number'
+                    ? entry.server_processing_ms
+                    : parseFloat(entry.server_processing_ms);
+
+                if (!isFinite(timestamp) || timestamp <= 0 || !isFinite(value) || value < 0) {
+                    return null;
+                }
+
+                return {
+                    timestamp: timestamp,
+                    server_processing_ms: value
+                };
+            })
+            .filter(function (entry) {
+                return !!entry;
+            })
+            .sort(function (a, b) {
+                return a.timestamp - b.timestamp;
+            });
+    }
+
+    function formatTimestamp(timestamp) {
+        var date = new Date(timestamp * 1000);
+
+        if (Number.isNaN(date.getTime())) {
+            return '';
+        }
+
+        return date.toLocaleString();
+    }
+
+    function renderHistory(history, dom) {
+        var sanitized = sanitizeHistory(history);
+        var canvas = dom.canvas;
+        var tableBody = dom.tableBody;
+        var i18n = settings.i18n || {};
+
+        if (tableBody) {
+            tableBody.innerHTML = '';
+
+            if (!sanitized.length) {
+                var emptyRow = document.createElement('tr');
+                var emptyCell = document.createElement('td');
+                emptyCell.colSpan = 2;
+                emptyCell.textContent = i18n.noHistory || '';
+                emptyRow.appendChild(emptyCell);
+                tableBody.appendChild(emptyRow);
+            } else {
+                sanitized.forEach(function (entry) {
+                    var row = document.createElement('tr');
+                    var dateCell = document.createElement('td');
+                    var valueCell = document.createElement('td');
+
+                    dateCell.textContent = formatTimestamp(entry.timestamp);
+                    valueCell.textContent = entry.server_processing_ms.toFixed(2);
+
+                    row.appendChild(dateCell);
+                    row.appendChild(valueCell);
+                    tableBody.appendChild(row);
+                });
+            }
+        }
+
+        if (!canvas || typeof window.Chart === 'undefined') {
+            return;
+        }
+
+        var labels = sanitized.map(function (entry) {
+            return formatTimestamp(entry.timestamp);
+        });
+        var values = sanitized.map(function (entry) {
+            return entry.server_processing_ms;
+        });
+
+        if (!chartInstance) {
+            chartInstance = new window.Chart(canvas.getContext('2d'), {
+                type: 'line',
+                data: {
+                    labels: labels,
+                    datasets: [
+                        {
+                            label: i18n.chartLabel || '',
+                            data: values,
+                            borderColor: '#0073aa',
+                            backgroundColor: 'rgba(0, 115, 170, 0.15)',
+                            borderWidth: 2,
+                            pointRadius: 3,
+                            pointBackgroundColor: '#ffffff',
+                            pointBorderColor: '#0073aa',
+                            tension: 0.25,
+                            fill: true
+                        }
+                    ]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    scales: {
+                        y: {
+                            beginAtZero: true,
+                            ticks: {
+                                callback: function (value) {
+                                    return value + ' ms';
+                                }
+                            }
+                        }
+                    },
+                    plugins: {
+                        legend: {
+                            display: false
+                        },
+                        tooltip: {
+                            callbacks: {
+                                label: function (context) {
+                                    var label = context.dataset.label ? context.dataset.label + ': ' : '';
+                                    return label + context.parsed.y.toFixed(2) + ' ms';
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        } else {
+            chartInstance.data.labels = labels;
+            chartInstance.data.datasets[0].data = values;
+            chartInstance.update();
+        }
+    }
+
+    function updateRecommendations(recommendations, dom) {
+        var list = dom.recommendations;
+        var i18n = settings.i18n || {};
+
+        if (!list) {
+            return;
+        }
+
+        list.innerHTML = '';
+
+        if (!Array.isArray(recommendations) || !recommendations.length) {
+            var item = document.createElement('li');
+            item.textContent = i18n.noHistory || '';
+            list.appendChild(item);
+            return;
+        }
+
+        recommendations.forEach(function (recommendation) {
+            var li = document.createElement('li');
+            li.textContent = recommendation;
+            list.appendChild(li);
+        });
+    }
+
+    function setStatus(message, type, dom) {
+        var statusEl = dom.status;
+
+        if (!statusEl) {
+            return;
+        }
+
+        statusEl.textContent = message || '';
+        statusEl.className = 'sitepulse-speed-status';
+
+        if (type) {
+            statusEl.classList.add('status-' + type);
+        }
+    }
+
+    function setButtonState(isRunning, dom) {
+        var button = dom.button;
+        var i18n = settings.i18n || {};
+
+        if (!button) {
+            return;
+        }
+
+        if (typeof button.dataset.originalLabel === 'undefined') {
+            button.dataset.originalLabel = button.textContent || '';
+        }
+
+        if (isRunning) {
+            button.disabled = true;
+            button.setAttribute('aria-busy', 'true');
+            button.textContent = i18n.running || button.dataset.originalLabel;
+        } else {
+            button.disabled = false;
+            button.removeAttribute('aria-busy');
+            button.textContent = i18n.retry || button.dataset.originalLabel;
+        }
+    }
+
+    function handleError(message, dom) {
+        var i18n = settings.i18n || {};
+        setStatus(message || i18n.error || '', 'error', dom);
+        setButtonState(false, dom);
+    }
+
+    function init() {
+        var dom = {
+            button: document.getElementById('sitepulse-speed-rescan'),
+            status: document.getElementById('sitepulse-speed-scan-status'),
+            canvas: document.getElementById('sitepulse-speed-history-chart'),
+            tableBody: document.querySelector('#sitepulse-speed-history-table tbody'),
+            recommendations: document.querySelector('#sitepulse-speed-recommendations ul')
+        };
+
+        renderHistory(settings.history || [], dom);
+        updateRecommendations(settings.recommendations || [], dom);
+
+        if (!dom.button) {
+            return;
+        }
+
+        dom.button.addEventListener('click', function () {
+            var ajaxUrl = settings.ajaxUrl;
+            var nonce = settings.nonce;
+            var i18n = settings.i18n || {};
+
+            if (!ajaxUrl || !nonce) {
+                handleError(i18n.error || '', dom);
+                return;
+            }
+
+            setButtonState(true, dom);
+            setStatus(i18n.running || '', 'info', dom);
+
+            var body = new URLSearchParams();
+            body.append('action', 'sitepulse_run_speed_scan');
+            body.append('nonce', nonce);
+
+            fetch(ajaxUrl, {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+                },
+                body: body.toString()
+            })
+                .then(function (response) {
+                    return response.json()
+                        .catch(function () {
+                            return {};
+                        })
+                        .then(function (payload) {
+                            return {
+                                ok: response.ok,
+                                payload: payload
+                            };
+                        });
+                })
+                .then(function (result) {
+                    if (!result) {
+                        handleError(null, dom);
+                        return;
+                    }
+
+                    var payload = result.payload || {};
+
+                    if (!payload.success) {
+                        var errorData = payload.data || {};
+                        var message = errorData.message || (settings.i18n && settings.i18n.error) || '';
+                        var type = errorData.status === 'throttled' ? 'warning' : 'error';
+
+                        if (errorData.status === 'throttled' && errorData.next_available) {
+                            var nextDate = new Date(errorData.next_available * 1000);
+                            var human = nextDate.toLocaleTimeString();
+                            if (settings.i18n && settings.i18n.rateLimitIntro) {
+                                message += ' ' + settings.i18n.rateLimitIntro + ' ' + human;
+                            }
+                        }
+
+                        if (Array.isArray(errorData.recommendations)) {
+                            updateRecommendations(errorData.recommendations, dom);
+                        }
+
+                        if (Array.isArray(errorData.history)) {
+                            renderHistory(errorData.history, dom);
+                        }
+
+                        setStatus(message, type, dom);
+                        setButtonState(false, dom);
+                        return;
+                    }
+
+                    var data = payload.data || {};
+
+                    settings.history = Array.isArray(data.history) ? data.history : [];
+                    settings.recommendations = Array.isArray(data.recommendations) ? data.recommendations : [];
+                    settings.lastRun = data.last_run || settings.lastRun;
+                    settings.rateLimit = data.rate_limit || settings.rateLimit;
+
+                    renderHistory(settings.history, dom);
+                    updateRecommendations(settings.recommendations, dom);
+
+                    setStatus(data.message || '', 'success', dom);
+                    setButtonState(false, dom);
+                })
+                .catch(function () {
+                    handleError(null, dom);
+                });
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})(window, document);

--- a/sitepulse_FR/modules/speed_analyzer.php
+++ b/sitepulse_FR/modules/speed_analyzer.php
@@ -14,50 +14,31 @@ add_action('admin_menu', function() {
 });
 
 add_action('admin_enqueue_scripts', 'sitepulse_speed_analyzer_enqueue_assets');
+add_action('wp_ajax_sitepulse_run_speed_scan', 'sitepulse_ajax_run_speed_scan');
 
 /**
- * Enqueues the Speed Analyzer stylesheet on the relevant admin page.
+ * Retrieves the configured rate limit (in seconds) for manual scans.
  *
- * @param string $hook_suffix Current admin page identifier.
- * @return void
+ * @return int
  */
-function sitepulse_speed_analyzer_enqueue_assets($hook_suffix) {
-    if ($hook_suffix !== 'sitepulse-dashboard_page_sitepulse-speed') {
-        return;
+function sitepulse_speed_analyzer_get_rate_limit() {
+    $interval = apply_filters('sitepulse_speed_scan_min_interval', MINUTE_IN_SECONDS);
+
+    if (!is_scalar($interval)) {
+        $interval = MINUTE_IN_SECONDS;
     }
 
-    wp_enqueue_style(
-        'sitepulse-speed-analyzer',
-        SITEPULSE_URL . 'modules/css/speed-analyzer.css',
-        [],
-        SITEPULSE_VERSION
-    );
+    $interval = (int) $interval;
+
+    return max(10, $interval);
 }
 
 /**
- * Renders the Speed Analyzer page.
- * The analysis is now based on internal WordPress timers for better reliability.
+ * Retrieves the warning and critical thresholds for speed measurements.
+ *
+ * @return array{warning:int,critical:int,default_warning:int,default_critical:int}
  */
-function sitepulse_speed_analyzer_page() {
-    if (!current_user_can(sitepulse_get_capability())) {
-        wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
-    }
-
-    global $wpdb;
-
-    // --- Server Performance Metrics ---
-
-    // 1. Page Generation Time (Backend processing)
-    // **FIX:** Replaced timer_stop() with a direct microtime calculation to prevent non-numeric value warnings in specific environments.
-    if (isset($_SERVER['REQUEST_TIME_FLOAT']) && is_numeric($_SERVER['REQUEST_TIME_FLOAT'])) {
-        $timestart = (float) $_SERVER['REQUEST_TIME_FLOAT'];
-    } elseif (isset($GLOBALS['timestart']) && is_numeric($GLOBALS['timestart'])) {
-        $timestart = (float) $GLOBALS['timestart'];
-    } else {
-        $timestart = microtime(true);
-    }
-    $page_generation_time = (microtime(true) - $timestart) * 1000.0; // in milliseconds
-
+function sitepulse_speed_analyzer_get_thresholds() {
     $default_speed_warning = defined('SITEPULSE_DEFAULT_SPEED_WARNING_MS') ? (int) SITEPULSE_DEFAULT_SPEED_WARNING_MS : 200;
     $default_speed_critical = defined('SITEPULSE_DEFAULT_SPEED_CRITICAL_MS') ? (int) SITEPULSE_DEFAULT_SPEED_CRITICAL_MS : 500;
     $speed_warning_threshold = $default_speed_warning;
@@ -98,6 +79,309 @@ function sitepulse_speed_analyzer_page() {
     if ($speed_critical_threshold <= $speed_warning_threshold) {
         $speed_critical_threshold = max($speed_warning_threshold + 1, $default_speed_critical);
     }
+
+    return [
+        'warning'          => $speed_warning_threshold,
+        'critical'         => $speed_critical_threshold,
+        'default_warning'  => $default_speed_warning,
+        'default_critical' => $default_speed_critical,
+    ];
+}
+
+/**
+ * Returns the recorded speed history in a normalized format.
+ *
+ * @return array<int,array{timestamp:int,server_processing_ms:float}>
+ */
+function sitepulse_speed_analyzer_get_history_data() {
+    $history = get_option(SITEPULSE_OPTION_SPEED_SCAN_HISTORY, []);
+
+    if (!is_array($history)) {
+        return [];
+    }
+
+    $normalized = array_values(array_filter(
+        array_map(
+            static function ($entry) {
+                if (!is_array($entry)) {
+                    return null;
+                }
+
+                if (!isset($entry['timestamp'], $entry['server_processing_ms'])) {
+                    return null;
+                }
+
+                if (!is_numeric($entry['timestamp']) || !is_numeric($entry['server_processing_ms'])) {
+                    return null;
+                }
+
+                return [
+                    'timestamp'            => max(0, (int) $entry['timestamp']),
+                    'server_processing_ms' => max(0.0, (float) $entry['server_processing_ms']),
+                ];
+            },
+            $history
+        ),
+        static function ($entry) {
+            return is_array($entry);
+        }
+    ));
+
+    usort(
+        $normalized,
+        static function ($a, $b) {
+            return $a['timestamp'] <=> $b['timestamp'];
+        }
+    );
+
+    return $normalized;
+}
+
+/**
+ * Retrieves the latest entry from the history array.
+ *
+ * @param array<int,array{timestamp:int,server_processing_ms:float}> $history History entries.
+ *
+ * @return array{timestamp:int,server_processing_ms:float}|null
+ */
+function sitepulse_speed_analyzer_get_latest_entry($history) {
+    if (empty($history) || !is_array($history)) {
+        return null;
+    }
+
+    $last_index = count($history) - 1;
+
+    if (!isset($history[$last_index]) || !is_array($history[$last_index])) {
+        return null;
+    }
+
+    return $history[$last_index];
+}
+
+/**
+ * Generates textual recommendations based on the latest measurement.
+ *
+ * @param array{timestamp:int,server_processing_ms:float}|null $latest_entry Latest history entry.
+ * @param array{warning:int,critical:int}                       $thresholds   Threshold configuration.
+ *
+ * @return string[]
+ */
+function sitepulse_speed_analyzer_build_recommendations($latest_entry, $thresholds) {
+    $messages = [];
+
+    if (empty($latest_entry)) {
+        $messages[] = esc_html__("Nous attendons encore suffisamment de données pour formuler des recommandations. Relancez un test pour commencer l'historique.", 'sitepulse');
+
+        return $messages;
+    }
+
+    $duration = isset($latest_entry['server_processing_ms']) ? (float) $latest_entry['server_processing_ms'] : 0.0;
+    $warning = isset($thresholds['warning']) ? (int) $thresholds['warning'] : 0;
+    $critical = isset($thresholds['critical']) ? (int) $thresholds['critical'] : 0;
+
+    if ($duration >= $critical) {
+        $messages[] = esc_html__("Les temps de réponse du serveur sont critiques. Contactez votre hébergeur et désactivez temporairement les extensions lourdes pour identifier le goulot d'étranglement.", 'sitepulse');
+    } elseif ($duration >= $warning) {
+        $messages[] = esc_html__("Vos performances se dégradent. Vérifiez les dernières extensions installées, optimisez la base de données et activez un cache persistant si possible.", 'sitepulse');
+    } else {
+        $messages[] = esc_html__("Le serveur répond correctement. Continuez à surveiller l'historique pour repérer les écarts ou planifiez des tests réguliers après les mises à jour.", 'sitepulse');
+    }
+
+    if ($duration >= $warning) {
+        $messages[] = esc_html__("Pensez à réduire les tâches cron simultanées et à surveiller l'utilisation CPU côté hébergeur pendant les pics.", 'sitepulse');
+    } else {
+        $messages[] = esc_html__("Aucune action urgente n'est requise, mais gardez un œil sur l'évolution après des déploiements importants.", 'sitepulse');
+    }
+
+    return $messages;
+}
+
+/**
+ * Handles the AJAX request to trigger a fresh speed scan.
+ */
+function sitepulse_ajax_run_speed_scan() {
+    if (!current_user_can(sitepulse_get_capability())) {
+        wp_send_json_error([
+            'message' => esc_html__("Vous n'avez pas les permissions nécessaires pour réaliser ce test.", 'sitepulse'),
+        ], 403);
+    }
+
+    check_ajax_referer('sitepulse_speed_scan', 'nonce');
+
+    $rate_limit = sitepulse_speed_analyzer_get_rate_limit();
+    $last_run = (int) get_option('sitepulse_speed_scan_last_run', 0);
+    $now = current_time('timestamp');
+    $thresholds = sitepulse_speed_analyzer_get_thresholds();
+
+    if ($rate_limit > 0 && ($now - $last_run) < $rate_limit) {
+        $remaining = max(0, $rate_limit - ($now - $last_run));
+        $history = sitepulse_speed_analyzer_get_history_data();
+        $latest = sitepulse_speed_analyzer_get_latest_entry($history);
+
+        wp_send_json_error([
+            'message'          => sprintf(
+                /* translators: %s: human readable delay before the next scan. */
+                esc_html__('Veuillez patienter encore %s avant de relancer un test pour éviter de surcharger le serveur.', 'sitepulse'),
+                esc_html(human_time_diff($now, $now + max(1, $remaining)))
+            ),
+            'status'           => 'throttled',
+            'history'          => $history,
+            'recommendations'  => sitepulse_speed_analyzer_build_recommendations($latest, $thresholds),
+            'latest'           => $latest,
+            'next_available'   => $last_run + $rate_limit,
+            'rate_limit'       => $rate_limit,
+            'remaining'        => $remaining,
+        ], 429);
+    }
+
+    global $sitepulse_plugin_impact_tracker_force_persist;
+
+    $previous_force_state = isset($sitepulse_plugin_impact_tracker_force_persist)
+        ? (bool) $sitepulse_plugin_impact_tracker_force_persist
+        : false;
+
+    $sitepulse_plugin_impact_tracker_force_persist = true;
+    sitepulse_plugin_impact_tracker_persist();
+    $sitepulse_plugin_impact_tracker_force_persist = $previous_force_state;
+
+    update_option('sitepulse_speed_scan_last_run', $now, false);
+
+    $history = sitepulse_speed_analyzer_get_history_data();
+    $latest = sitepulse_speed_analyzer_get_latest_entry($history);
+
+    wp_send_json_success([
+        'message'         => esc_html__('Un nouveau relevé a été ajouté à votre historique.', 'sitepulse'),
+        'history'         => $history,
+        'latest'          => $latest,
+        'recommendations' => sitepulse_speed_analyzer_build_recommendations($latest, $thresholds),
+        'last_run'        => $now,
+        'rate_limit'      => $rate_limit,
+    ]);
+}
+
+/**
+ * Enqueues the Speed Analyzer stylesheet on the relevant admin page.
+ *
+ * @param string $hook_suffix Current admin page identifier.
+ * @return void
+ */
+function sitepulse_speed_analyzer_enqueue_assets($hook_suffix) {
+    if ($hook_suffix !== 'sitepulse-dashboard_page_sitepulse-speed') {
+        return;
+    }
+
+    $thresholds = sitepulse_speed_analyzer_get_thresholds();
+    $history = sitepulse_speed_analyzer_get_history_data();
+    $rate_limit = sitepulse_speed_analyzer_get_rate_limit();
+    $last_run = (int) get_option('sitepulse_speed_scan_last_run', 0);
+
+    wp_enqueue_style(
+        'sitepulse-speed-analyzer',
+        SITEPULSE_URL . 'modules/css/speed-analyzer.css',
+        [],
+        SITEPULSE_VERSION
+    );
+
+    $default_chartjs_src = SITEPULSE_URL . 'modules/vendor/chart.js/chart.umd.js';
+    $chartjs_src = apply_filters('sitepulse_chartjs_src', $default_chartjs_src);
+
+    if (!wp_script_is('sitepulse-chartjs', 'registered')) {
+        $is_custom_source = $chartjs_src !== $default_chartjs_src;
+
+        wp_register_script(
+            'sitepulse-chartjs',
+            $chartjs_src,
+            [],
+            '4.4.5',
+            true
+        );
+
+        if ($is_custom_source) {
+            $fallback_loader = '(function(){if (typeof window.Chart === "undefined") {'
+                . 'var script=document.createElement("script");'
+                . 'script.src=' . wp_json_encode($default_chartjs_src) . ';'
+                . 'script.defer=true;'
+                . 'document.head.appendChild(script);'
+                . '}})();';
+
+            wp_add_inline_script('sitepulse-chartjs', $fallback_loader, 'after');
+        }
+    }
+
+    wp_enqueue_script('sitepulse-chartjs');
+
+    wp_enqueue_script(
+        'sitepulse-speed-analyzer',
+        SITEPULSE_URL . 'modules/js/speed-analyzer.js',
+        ['sitepulse-chartjs'],
+        SITEPULSE_VERSION,
+        true
+    );
+
+    wp_localize_script(
+        'sitepulse-speed-analyzer',
+        'SitePulseSpeedAnalyzer',
+        [
+            'ajaxUrl'        => admin_url('admin-ajax.php'),
+            'nonce'          => wp_create_nonce('sitepulse_speed_scan'),
+            'history'        => $history,
+            'thresholds'     => [
+                'warning'  => (int) $thresholds['warning'],
+                'critical' => (int) $thresholds['critical'],
+            ],
+            'rateLimit'      => $rate_limit,
+            'lastRun'        => $last_run,
+            'recommendations'=> sitepulse_speed_analyzer_build_recommendations(
+                sitepulse_speed_analyzer_get_latest_entry($history),
+                $thresholds
+            ),
+            'i18n'           => [
+                'running'        => esc_html__('Analyse en cours…', 'sitepulse'),
+                'retry'          => esc_html__('Relancer un test', 'sitepulse'),
+                'noHistory'      => esc_html__("Aucun historique disponible pour le moment.", 'sitepulse'),
+                'timestamp'      => esc_html__('Horodatage', 'sitepulse'),
+                'duration'       => esc_html__('Temps serveur (ms)', 'sitepulse'),
+                'chartLabel'     => esc_html__('Temps de traitement du serveur', 'sitepulse'),
+                'error'          => esc_html__("Une erreur est survenue pendant le test. Veuillez réessayer.", 'sitepulse'),
+                'throttled'      => esc_html__('Test bloqué temporairement par la limite de fréquence.', 'sitepulse'),
+                'rateLimitIntro' => esc_html__('Prochain test possible dans', 'sitepulse'),
+            ],
+        ]
+    );
+}
+
+/**
+ * Renders the Speed Analyzer page.
+ * The analysis is now based on internal WordPress timers for better reliability.
+ */
+function sitepulse_speed_analyzer_page() {
+    if (!current_user_can(sitepulse_get_capability())) {
+        wp_die(esc_html__("Vous n'avez pas les permissions nécessaires pour accéder à cette page.", 'sitepulse'));
+    }
+
+    global $wpdb;
+
+    // --- Server Performance Metrics ---
+
+    // 1. Page Generation Time (Backend processing)
+    // **FIX:** Replaced timer_stop() with a direct microtime calculation to prevent non-numeric value warnings in specific environments.
+    if (isset($_SERVER['REQUEST_TIME_FLOAT']) && is_numeric($_SERVER['REQUEST_TIME_FLOAT'])) {
+        $timestart = (float) $_SERVER['REQUEST_TIME_FLOAT'];
+    } elseif (isset($GLOBALS['timestart']) && is_numeric($GLOBALS['timestart'])) {
+        $timestart = (float) $GLOBALS['timestart'];
+    } else {
+        $timestart = microtime(true);
+    }
+    $page_generation_time = (microtime(true) - $timestart) * 1000.0; // in milliseconds
+
+    $thresholds = sitepulse_speed_analyzer_get_thresholds();
+    $speed_warning_threshold = $thresholds['warning'];
+    $speed_critical_threshold = $thresholds['critical'];
+    $rate_limit = sitepulse_speed_analyzer_get_rate_limit();
+    $history = sitepulse_speed_analyzer_get_history_data();
+    $latest_entry = sitepulse_speed_analyzer_get_latest_entry($history);
+    $now_timestamp = current_time('timestamp');
+    $rate_limit_label = human_time_diff($now_timestamp, $now_timestamp + max(1, $rate_limit));
 
     // 2. Database Query Time & Count
     $db_query_total_time = 0;
@@ -149,6 +433,67 @@ function sitepulse_speed_analyzer_page() {
     <div class="wrap">
         <h1><span class="dashicons-before dashicons-performance"></span> <?php esc_html_e('Analyseur de Vitesse', 'sitepulse'); ?></h1>
         <p><?php esc_html_e('Cet outil analyse la performance interne de votre serveur et de votre base de données à chaque chargement de page.', 'sitepulse'); ?></p>
+
+        <div class="speed-scan-actions">
+            <button type="button" class="button button-primary" id="sitepulse-speed-rescan">
+                <?php esc_html_e('Relancer un test', 'sitepulse'); ?>
+            </button>
+            <p class="description">
+                <?php
+                printf(
+                    /* translators: %s: human readable rate limit duration. */
+                    esc_html__('Pour préserver les ressources serveur, un nouveau test manuel est disponible toutes les %s.', 'sitepulse'),
+                    esc_html($rate_limit_label)
+                );
+                ?>
+            </p>
+            <div id="sitepulse-speed-scan-status" class="sitepulse-speed-status" role="status" aria-live="polite"></div>
+        </div>
+
+        <div class="speed-history-wrapper">
+            <h2><?php esc_html_e('Historique des temps de réponse', 'sitepulse'); ?></h2>
+            <div class="speed-history-visual">
+                <canvas id="sitepulse-speed-history-chart" aria-describedby="sitepulse-speed-history-summary"></canvas>
+            </div>
+            <table class="widefat fixed" id="sitepulse-speed-history-table" aria-live="polite">
+                <caption id="sitepulse-speed-history-summary" class="screen-reader-text">
+                    <?php esc_html_e('Historique des mesures de temps de réponse du serveur.', 'sitepulse'); ?>
+                </caption>
+                <thead>
+                    <tr>
+                        <th scope="col"><?php esc_html_e('Horodatage', 'sitepulse'); ?></th>
+                        <th scope="col"><?php esc_html_e('Temps serveur (ms)', 'sitepulse'); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if (!empty($history)) : ?>
+                        <?php foreach ($history as $entry) : ?>
+                            <tr>
+                                <td><?php echo esc_html(wp_date(get_option('date_format') . ' ' . get_option('time_format'), $entry['timestamp'])); ?></td>
+                                <td><?php echo esc_html(number_format_i18n($entry['server_processing_ms'], 2)); ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php else : ?>
+                        <tr>
+                            <td colspan="2"><?php esc_html_e('Aucun historique disponible pour le moment.', 'sitepulse'); ?></td>
+                        </tr>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
+
+        <div id="sitepulse-speed-recommendations" class="speed-recommendations">
+            <h2><?php esc_html_e('Recommandations', 'sitepulse'); ?></h2>
+            <ul>
+                <?php
+                $initial_recommendations = sitepulse_speed_analyzer_build_recommendations($latest_entry, $thresholds);
+
+                foreach ($initial_recommendations as $recommendation) {
+                    echo '<li>' . esc_html($recommendation) . '</li>';
+                }
+                ?>
+            </ul>
+        </div>
 
         <div class="speed-grid">
             <!-- Server Processing Card -->


### PR DESCRIPTION
## Summary
- add an authenticated AJAX endpoint that forces a fresh speed scan sample and returns normalized history data
- enhance the speed analyzer admin view with a manual scan button, history visualization, and recommendation section
- enqueue a new Chart.js-powered script to refresh history, surface recommendations, and communicate rate limits

## Testing
- php -l sitepulse_FR/includes/plugin-impact-tracker.php
- php -l sitepulse_FR/modules/speed_analyzer.php

------
https://chatgpt.com/codex/tasks/task_e_68dee7c45e34832e8cb1514b5a533b0a