### PR TITLE
Ensure dashboard preferences panel restores focus to toggle

### DIFF
--- a/sitepulse_FR/modules/js/sitepulse-dashboard-preferences.js
+++ b/sitepulse_FR/modules/js/sitepulse-dashboard-preferences.js
@@ -98,14 +98,10 @@
     }
 
     function closePanel(focusTarget) {
-        lastActiveElement = focusTarget || document.activeElement || null;
+        rememberActiveElement(focusTarget);
 
         panel.setAttribute('hidden', 'hidden');
         toggleButton.setAttribute('aria-expanded', 'false');
-
-        if (!isFocusableElement(lastActiveElement) || (panel.contains(lastActiveElement))) {
-            lastActiveElement = toggleButton;
-        }
 
         focusAfterTransition(() => {
             if (isFocusableElement(lastActiveElement)) {
@@ -114,6 +110,17 @@
 
             lastActiveElement = null;
         });
+    }
+
+    function rememberActiveElement(focusTarget) {
+        const activeElement = focusTarget || document.activeElement || lastActiveElement;
+
+        if (isFocusableElement(activeElement) && !panel.contains(activeElement)) {
+            lastActiveElement = activeElement;
+            return;
+        }
+
+        lastActiveElement = toggleButton;
     }
 
     function normaliseState(prefs) {


### PR DESCRIPTION
## Summary
- add a helper to remember the element that should regain focus when the preferences panel closes
- ensure panel closing reuses the stored focus target so toggles, cancel, and save handlers behave consistently

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfccdcc3f8832e9e4342a03168b6ba