### PR TITLE
Support multi-target uptime monitoring

### DIFF
--- a/sitepulse_FR/blocks/dashboard-preview/style.css
+++ b/sitepulse_FR/blocks/dashboard-preview/style.css
@@ -89,6 +89,43 @@
     color: var(--wp-admin-color-gray-800, #2c3338);
 }
 
+.wp-block-sitepulse-dashboard-preview .sitepulse-uptime-target-list {
+    list-style: none;
+    margin: 12px 0 0;
+    padding: 0;
+    display: grid;
+    gap: 8px;
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-uptime-target-list li {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-uptime-target-name {
+    font-weight: 600;
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-uptime-target-percentage {
+    margin-left: auto;
+    font-variant-numeric: tabular-nums;
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-uptime-target-incident {
+    display: inline-block;
+    margin-left: 8px;
+    color: var(--wp-admin-color-error, #d63638);
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-card-note {
+    margin: 12px 0 0;
+    font-size: 12px;
+    color: var(--wp-admin-color-gray-700, #50575e);
+}
+
 @media (max-width: 480px) {
     .wp-block-sitepulse-dashboard-preview .sitepulse-preview-list li {
         flex-direction: column;

--- a/sitepulse_FR/includes/integrations.php
+++ b/sitepulse_FR/includes/integrations.php
@@ -15,7 +15,11 @@ add_action('plugins_loaded', function () {
 
             public function process() {
                 $this->data['load_time'] = get_option(SITEPULSE_OPTION_LAST_LOAD_TIME, 'N/A');
-                $this->data['uptime'] = get_option(SITEPULSE_OPTION_UPTIME_LOG, []);
+                if (function_exists('sitepulse_get_uptime_log_store')) {
+                    $this->data['uptime'] = sitepulse_get_uptime_log_store();
+                } else {
+                    $this->data['uptime'] = get_option(SITEPULSE_OPTION_UPTIME_LOG, []);
+                }
             }
         }
     }

--- a/sitepulse_FR/modules/css/uptime-tracker.css
+++ b/sitepulse_FR/modules/css/uptime-tracker.css
@@ -203,6 +203,54 @@
     white-space: nowrap;
     border: 0;
 }
+
+.sitepulse-uptime-status-list {
+    list-style: none;
+    margin: 20px 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.sitepulse-uptime-status-list li {
+    background: var(--sitepulse-uptime-surface);
+    border: 1px solid var(--sitepulse-uptime-border);
+    border-radius: 6px;
+    padding: 10px 12px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+}
+
+.sitepulse-uptime-status-meta {
+    color: var(--sitepulse-uptime-text-subtle);
+    font-size: 0.85em;
+}
+
+.sitepulse-uptime-target-report {
+    margin: 32px 0;
+    padding: 24px;
+    background: var(--sitepulse-uptime-surface);
+    border: 1px solid var(--sitepulse-uptime-border);
+    border-radius: 8px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
+.sitepulse-uptime-target-report h2 {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 0;
+}
+
+.sitepulse-uptime-target-meta {
+    margin: 10px 0 20px;
+    color: var(--sitepulse-uptime-text-subtle);
+    font-size: 0.9em;
+    line-height: 1.6;
+}
 .is-dark .uptime-summary-card__value,
 .is-dark .uptime-summary-card__meta,
 .is-dark .uptime-trend__legend,

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -27,7 +27,8 @@ define('SITEPULSE_OPTION_AI_RATE_LIMIT', 'sitepulse_ai_rate_limit');
 define('SITEPULSE_OPTION_AI_LAST_RUN', 'sitepulse_ai_last_run');
 define('SITEPULSE_DEFAULT_AI_MODEL', 'gemini-1.5-flash');
 define('SITEPULSE_OPTION_UPTIME_LOG', 'sitepulse_uptime_log');
-define('SITEPULSE_OPTION_UPTIME_URL', 'sitepulse_uptime_url');
+define('SITEPULSE_OPTION_UPTIME_TARGETS', 'sitepulse_uptime_targets');
+define('SITEPULSE_OPTION_UPTIME_URL', 'sitepulse_uptime_url'); // Legacy single target option.
 define('SITEPULSE_OPTION_UPTIME_TIMEOUT', 'sitepulse_uptime_timeout');
 define('SITEPULSE_OPTION_UPTIME_FREQUENCY', 'sitepulse_uptime_frequency');
 define('SITEPULSE_OPTION_UPTIME_HTTP_METHOD', 'sitepulse_uptime_http_method');


### PR DESCRIPTION
## Summary
- add a repeater-based uptime settings UI to configure multiple targets with individual frequencies and alert toggles
- refactor the uptime tracker to schedule cron hooks per frequency, log results per target, and surface incident context across the admin, dashboard, and Gutenberg block
- update downstream consumers (integrations, AI insights, uninstall routines, tests, and styling) for the new multi-target uptime data model

## Testing
- ⚠️ `phpunit --configuration phpunit.xml.dist --filter Sitepulse_Uptime_Tracker_Test` *(phpunit binary unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df966aaa7c832e9d5b251e29ada3ed