### PR TITLE
Add user-specific dashboard card customization controls

### DIFF
--- a/sitepulse_FR/modules/css/custom-dashboard.css
+++ b/sitepulse_FR/modules/css/custom-dashboard.css
@@ -81,6 +81,22 @@
     margin-top: 20px;
 }
 
+.sitepulse-card--small .sitepulse-chart-container {
+    height: 160px;
+}
+
+.sitepulse-card--medium .sitepulse-chart-container {
+    height: 220px;
+}
+
+.sitepulse-card--large .sitepulse-chart-container {
+    height: 300px;
+}
+
+.sitepulse-card--is-hidden {
+    display: none;
+}
+
 .sitepulse-card {
     background-color: var(--wp-admin-color-gray-0, #ffffff);
     padding: 20px;
@@ -135,6 +151,146 @@
     border: 1px dashed var(--wp-admin-color-gray-200, #c3c4c7);
     border-radius: 6px;
     font-size: 13px;
+}
+
+.sitepulse-dashboard-preferences {
+    margin-top: 24px;
+}
+
+.sitepulse-preferences__panel {
+    margin-top: 16px;
+    border: 1px solid var(--wp-admin-color-gray-200, #c3c4c7);
+    border-radius: 6px;
+    background-color: var(--wp-admin-color-gray-0, #ffffff);
+    padding: 16px;
+}
+
+.sitepulse-preferences__panel.is-loading {
+    opacity: 0.7;
+    pointer-events: none;
+}
+
+.sitepulse-preferences__description {
+    margin-top: 0;
+    margin-bottom: 16px;
+    color: var(--wp-admin-color-gray-600, #646970);
+}
+
+.sitepulse-preferences__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.sitepulse-preferences__item {
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
+    border: 1px solid var(--wp-admin-color-gray-200, #c3c4c7);
+    border-radius: 4px;
+    padding: 12px;
+    background-color: var(--wp-admin-color-gray-0, #ffffff);
+}
+
+.sitepulse-preferences__item.is-disabled {
+    opacity: 0.6;
+}
+
+.sitepulse-preferences__drag-handle {
+    width: 12px;
+    min-height: 48px;
+    background-image: radial-gradient(currentColor 10%, transparent 12%);
+    background-size: 6px 6px;
+    background-position: 0 0;
+    color: var(--wp-admin-color-gray-400, #8c8f94);
+    border-radius: 3px;
+}
+
+.sitepulse-preferences__details {
+    flex: 1;
+    min-width: 0;
+}
+
+.sitepulse-preferences__label {
+    font-weight: 600;
+}
+
+.sitepulse-preferences__status {
+    display: block;
+    margin-top: 4px;
+    font-size: 12px;
+    color: var(--wp-admin-color-gray-600, #646970);
+}
+
+.sitepulse-preferences__controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px 24px;
+    margin-top: 12px;
+}
+
+.sitepulse-preferences__control {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.sitepulse-preferences__control--size select {
+    min-width: 140px;
+}
+
+.sitepulse-preferences__notice {
+    margin-top: 16px;
+    font-size: 13px;
+    color: var(--wp-admin-color-gray-600, #646970);
+}
+
+.sitepulse-preferences__notice.is-error {
+    color: var(--wp-admin-color-red-50, #b32d2e);
+}
+
+.sitepulse-preferences__notice.is-hidden {
+    display: none;
+}
+
+.sitepulse-preferences__actions {
+    margin-top: 16px;
+    display: flex;
+    gap: 8px;
+}
+
+.sitepulse-preferences__placeholder {
+    height: 52px;
+    border: 2px dashed var(--wp-admin-color-gray-300, #b5bcc2);
+    border-radius: 4px;
+}
+
+.sitepulse-empty-state {
+    margin-top: 24px;
+    padding: 40px 24px;
+    text-align: center;
+    border: 1px dashed var(--wp-admin-color-gray-200, #c3c4c7);
+    border-radius: 6px;
+    background-color: var(--wp-admin-color-gray-0, #ffffff);
+}
+
+.sitepulse-empty-state p {
+    margin: 12px 0 0;
+    color: var(--wp-admin-color-gray-600, #646970);
+}
+
+@media (max-width: 782px) {
+    .sitepulse-preferences__controls {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .sitepulse-preferences__drag-handle {
+        display: none;
+    }
 }
 
 .sitepulse-metric {

--- a/sitepulse_FR/modules/js/sitepulse-dashboard-preferences.js
+++ b/sitepulse_FR/modules/js/sitepulse-dashboard-preferences.js
@@ -1,0 +1,334 @@
+(function ($) {
+    'use strict';
+
+    const data = window.SitePulsePreferencesData || null;
+
+    if (!data) {
+        return;
+    }
+
+    const grid = document.querySelector('[data-sitepulse-card-grid]');
+    const emptyState = document.querySelector('[data-sitepulse-empty-state]');
+    const panel = document.getElementById('sitepulse-preferences-panel');
+    const toggleButton = document.querySelector('.sitepulse-preferences__toggle');
+    const list = document.querySelector('[data-sitepulse-preferences-list]');
+    const notice = panel ? panel.querySelector('.sitepulse-preferences__notice') : null;
+    const saveButton = panel ? panel.querySelector('.sitepulse-preferences__save') : null;
+    const cancelButton = panel ? panel.querySelector('.sitepulse-preferences__cancel') : null;
+    const cardKeys = Object.keys(data.cards || {});
+    const sizeKeys = Object.keys(data.sizes || {});
+    const $list = list ? $(list) : null;
+
+    if (!panel || !toggleButton || !list) {
+        return;
+    }
+
+    let savedState = normaliseState(data.preferences || {});
+    let currentState = deepClone(savedState);
+
+    initialise();
+
+    function initialise() {
+        setControlsFromState(savedState);
+        applyStateToGrid(savedState);
+        bindEvents();
+        updateEmptyState();
+    }
+
+    function bindEvents() {
+        toggleButton.addEventListener('click', () => {
+            if (panel.hasAttribute('hidden')) {
+                openPanel();
+            } else {
+                closePanel();
+            }
+        });
+
+        if (cancelButton) {
+            cancelButton.addEventListener('click', () => {
+                currentState = deepClone(savedState);
+                setControlsFromState(savedState);
+                applyStateToGrid(savedState);
+                clearNotice();
+                closePanel();
+            });
+        }
+
+        if (saveButton) {
+            saveButton.addEventListener('click', () => {
+                currentState = buildStateFromUI();
+                persistState(currentState);
+            });
+        }
+
+        list.addEventListener('change', (event) => {
+            const target = event.target;
+
+            if (!target.classList) {
+                return;
+            }
+
+            if (target.classList.contains('sitepulse-preferences__visibility') || target.classList.contains('sitepulse-preferences__size')) {
+                currentState = buildStateFromUI();
+                applyStateToGrid(currentState);
+            }
+        });
+
+        if ($list && typeof $list.sortable === 'function') {
+            $list.sortable({
+                axis: 'y',
+                handle: '.sitepulse-preferences__drag-handle',
+                placeholder: 'sitepulse-preferences__placeholder',
+                update: () => {
+                    currentState = buildStateFromUI();
+                    applyStateToGrid(currentState);
+                }
+            });
+        }
+    }
+
+    function openPanel() {
+        currentState = deepClone(savedState);
+        setControlsFromState(savedState);
+        clearNotice();
+        panel.removeAttribute('hidden');
+        toggleButton.setAttribute('aria-expanded', 'true');
+        panel.focus();
+    }
+
+    function closePanel() {
+        panel.setAttribute('hidden', 'hidden');
+        toggleButton.setAttribute('aria-expanded', 'false');
+    }
+
+    function normaliseState(prefs) {
+        const state = {
+            order: Array.isArray(prefs.order) ? prefs.order.slice() : [],
+            visibility: typeof prefs.visibility === 'object' && prefs.visibility !== null ? { ...prefs.visibility } : {},
+            sizes: typeof prefs.sizes === 'object' && prefs.sizes !== null ? { ...prefs.sizes } : {},
+        };
+
+        const order = [];
+
+        state.order.forEach((key) => {
+            if (cardKeys.indexOf(key) !== -1 && order.indexOf(key) === -1) {
+                order.push(key);
+            }
+        });
+
+        cardKeys.forEach((key) => {
+            if (order.indexOf(key) === -1) {
+                order.push(key);
+            }
+
+            state.visibility[key] = typeof state.visibility[key] !== 'undefined' ? Boolean(state.visibility[key]) : true;
+
+            const size = typeof state.sizes[key] === 'string' ? state.sizes[key] : '';
+            state.sizes[key] = sizeKeys.indexOf(size) !== -1 ? size : (data.cards[key] && data.cards[key].defaultSize) || 'medium';
+        });
+
+        state.order = order;
+
+        return state;
+    }
+
+    function deepClone(value) {
+        return JSON.parse(JSON.stringify(value));
+    }
+
+    function setControlsFromState(state) {
+        if (!list) {
+            return;
+        }
+
+        const fragment = document.createDocumentFragment();
+
+        state.order.forEach((key) => {
+            const item = list.querySelector('[data-card-key="' + key + '"]');
+
+            if (!item) {
+                return;
+            }
+
+            const checkbox = item.querySelector('.sitepulse-preferences__visibility');
+            const select = item.querySelector('.sitepulse-preferences__size');
+
+            if (checkbox) {
+                checkbox.checked = Boolean(state.visibility[key]);
+            }
+
+            if (select) {
+                select.value = state.sizes[key] || select.value;
+            }
+
+            fragment.appendChild(item);
+        });
+
+        list.appendChild(fragment);
+
+        if ($list && typeof $list.sortable === 'function') {
+            $list.sortable('refresh');
+        }
+    }
+
+    function buildStateFromUI() {
+        if (!list) {
+            return deepClone(savedState);
+        }
+
+        const order = [];
+        const visibility = {};
+        const sizes = {};
+
+        list.querySelectorAll('[data-card-key]').forEach((item) => {
+            const key = item.getAttribute('data-card-key');
+
+            if (!key) {
+                return;
+            }
+
+            order.push(key);
+
+            const checkbox = item.querySelector('.sitepulse-preferences__visibility');
+            const select = item.querySelector('.sitepulse-preferences__size');
+
+            visibility[key] = checkbox ? Boolean(checkbox.checked) : true;
+            sizes[key] = select && typeof select.value === 'string' && select.value ? select.value : ((data.cards[key] && data.cards[key].defaultSize) || 'medium');
+        });
+
+        return normaliseState({ order, visibility, sizes });
+    }
+
+    function applyStateToGrid(state) {
+        if (!grid) {
+            return;
+        }
+
+        state.order.forEach((key) => {
+            const card = grid.querySelector('[data-card-key="' + key + '"]');
+
+            if (!card) {
+                return;
+            }
+
+            grid.appendChild(card);
+
+            const size = state.sizes[key] || 'medium';
+            card.setAttribute('data-card-size', size);
+            card.classList.remove('sitepulse-card--small', 'sitepulse-card--medium', 'sitepulse-card--large');
+            card.classList.add('sitepulse-card--' + size);
+
+            const isVisible = Boolean(state.visibility[key]);
+
+            if (isVisible) {
+                card.classList.remove('sitepulse-card--is-hidden');
+                card.removeAttribute('hidden');
+                card.removeAttribute('aria-hidden');
+            } else {
+                card.classList.add('sitepulse-card--is-hidden');
+                card.setAttribute('hidden', 'hidden');
+                card.setAttribute('aria-hidden', 'true');
+            }
+        });
+
+        updateEmptyState();
+    }
+
+    function updateEmptyState() {
+        if (!emptyState) {
+            return;
+        }
+
+        if (!grid) {
+            emptyState.removeAttribute('hidden');
+            return;
+        }
+
+        const visibleCards = grid.querySelectorAll('.sitepulse-card:not(.sitepulse-card--is-hidden)');
+
+        if (visibleCards.length === 0) {
+            emptyState.removeAttribute('hidden');
+        } else {
+            emptyState.setAttribute('hidden', 'hidden');
+        }
+    }
+
+    function persistState(state) {
+        if (!data.ajaxUrl) {
+            return;
+        }
+
+        toggleLoading(true);
+
+        $.post(data.ajaxUrl, {
+            action: 'sitepulse_save_dashboard_preferences',
+            nonce: data.nonce,
+            order: state.order,
+            visibility: state.visibility,
+            sizes: state.sizes,
+        }).done((response) => {
+            if (response && response.success && response.data && response.data.preferences) {
+                savedState = normaliseState(response.data.preferences);
+                currentState = deepClone(savedState);
+                showNotice((data.strings && data.strings.saveSuccess) || '', false);
+                speak((data.strings && data.strings.changesSaved) || '');
+                closePanel();
+            } else {
+                showNotice(getErrorMessage(response), true);
+            }
+        }).fail(() => {
+            showNotice((data.strings && data.strings.saveError) || '', true);
+        }).always(() => {
+            toggleLoading(false);
+            applyStateToGrid(savedState);
+            setControlsFromState(savedState);
+        });
+    }
+
+    function toggleLoading(isLoading) {
+        if (saveButton) {
+            saveButton.disabled = Boolean(isLoading);
+        }
+
+        if (panel) {
+            panel.classList.toggle('is-loading', Boolean(isLoading));
+        }
+    }
+
+    function showNotice(message, isError) {
+        if (!notice) {
+            return;
+        }
+
+        notice.textContent = message || '';
+        notice.classList.toggle('is-error', Boolean(isError));
+
+        if (message) {
+            notice.classList.remove('is-hidden');
+        } else {
+            notice.classList.add('is-hidden');
+        }
+    }
+
+    function clearNotice() {
+        showNotice('', false);
+    }
+
+    function getErrorMessage(response) {
+        if (response && response.data && response.data.message) {
+            return response.data.message;
+        }
+
+        return (data.strings && data.strings.saveError) || '';
+    }
+
+    function speak(message) {
+        if (!message) {
+            return;
+        }
+
+        if (window.wp && wp.a11y && typeof wp.a11y.speak === 'function') {
+            wp.a11y.speak(message, 'assertive');
+        }
+    }
+})(jQuery);


### PR DESCRIPTION
## Summary
- implement a user meta backed API and AJAX endpoint for storing dashboard card order, visibility, and sizing preferences
- render dashboard cards based on saved preferences, include an empty-state message, and expose a customization panel in the dashboard UI
- add a drag-and-drop JavaScript controller and supporting styles so users can reorder, toggle, and resize cards interactively

## Testing
- php -l sitepulse_FR/modules/custom_dashboards.php

------
https://chatgpt.com/codex/tasks/task_e_68defb989d9c832e88d477fa4dccb347