### PR TITLE
Fix translation for Log Analyzer header

### DIFF
--- a/sitepulse_FR/modules/log_analyzer.php
+++ b/sitepulse_FR/modules/log_analyzer.php
@@ -42,7 +42,7 @@ function sitepulse_log_analyzer_page() {
     }
     ?>
     <div class="wrap">
-        <h1><span class="dashicons-before dashicons-hammer"></span> <?php echo esc_html__('Analyseur de Logs', 'sitepulse'); ?></h1>
+        <h1><span class="dashicons-before dashicons-hammer"></span> <?php echo esc_html__('Log Analyzer', 'sitepulse'); ?></h1>
         <p><?php printf(esc_html__('Cet outil scanne le fichier %s de WordPress pour vous aider à trouver et corriger les problèmes sur votre site.', 'sitepulse'), $log_file_display); ?></p>
 
         <?php


### PR DESCRIPTION
## Summary
- ensure the Log Analyzer page header is wrapped in `esc_html__()` with the English source string so it can be translated correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0ee4f2564832e87450e7641b5439e