### PR TITLE
Add responsive navigation to SitePulse dashboard module

### DIFF
--- a/sitepulse_FR/modules/css/custom-dashboard.css
+++ b/sitepulse_FR/modules/css/custom-dashboard.css
@@ -2,13 +2,56 @@
     margin: 16px 0 24px;
 }
 
+.sitepulse-module-nav__mobile-form {
+    display: none;
+    margin: 0 0 16px;
+}
+
+.sitepulse-module-nav__mobile-label {
+    display: block;
+    font-weight: 600;
+    font-size: 13px;
+    margin-bottom: 6px;
+    color: var(--wp-admin-color-gray-800, #2c3338);
+}
+
+.sitepulse-module-nav__mobile-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.sitepulse-module-nav__select {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.sitepulse-module-nav__select-submit {
+    flex: 0 0 auto;
+}
+
+.sitepulse-module-nav--js .sitepulse-module-nav__select-submit {
+    display: none;
+}
+
+.sitepulse-module-nav__scroll {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.sitepulse-module-nav__scroll-viewport {
+    flex: 1 1 auto;
+}
+
 .sitepulse-module-nav__list {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     gap: 8px;
     list-style: none;
     margin: 0;
     padding: 0;
+    padding-bottom: 6px;
 }
 
 .sitepulse-module-nav__item {
@@ -62,15 +105,79 @@
     white-space: nowrap;
 }
 
+.sitepulse-module-nav__scroll-button {
+    background: var(--wp-admin-color-gray-0, #ffffff);
+    border: 1px solid var(--wp-admin-color-gray-200, #c3c4c7);
+    border-radius: 50%;
+    cursor: pointer;
+    display: none;
+    height: 32px;
+    width: 32px;
+    align-items: center;
+    justify-content: center;
+    color: var(--wp-admin-color-gray-700, #50575e);
+    padding: 0;
+    transition: border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sitepulse-module-nav__scroll-button .dashicons {
+    font-size: 18px;
+    line-height: 1;
+}
+
+.sitepulse-module-nav__scroll-button:hover,
+.sitepulse-module-nav__scroll-button:focus-visible {
+    border-color: var(--wp-admin-color-blue-50, #72aee6);
+    color: var(--wp-admin-color-gray-900, #1d2327);
+    box-shadow: 0 0 0 2px rgba(34, 113, 177, 0.15);
+    outline: none;
+}
+
+.sitepulse-module-nav__scroll-button[disabled] {
+    cursor: default;
+    opacity: 0.5;
+    box-shadow: none;
+}
+
+.sitepulse-module-nav--scrollable .sitepulse-module-nav__scroll-button {
+    display: inline-flex;
+}
+
+.sitepulse-module-nav__scroll-viewport {
+    overflow-x: auto;
+    scrollbar-width: thin;
+}
+
+.sitepulse-module-nav__scroll-viewport::-webkit-scrollbar {
+    height: 6px;
+}
+
+.sitepulse-module-nav__scroll-viewport::-webkit-scrollbar-thumb {
+    background-color: rgba(34, 113, 177, 0.35);
+    border-radius: 999px;
+}
+
+.sitepulse-module-nav__scroll-viewport::-webkit-scrollbar-track {
+    background-color: transparent;
+}
+
+.sitepulse-module-nav__scroll-viewport:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 2px rgba(34, 113, 177, 0.25);
+    border-radius: 6px;
+}
+
+.sitepulse-module-nav__scroll-viewport:hover {
+    scrollbar-color: rgba(34, 113, 177, 0.45) transparent;
+}
+
 @media (max-width: 782px) {
-    .sitepulse-module-nav__list {
-        flex-wrap: nowrap;
-        overflow-x: auto;
-        padding-bottom: 6px;
+    .sitepulse-module-nav__mobile-form {
+        display: block;
     }
 
-    .sitepulse-module-nav__link {
-        flex: 0 0 auto;
+    .sitepulse-module-nav__scroll {
+        display: none;
     }
 }
 

--- a/sitepulse_FR/modules/custom_dashboards.php
+++ b/sitepulse_FR/modules/custom_dashboards.php
@@ -99,6 +99,16 @@ function sitepulse_custom_dashboard_enqueue_assets($hook_suffix) {
     wp_enqueue_style('sitepulse-custom-dashboard');
 
     wp_register_script(
+        'sitepulse-dashboard-nav',
+        SITEPULSE_URL . 'modules/js/sitepulse-dashboard-nav.js',
+        [],
+        SITEPULSE_VERSION,
+        true
+    );
+
+    wp_enqueue_script('sitepulse-dashboard-nav');
+
+    wp_register_script(
         'sitepulse-chartjs',
         $chartjs_src,
         [],
@@ -1610,6 +1620,7 @@ function sitepulse_custom_dashboards_page() {
             'label'   => isset($definition['label']) ? $definition['label'] : '',
             'icon'    => isset($definition['icon']) ? $definition['icon'] : '',
             'url'     => admin_url('admin.php?page=' . $page_slug),
+            'slug'    => $page_slug,
             'current' => ($current_page === $page_slug),
         ];
     }
@@ -1620,25 +1631,74 @@ function sitepulse_custom_dashboards_page() {
         <p><?php esc_html_e("A real-time overview of your site's performance and health.", 'sitepulse'); ?></p>
 
         <?php if (!empty($module_navigation)) : ?>
-            <nav class="sitepulse-module-nav" aria-label="<?php esc_attr_e('SitePulse sections', 'sitepulse'); ?>">
-                <ul class="sitepulse-module-nav__list">
-                    <?php foreach ($module_navigation as $item) :
-                        $link_classes = ['sitepulse-module-nav__link'];
+            <?php
+            $nav_list_id = function_exists('wp_unique_id')
+                ? wp_unique_id('sitepulse-module-nav-list-')
+                : 'sitepulse-module-nav-list-' . uniqid();
 
-                        if (!empty($item['current'])) {
-                            $link_classes[] = 'is-current';
-                        }
-                    ?>
-                        <li class="sitepulse-module-nav__item">
-                            <a class="<?php echo esc_attr(implode(' ', $link_classes)); ?>" href="<?php echo esc_url($item['url']); ?>"<?php echo !empty($item['current']) ? ' aria-current="page"' : ''; ?>>
-                                <?php if (!empty($item['icon'])) : ?>
-                                    <span class="sitepulse-module-nav__icon dashicons <?php echo esc_attr($item['icon']); ?>" aria-hidden="true"></span>
-                                <?php endif; ?>
-                                <span class="sitepulse-module-nav__label"><?php echo esc_html($item['label']); ?></span>
-                            </a>
-                        </li>
-                    <?php endforeach; ?>
-                </ul>
+            $nav_select_id = function_exists('wp_unique_id')
+                ? wp_unique_id('sitepulse-module-nav-select-')
+                : 'sitepulse-module-nav-select-' . uniqid();
+            ?>
+            <nav class="sitepulse-module-nav" aria-label="<?php esc_attr_e('SitePulse sections', 'sitepulse'); ?>">
+                <form class="sitepulse-module-nav__mobile-form" method="get" action="<?php echo esc_url(admin_url('admin.php')); ?>">
+                    <label class="sitepulse-module-nav__mobile-label" for="<?php echo esc_attr($nav_select_id); ?>"><?php esc_html_e('Go to section', 'sitepulse'); ?></label>
+                    <div class="sitepulse-module-nav__mobile-controls">
+                        <select
+                            class="sitepulse-module-nav__select"
+                            id="<?php echo esc_attr($nav_select_id); ?>"
+                            name="page"
+                            data-sitepulse-nav-select
+                        >
+                            <?php foreach ($module_navigation as $item) : ?>
+                                <option value="<?php echo esc_attr($item['slug']); ?>"<?php selected(!empty($item['current'])); ?>><?php echo esc_html($item['label']); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <button type="submit" class="button sitepulse-module-nav__select-submit"><?php esc_html_e('View', 'sitepulse'); ?></button>
+                    </div>
+                </form>
+                <div class="sitepulse-module-nav__scroll">
+                    <button
+                        type="button"
+                        class="sitepulse-module-nav__scroll-button sitepulse-module-nav__scroll-button--prev"
+                        data-sitepulse-nav-scroll="prev"
+                        aria-controls="<?php echo esc_attr($nav_list_id); ?>"
+                        aria-label="<?php esc_attr_e('Scroll navigation left', 'sitepulse'); ?>"
+                        disabled
+                    >
+                        <span class="dashicons dashicons-arrow-left-alt2" aria-hidden="true"></span>
+                    </button>
+                    <div class="sitepulse-module-nav__scroll-viewport" data-sitepulse-nav-viewport>
+                        <ul class="sitepulse-module-nav__list" id="<?php echo esc_attr($nav_list_id); ?>">
+                            <?php foreach ($module_navigation as $item) :
+                                $link_classes = ['sitepulse-module-nav__link'];
+
+                                if (!empty($item['current'])) {
+                                    $link_classes[] = 'is-current';
+                                }
+                            ?>
+                                <li class="sitepulse-module-nav__item">
+                                    <a class="<?php echo esc_attr(implode(' ', $link_classes)); ?>" href="<?php echo esc_url($item['url']); ?>"<?php echo !empty($item['current']) ? ' aria-current="page"' : ''; ?>>
+                                        <?php if (!empty($item['icon'])) : ?>
+                                            <span class="sitepulse-module-nav__icon dashicons <?php echo esc_attr($item['icon']); ?>" aria-hidden="true"></span>
+                                        <?php endif; ?>
+                                        <span class="sitepulse-module-nav__label"><?php echo esc_html($item['label']); ?></span>
+                                    </a>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                    <button
+                        type="button"
+                        class="sitepulse-module-nav__scroll-button sitepulse-module-nav__scroll-button--next"
+                        data-sitepulse-nav-scroll="next"
+                        aria-controls="<?php echo esc_attr($nav_list_id); ?>"
+                        aria-label="<?php esc_attr_e('Scroll navigation right', 'sitepulse'); ?>"
+                        disabled
+                    >
+                        <span class="dashicons dashicons-arrow-right-alt2" aria-hidden="true"></span>
+                    </button>
+                </div>
             </nav>
         <?php endif; ?>
 

--- a/sitepulse_FR/modules/js/sitepulse-dashboard-nav.js
+++ b/sitepulse_FR/modules/js/sitepulse-dashboard-nav.js
@@ -1,0 +1,110 @@
+(function () {
+    'use strict';
+
+    var prefersReducedMotion = false;
+
+    if (window.matchMedia) {
+        var mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+        prefersReducedMotion = mediaQuery.matches;
+
+        if (typeof mediaQuery.addEventListener === 'function') {
+            mediaQuery.addEventListener('change', function (event) {
+                prefersReducedMotion = event.matches;
+            });
+        } else if (typeof mediaQuery.addListener === 'function') {
+            mediaQuery.addListener(function (event) {
+                prefersReducedMotion = event.matches;
+            });
+        }
+    }
+
+    var raf = typeof window.requestAnimationFrame === 'function'
+        ? window.requestAnimationFrame.bind(window)
+        : function (callback) {
+            window.setTimeout(callback, 16);
+        };
+
+    var initNavigation = function (nav) {
+        if (!nav) {
+            return;
+        }
+
+        nav.classList.add('sitepulse-module-nav--js');
+
+        var form = nav.querySelector('.sitepulse-module-nav__mobile-form');
+        var select = nav.querySelector('[data-sitepulse-nav-select]');
+
+        if (form && select) {
+            select.addEventListener('change', function () {
+                if (select.value) {
+                    form.submit();
+                }
+            });
+        }
+
+        var viewport = nav.querySelector('[data-sitepulse-nav-viewport]');
+        var prevButton = nav.querySelector('[data-sitepulse-nav-scroll="prev"]');
+        var nextButton = nav.querySelector('[data-sitepulse-nav-scroll="next"]');
+
+        if (!viewport || !prevButton || !nextButton) {
+            return;
+        }
+
+        var getScrollMetrics = function () {
+            var maxScroll = Math.max(viewport.scrollWidth - viewport.clientWidth, 0);
+
+            return {
+                maxScroll: maxScroll,
+                position: viewport.scrollLeft
+            };
+        };
+
+        var updateButtons = function () {
+            var metrics = getScrollMetrics();
+            var tolerance = 2;
+
+            if (metrics.maxScroll <= tolerance) {
+                nav.classList.remove('sitepulse-module-nav--scrollable');
+                prevButton.disabled = true;
+                nextButton.disabled = true;
+                return;
+            }
+
+            nav.classList.add('sitepulse-module-nav--scrollable');
+
+            prevButton.disabled = metrics.position <= tolerance;
+            nextButton.disabled = metrics.position >= (metrics.maxScroll - tolerance);
+        };
+
+        var scrollByAmount = function (direction) {
+            var amount = viewport.clientWidth * 0.8 * direction;
+
+            viewport.scrollBy({
+                left: amount,
+                behavior: prefersReducedMotion ? 'auto' : 'smooth'
+            });
+        };
+
+        prevButton.addEventListener('click', function () {
+            scrollByAmount(-1);
+        });
+
+        nextButton.addEventListener('click', function () {
+            scrollByAmount(1);
+        });
+
+        viewport.addEventListener('scroll', updateButtons, { passive: true });
+        window.addEventListener('resize', updateButtons);
+
+        // Ensure initial state after layout.
+        raf(updateButtons);
+    };
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var navigations = document.querySelectorAll('.sitepulse-module-nav');
+
+        navigations.forEach(function (nav) {
+            initNavigation(nav);
+        });
+    });
+})();

--- a/tests/phpunit/test-custom-dashboard-assets.php
+++ b/tests/phpunit/test-custom-dashboard-assets.php
@@ -17,6 +17,7 @@ class Sitepulse_Custom_Dashboard_Assets_Test extends WP_UnitTestCase {
         $scripts = wp_scripts();
         $scripts->remove('sitepulse-chartjs');
         $scripts->remove('sitepulse-dashboard-charts');
+        $scripts->remove('sitepulse-dashboard-nav');
     }
 
     public function test_invalid_chartjs_url_is_rejected(): void {
@@ -51,5 +52,19 @@ class Sitepulse_Custom_Dashboard_Assets_Test extends WP_UnitTestCase {
         $this->assertArrayHasKey('sitepulse-chartjs', $scripts->registered);
         $this->assertSame($custom_src, $scripts->registered['sitepulse-chartjs']->src);
         $this->assertEmpty($GLOBALS['sitepulse_logger']);
+    }
+
+    public function test_navigation_script_is_registered(): void {
+        sitepulse_custom_dashboard_enqueue_assets('toplevel_page_sitepulse-dashboard');
+
+        $scripts = wp_scripts();
+
+        $this->assertArrayHasKey('sitepulse-dashboard-nav', $scripts->registered);
+        $this->assertSame(
+            SITEPULSE_URL . 'modules/js/sitepulse-dashboard-nav.js',
+            $scripts->registered['sitepulse-dashboard-nav']->src
+        );
+        $this->assertSame([], $scripts->registered['sitepulse-dashboard-nav']->deps);
+        $this->assertTrue($scripts->registered['sitepulse-dashboard-nav']->args);
     }
 }


### PR DESCRIPTION
## Summary
- add a responsive navigation block with a mobile select and scroll controls to the custom dashboard
- provide supporting CSS and JavaScript for accessibility, scroll buttons, and reduced-motion preferences
- register the new navigation script and extend the asset test coverage

## Testing
- phpunit --configuration phpunit.xml.dist *(fails: phpunit not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68defb9f7e48832ea3a2840fb0f6de26