### PR TITLE
Improve dashboard preview block layout supports

### DIFF
--- a/sitepulse_FR/blocks/dashboard-preview/block.json
+++ b/sitepulse_FR/blocks/dashboard-preview/block.json
@@ -8,7 +8,15 @@
   "description": "Affiche un résumé des cartes SitePulse directement dans le contenu.",
   "textdomain": "sitepulse",
   "supports": {
-    "html": false
+    "html": false,
+    "align": ["wide", "full"],
+    "anchor": true,
+    "className": true,
+    "spacing": {
+      "margin": true,
+      "padding": true,
+      "blockGap": true
+    }
   },
   "attributes": {
     "showSpeed": {
@@ -26,6 +34,18 @@
     "showLogs": {
       "type": "boolean",
       "default": true
+    },
+    "layoutVariant": {
+      "type": "string",
+      "default": "grid"
+    },
+    "columns": {
+      "type": "integer",
+      "default": 2
+    },
+    "gridDensity": {
+      "type": "string",
+      "default": "comfortable"
     }
   }
 }

--- a/sitepulse_FR/blocks/dashboard-preview/style.css
+++ b/sitepulse_FR/blocks/dashboard-preview/style.css
@@ -1,13 +1,54 @@
-.wp-block-sitepulse-dashboard-preview {
+.wp-block-sitepulse-dashboard-preview.sitepulse-dashboard-preview {
     margin: 0 auto;
+    --sitepulse-dashboard-gap: 20px;
+    --sitepulse-dashboard-card-padding: 20px;
+    --sitepulse-dashboard-header-spacing: 24px;
+}
+
+.wp-block-sitepulse-dashboard-preview.sitepulse-dashboard-preview--density-compact {
+    --sitepulse-dashboard-gap: 12px;
+    --sitepulse-dashboard-card-padding: 16px;
+    --sitepulse-dashboard-header-spacing: 18px;
+}
+
+.wp-block-sitepulse-dashboard-preview.sitepulse-dashboard-preview--density-spacious {
+    --sitepulse-dashboard-gap: 32px;
+    --sitepulse-dashboard-card-padding: 28px;
+    --sitepulse-dashboard-header-spacing: 32px;
 }
 
 .wp-block-sitepulse-dashboard-preview .sitepulse-grid {
+    display: grid;
     margin-top: 0;
+    gap: var(--sitepulse-dashboard-gap, 20px);
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-grid--cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-grid--cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-grid--cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-grid--cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.wp-block-sitepulse-dashboard-preview .sitepulse-grid--variant-list {
+    display: flex;
+    flex-direction: column;
+    grid-template-columns: none;
 }
 
 .wp-block-sitepulse-dashboard-preview .sitepulse-card {
     height: 100%;
+    padding: var(--sitepulse-dashboard-card-padding, 20px);
 }
 
 .sitepulse-dashboard-preview-block__notice {
@@ -38,7 +79,7 @@
 
 .wp-block-sitepulse-dashboard-preview .sitepulse-dashboard-preview__header {
     text-align: center;
-    margin-bottom: 24px;
+    margin-bottom: var(--sitepulse-dashboard-header-spacing, 24px);
 }
 
 .wp-block-sitepulse-dashboard-preview .sitepulse-dashboard-preview__header h3 {


### PR DESCRIPTION
## Summary
- expose align, spacing, anchor, and className support in the dashboard preview block metadata and add layout attributes for future options
- render the block wrapper with get_block_wrapper_attributes(), merging Gutenberg classes with new layout modifiers
- adjust block styles to honour density, column, and variant classes while keeping existing visuals intact

## Testing
- php -l sitepulse_FR/blocks/dashboard-preview/render.php

------
https://chatgpt.com/codex/tasks/task_e_68dff81a978c832eaa628f4b1c5f744b