### PR TITLE
Wrap admin submenu labels for translation

### DIFF
--- a/sitepulse_FR/modules/log_analyzer.php
+++ b/sitepulse_FR/modules/log_analyzer.php
@@ -5,8 +5,8 @@ if (!defined('ABSPATH')) exit;
 add_action('admin_menu', function() {
     add_submenu_page(
         'sitepulse-dashboard',
-        'Log Analyzer',
-        'Logs',
+        __('Log Analyzer', 'sitepulse'),
+        __('Logs', 'sitepulse'),
         sitepulse_get_capability(),
         'sitepulse-logs',
         'sitepulse_log_analyzer_page'
@@ -42,7 +42,7 @@ function sitepulse_log_analyzer_page() {
     }
     ?>
     <div class="wrap">
-        <h1><span class="dashicons-before dashicons-hammer"></span> Analyseur de Logs</h1>
+        <h1><span class="dashicons-before dashicons-hammer"></span> <?php echo esc_html__('Analyseur de Logs', 'sitepulse'); ?></h1>
         <p><?php printf(esc_html__('Cet outil scanne le fichier %s de WordPress pour vous aider à trouver et corriger les problèmes sur votre site.', 'sitepulse'), $log_file_display); ?></p>
 
         <?php

--- a/sitepulse_FR/modules/plugin_impact_scanner.php
+++ b/sitepulse_FR/modules/plugin_impact_scanner.php
@@ -8,8 +8,8 @@ add_action(
     function () {
         add_submenu_page(
             'sitepulse-dashboard',
-            'Plugin Impact Scanner',
-            'Plugin Impact',
+            __('Plugin Impact Scanner', 'sitepulse'),
+            __('Plugin Impact', 'sitepulse'),
             sitepulse_get_capability(),
             'sitepulse-plugins',
             'sitepulse_plugin_impact_scanner_page'

--- a/sitepulse_FR/modules/uptime_tracker.php
+++ b/sitepulse_FR/modules/uptime_tracker.php
@@ -14,7 +14,7 @@ $sitepulse_uptime_cron_hook = function_exists('sitepulse_get_cron_hook') ? sitep
 add_filter('cron_schedules', 'sitepulse_uptime_tracker_register_cron_schedules');
 
 add_action('admin_menu', function() {
-    add_submenu_page('sitepulse-dashboard', 'Uptime Tracker', 'Uptime', sitepulse_get_capability(), 'sitepulse-uptime', 'sitepulse_uptime_tracker_page');
+    add_submenu_page('sitepulse-dashboard', __('Uptime Tracker', 'sitepulse'), __('Uptime', 'sitepulse'), sitepulse_get_capability(), 'sitepulse-uptime', 'sitepulse_uptime_tracker_page');
 });
 
 add_action('admin_enqueue_scripts', 'sitepulse_uptime_tracker_enqueue_assets');


### PR DESCRIPTION
## Summary
- wrap Plugin Impact Scanner submenu title and label in translation helpers
- localize Log Analyzer submenu labels and heading text
- update Uptime Tracker submenu labels to use translation functions

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e0ea029fd4832ebb2a2425d8377745