### PR TITLE
Add module activation guidance to dashboard preview block

### DIFF
--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -1254,6 +1254,10 @@ function sitepulse_localize_dashboard_preview_block() {
 
     $modules_payload = [];
 
+    $module_settings_url = function_exists('admin_url')
+        ? admin_url('admin.php?page=sitepulse-settings#sitepulse-section-modules')
+        : '';
+
     foreach ($module_definitions as $key => $definition) {
         $module_state = isset($modules_context[$key]) && is_array($modules_context[$key]) ? $modules_context[$key] : [];
 
@@ -1266,8 +1270,15 @@ function sitepulse_localize_dashboard_preview_block() {
 
     $data = [
         'modules' => $modules_payload,
+        'settings' => [
+            'moduleSettingsUrl' => $module_settings_url,
+        ],
         'strings' => [
-            'inactiveNotice' => __('Les modules suivants sont désactivés : %s', 'sitepulse'),
+            'inactiveNotice'        => __('Les modules suivants sont désactivés : %s', 'sitepulse'),
+            'inactiveNoticeHelp'    => __('Activez les modules requis pour afficher toutes les cartes du tableau de bord.', 'sitepulse'),
+            'inactiveNoticeCta'     => __('Gérer les modules', 'sitepulse'),
+            'moduleDisabledHelp'    => __('Ce module est actuellement désactivé. Activez-le depuis les réglages de SitePulse.', 'sitepulse'),
+            'moduleDisabledHelpCta' => __('Accéder aux réglages des modules', 'sitepulse'),
         ],
     ];
 


### PR DESCRIPTION
## Summary
- expose the dashboard preview block data for module settings URL and translated help strings
- surface contextual help and a settings CTA when modules are disabled in the editor notice and module toggles

## Testing
- php -l sitepulse_FR/sitepulse.php

------
https://chatgpt.com/codex/tasks/task_e_68dff81c4ff8832eaf818505536472ad