### PR TITLE
Améliorer les supports du bloc dashboard preview

### DIFF
--- a/sitepulse_FR/blocks/dashboard-preview/block.json
+++ b/sitepulse_FR/blocks/dashboard-preview/block.json
@@ -16,6 +16,12 @@
       "margin": true,
       "padding": true,
       "blockGap": true
+    },
+    "layout": {
+      "allowSwitching": true,
+      "default": {
+        "type": "grid"
+      }
     }
   },
   "attributes": {
@@ -46,6 +52,10 @@
     "gridDensity": {
       "type": "string",
       "default": "comfortable"
+    },
+    "showHeader": {
+      "type": "boolean",
+      "default": true
     }
   }
 }

--- a/sitepulse_FR/blocks/dashboard-preview/render.php
+++ b/sitepulse_FR/blocks/dashboard-preview/render.php
@@ -203,6 +203,7 @@ if (!function_exists('sitepulse_render_dashboard_preview_block')) {
             'layoutVariant' => 'grid',
             'columns'       => 2,
             'gridDensity'   => 'comfortable',
+            'showHeader'    => true,
         ];
 
         $attributes = is_array($attributes) ? $attributes : [];
@@ -234,12 +235,18 @@ if (!function_exists('sitepulse_render_dashboard_preview_block')) {
             $columns = 4;
         }
 
+        $show_header = !empty($attributes['showHeader']);
+
         $base_wrapper_classes = [
             'sitepulse-dashboard-preview',
             'sitepulse-dashboard-preview--layout-' . $layout_variant_slug,
             'sitepulse-dashboard-preview--density-' . $grid_density_slug,
             'sitepulse-dashboard-preview--columns-' . $columns,
         ];
+
+        $base_wrapper_classes[] = $show_header
+            ? 'sitepulse-dashboard-preview--has-header'
+            : 'sitepulse-dashboard-preview--no-header';
 
         $grid_classes = [
             'sitepulse-grid',
@@ -248,12 +255,16 @@ if (!function_exists('sitepulse_render_dashboard_preview_block')) {
             'sitepulse-grid--variant-' . $layout_variant_slug,
         ];
 
+        $wrapper_class_attribute = function ($additional_classes = []) use ($base_wrapper_classes) {
+            $classes = array_merge($base_wrapper_classes, $additional_classes);
+            $classes = array_map('sanitize_html_class', array_unique(array_filter($classes)));
+
+            return implode(' ', $classes);
+        };
+
         if (!function_exists('sitepulse_get_dashboard_preview_context')) {
             $wrapper_attributes = get_block_wrapper_attributes([
-                'class' => implode(' ', array_filter(array_unique(array_merge(
-                    $base_wrapper_classes,
-                    ['sitepulse-dashboard-preview--is-empty']
-                )))),
+                'class' => $wrapper_class_attribute(['sitepulse-dashboard-preview--is-empty']),
             ]);
 
             return sprintf(
@@ -397,10 +408,7 @@ if (!function_exists('sitepulse_render_dashboard_preview_block')) {
 
         if (empty($cards)) {
             $wrapper_attributes = get_block_wrapper_attributes([
-                'class' => implode(' ', array_filter(array_unique(array_merge(
-                    $base_wrapper_classes,
-                    ['sitepulse-dashboard-preview--is-empty']
-                )))),
+                'class' => $wrapper_class_attribute(['sitepulse-dashboard-preview--is-empty']),
             ]);
 
             return sprintf(
@@ -410,21 +418,25 @@ if (!function_exists('sitepulse_render_dashboard_preview_block')) {
             );
         }
 
-        $header = sprintf(
-            '<div class="sitepulse-dashboard-preview__header"><h3>%1$s</h3><p>%2$s</p></div>',
-            esc_html__('Aperçu SitePulse', 'sitepulse'),
-            esc_html__('Dernières mesures agrégées par vos modules actifs.', 'sitepulse')
-        );
+        $header = '';
+
+        if ($show_header) {
+            $header = sprintf(
+                '<div class="sitepulse-dashboard-preview__header"><h3>%1$s</h3><p>%2$s</p></div>',
+                esc_html__('Aperçu SitePulse', 'sitepulse'),
+                esc_html__('Dernières mesures agrégées par vos modules actifs.', 'sitepulse')
+            );
+        }
 
         $wrapper_attributes = get_block_wrapper_attributes([
-            'class' => implode(' ', array_filter(array_unique($base_wrapper_classes))),
+            'class' => $wrapper_class_attribute(),
         ]);
 
         return sprintf(
             '<div %1$s>%2$s<div class="%3$s">%4$s</div></div>',
             $wrapper_attributes,
             $header,
-            esc_attr(implode(' ', array_map('sanitize_html_class', $grid_classes))),
+            esc_attr(implode(' ', array_map('sanitize_html_class', array_unique($grid_classes)))),
             implode('', $cards)
         );
     }

--- a/sitepulse_FR/blocks/dashboard-preview/style.css
+++ b/sitepulse_FR/blocks/dashboard-preview/style.css
@@ -1,8 +1,12 @@
-.wp-block-sitepulse-dashboard-preview.sitepulse-dashboard-preview {
-    margin: 0 auto;
+.wp-block-sitepulse-dashboard-preview {
     --sitepulse-dashboard-gap: 20px;
     --sitepulse-dashboard-card-padding: 20px;
     --sitepulse-dashboard-header-spacing: 24px;
+    margin-block: 0;
+}
+
+.wp-block-sitepulse-dashboard-preview:not(.alignwide):not(.alignfull) {
+    margin-inline: auto;
 }
 
 .wp-block-sitepulse-dashboard-preview.sitepulse-dashboard-preview--density-compact {
@@ -20,7 +24,7 @@
 .wp-block-sitepulse-dashboard-preview .sitepulse-grid {
     display: grid;
     margin-top: 0;
-    gap: var(--sitepulse-dashboard-gap, 20px);
+    gap: var(--wp--style--block-gap, var(--sitepulse-dashboard-gap, 20px));
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
@@ -44,6 +48,7 @@
     display: flex;
     flex-direction: column;
     grid-template-columns: none;
+    gap: var(--wp--style--block-gap, var(--sitepulse-dashboard-gap, 20px));
 }
 
 .wp-block-sitepulse-dashboard-preview .sitepulse-card {
@@ -84,6 +89,10 @@
 .wp-block-sitepulse-dashboard-preview .sitepulse-dashboard-preview__header {
     text-align: center;
     margin-bottom: var(--sitepulse-dashboard-header-spacing, 24px);
+}
+
+.wp-block-sitepulse-dashboard-preview.sitepulse-dashboard-preview--no-header .sitepulse-dashboard-preview__header {
+    display: none;
 }
 
 .wp-block-sitepulse-dashboard-preview .sitepulse-dashboard-preview__header h3 {


### PR DESCRIPTION
## Summary
- expose explicit layout support and a header toggle attribute for the bloc Aperçu SitePulse
- harmonise le rendu serveur en fusionnant les classes Gutenberg via get_block_wrapper_attributes
- ajuster les styles pour respecter les nouvelles classes d’alignement et l’écart défini par le support spacing

## Testing
- php -l sitepulse_FR/blocks/dashboard-preview/render.php

------
https://chatgpt.com/codex/tasks/task_e_68e034a61e98832eb6c0af177fdf0bfa