### PR TITLE
Improve accessibility of dashboard preview charts

### DIFF
--- a/sitepulse_FR/blocks/dashboard-preview/style.css
+++ b/sitepulse_FR/blocks/dashboard-preview/style.css
@@ -32,8 +32,12 @@
     background: rgba(255, 255, 255, 0.7);
 }
 
-.wp-block-sitepulse-dashboard-preview .sitepulse-chart-container canvas + .sitepulse-preview-list {
+.wp-block-sitepulse-dashboard-preview .sitepulse-chart-container .sitepulse-preview-summary {
     margin-top: 12px;
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-chart-container .sitepulse-preview-summary:empty {
+    display: none;
 }
 
 .wp-block-sitepulse-dashboard-preview .sitepulse-dashboard-preview__header {


### PR DESCRIPTION
## Summary
- generate dataset summaries with stable unique IDs for associating charts with descriptive text
- add accessibility attributes and canvas fallback text in the dashboard preview chart renderer
- update styles to handle the new summary wrapper without changing the visual layout

## Testing
- php -l sitepulse_FR/blocks/dashboard-preview/render.php

------
https://chatgpt.com/codex/tasks/task_e_68dff81b95fc832ea37725904290a766