### PR TITLE
Localize uptime tracker UI strings

### DIFF
--- a/sitepulse_FR/languages/sitepulse.pot
+++ b/sitepulse_FR/languages/sitepulse.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-10-01T19:24:15+00:00\n"
+"POT-Creation-Date: 2025-10-04T09:54:15+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: sitepulse\n"
@@ -35,18 +35,160 @@ msgstr ""
 msgid "Jérôme Le Gousse"
 msgstr ""
 
+#: blocks/dashboard-preview/render.php:128
+msgid "Aperçu du graphique des données SitePulse."
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:146
+msgid "Votre navigateur ne prend pas en charge les graphiques. Consultez le résumé textuel ci-dessous."
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:150
+msgid "Les données du graphique sont détaillées dans le résumé textuel qui suit."
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:166
+msgid "Pas encore de mesures disponibles pour ce graphique."
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:189
+msgid "Indisponible"
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:190
+msgid "Statut non disponible"
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:282
+msgid "Activez le module « Tableaux de bord personnalisés » pour utiliser ce bloc."
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:305
+msgid "Performance PHP"
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:306
+msgid "Dernier temps de traitement mesuré lors d’un scan récent."
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:312
+#: modules/custom_dashboards.php:684
+#: modules/custom_dashboards.php:1360
+#: modules/resource_monitor.php:41
+#: modules/resource_monitor.php:101
+#: modules/speed_analyzer.php:584
+msgid "N/A"
+msgstr ""
+
+#. translators: 1: warning threshold in ms, 2: critical threshold in ms
+#: blocks/dashboard-preview/render.php:315
+#, php-format
+msgid "En dessous de %1$d ms, tout va bien. Au-delà de %2$d ms, investiguez les plugins ou l’hébergement."
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:332
+#: includes/admin-settings.php:1326
+#: includes/admin-settings.php:1337
+#: includes/admin-settings.php:1781
+#: sitepulse.php:1240
+msgid "Disponibilité"
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:333
+msgid "Taux de réussite des 30 dernières vérifications horaires."
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:340
+#: modules/custom_dashboards.php:848
+#: modules/custom_dashboards.php:1523
+#: modules/custom_dashboards.php:1930
+msgid "%"
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:341
+msgid "Chaque barre représente une vérification de disponibilité programmée."
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:356
+msgid "Santé de la base"
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:357
+msgid "Volume des révisions par rapport au budget défini."
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:364
+msgid "révisions"
+msgstr ""
+
+#. translators: %d: recommended revision limit
+#: blocks/dashboard-preview/render.php:367
+#, php-format
+msgid "Essayez de rester sous la barre des %d révisions pour éviter de gonfler la table des articles."
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:382
+msgid "Erreurs fatales"
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:383
+#: modules/log_analyzer.php:89
+msgid "Avertissements"
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:384
+#: modules/custom_dashboards.php:1007
+#: modules/custom_dashboards.php:1688
+#: modules/custom_dashboards.php:2005
+#: modules/log_analyzer.php:95
+msgid "Notices"
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:385
+msgid "Obsolescences"
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:405
+#: sitepulse.php:1250
+msgid "Journal d’erreurs"
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:406
+msgid "Répartition des évènements récents trouvés dans le fichier debug.log."
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:412
+msgid "Aucune donnée disponible."
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:414
+msgid "Analysez le journal complet depuis l’interface SitePulse pour plus de détails."
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:426
+msgid "Aucune carte à afficher pour le moment. Activez les modules souhaités ou collectez davantage de données."
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:435
+msgid "Aperçu SitePulse"
+msgstr ""
+
+#: blocks/dashboard-preview/render.php:436
+msgid "Dernières mesures agrégées par vos modules actifs."
+msgstr ""
+
 #: includes/admin-settings.php:41
-#: includes/admin-settings.php:357
-#: includes/admin-settings.php:723
-#: modules/ai_insights.php:914
-#: modules/custom_dashboards.php:233
+#: includes/admin-settings.php:952
+#: includes/admin-settings.php:2047
+#: modules/ai_insights.php:1363
+#: modules/custom_dashboards.php:1076
 #: modules/database_optimizer.php:15
 #: modules/log_analyzer.php:21
 #: modules/maintenance_advisor.php:15
-#: modules/plugin_impact_scanner.php:129
+#: modules/plugin_impact_scanner.php:224
 #: modules/resource_monitor.php:317
-#: modules/speed_analyzer.php:43
-#: modules/uptime_tracker.php:296
+#: modules/speed_analyzer.php:359
+#: modules/uptime_tracker.php:383
 msgid "Vous n'avez pas les permissions nécessaires pour accéder à cette page."
 msgstr ""
 
@@ -62,7 +204,7 @@ msgstr ""
 
 #: includes/admin-settings.php:64
 #: includes/admin-settings.php:74
-#: modules/custom_dashboards.php:659
+#: modules/custom_dashboards.php:2106
 msgid "SitePulse Dashboard"
 msgstr ""
 
@@ -82,758 +224,1334 @@ msgstr ""
 msgid "Debug"
 msgstr ""
 
-#: includes/admin-settings.php:213
-#: modules/ai_insights.php:219
-#: modules/ai_insights.php:242
+#: includes/admin-settings.php:284
+#: modules/ai_insights.php:574
+#: modules/ai_insights.php:597
 msgid "Une fois par jour"
 msgstr ""
 
-#: includes/admin-settings.php:214
-#: modules/ai_insights.php:220
-#: modules/ai_insights.php:243
+#: includes/admin-settings.php:285
+#: modules/ai_insights.php:575
+#: modules/ai_insights.php:598
 msgid "Une fois par semaine"
 msgstr ""
 
-#: includes/admin-settings.php:215
-#: modules/ai_insights.php:221
-#: modules/ai_insights.php:244
+#: includes/admin-settings.php:286
+#: modules/ai_insights.php:576
+#: modules/ai_insights.php:599
 msgid "Une fois par mois"
 msgstr ""
 
-#: includes/admin-settings.php:216
-#: modules/ai_insights.php:222
-#: modules/ai_insights.php:245
+#: includes/admin-settings.php:287
+#: modules/ai_insights.php:577
+#: modules/ai_insights.php:600
 msgid "Illimité"
 msgstr ""
 
-#: includes/admin-settings.php:361
+#: includes/admin-settings.php:472
+#: includes/admin-settings.php:1741
+msgid "Toutes les 5 minutes"
+msgstr ""
+
+#: includes/admin-settings.php:476
+#: includes/admin-settings.php:1742
+msgid "Toutes les 10 minutes"
+msgstr ""
+
+#: includes/admin-settings.php:480
+#: includes/admin-settings.php:1743
+msgid "Toutes les 15 minutes"
+msgstr ""
+
+#: includes/admin-settings.php:484
+#: includes/admin-settings.php:1744
+msgid "Toutes les 30 minutes"
+msgstr ""
+
+#: includes/admin-settings.php:488
+msgid "Toutes les heures"
+msgstr ""
+
+#: includes/admin-settings.php:492
+msgid "Deux fois par jour"
+msgstr ""
+
+#: includes/admin-settings.php:496
+msgid "Quotidien"
+msgstr ""
+
+#: includes/admin-settings.php:518
+msgid "GET"
+msgstr ""
+
+#: includes/admin-settings.php:519
+msgid "HEAD"
+msgstr ""
+
+#: includes/admin-settings.php:520
+msgid "POST"
+msgstr ""
+
+#: includes/admin-settings.php:963
+msgid "E-mail de test envoyé. Vérifiez votre boîte de réception."
+msgstr ""
+
+#: includes/admin-settings.php:966
+msgid "Impossible d’envoyer le test : aucun destinataire valide."
+msgstr ""
+
+#: includes/admin-settings.php:969
+msgid "L’envoi de l’e-mail de test a échoué. Consultez les journaux ou réessayez."
+msgstr ""
+
+#: includes/admin-settings.php:977
+#: includes/module-selector.php:39
+#: modules/log_analyzer.php:8
 msgid "Log Analyzer"
 msgstr ""
 
-#: includes/admin-settings.php:362
+#: includes/admin-settings.php:978
+msgid "Analyse les journaux WordPress et met en évidence les erreurs critiques détectées."
+msgstr ""
+
+#: includes/admin-settings.php:982
+#: includes/module-selector.php:27
 #: modules/resource_monitor.php:7
 msgid "Resource Monitor"
 msgstr ""
 
-#: includes/admin-settings.php:363
+#: includes/admin-settings.php:983
+msgid "Surveille l’utilisation des ressources serveur pour repérer les pics de charge."
+msgstr ""
+
+#: includes/admin-settings.php:987
+#: includes/module-selector.php:23
+#: modules/plugin_impact_scanner.php:11
 msgid "Plugin Impact Scanner"
 msgstr ""
 
-#: includes/admin-settings.php:364
+#: includes/admin-settings.php:988
+msgid "Évalue l’impact de chaque extension sur les performances et la stabilité."
+msgstr ""
+
+#: includes/admin-settings.php:992
+#: includes/module-selector.php:15
 #: modules/speed_analyzer.php:8
 msgid "Speed Analyzer"
 msgstr ""
 
-#: includes/admin-settings.php:365
+#: includes/admin-settings.php:993
+msgid "Mesure la vitesse de chargement pour identifier les ralentissements critiques."
+msgstr ""
+
+#: includes/admin-settings.php:997
+#: includes/module-selector.php:31
 #: modules/database_optimizer.php:6
-#: modules/database_optimizer.php:213
+#: modules/database_optimizer.php:218
 msgid "Database Optimizer"
 msgstr ""
 
-#: includes/admin-settings.php:366
+#: includes/admin-settings.php:998
+msgid "Suggère des actions de nettoyage et d’optimisation de la base de données."
+msgstr ""
+
+#: includes/admin-settings.php:1002
+#: includes/module-selector.php:35
 #: modules/maintenance_advisor.php:6
 msgid "Maintenance Advisor"
 msgstr ""
 
-#: includes/admin-settings.php:367
+#: includes/admin-settings.php:1003
+msgid "Suit les mises à jour WordPress, extensions et thèmes pour garder le site à jour."
+msgstr ""
+
+#: includes/admin-settings.php:1007
+#: includes/module-selector.php:19
+#: modules/uptime_tracker.php:17
 msgid "Uptime Tracker"
 msgstr ""
 
-#: includes/admin-settings.php:368
+#: includes/admin-settings.php:1008
+msgid "Vérifie régulièrement la disponibilité du site et alerte en cas d’incident."
+msgstr ""
+
+#: includes/admin-settings.php:1012
 msgid "AI-Powered Insights"
 msgstr ""
 
-#: includes/admin-settings.php:369
+#: includes/admin-settings.php:1013
+msgid "Génère automatiquement des recommandations basées sur l’intelligence artificielle."
+msgstr ""
+
+#: includes/admin-settings.php:1017
 msgid "Custom Dashboards"
 msgstr ""
 
-#: includes/admin-settings.php:370
+#: includes/admin-settings.php:1018
+msgid "Propose une vue d’ensemble personnalisable de vos indicateurs clés."
+msgstr ""
+
+#: includes/admin-settings.php:1022
 msgid "Error Alerts"
 msgstr ""
 
-#: includes/admin-settings.php:425
+#: includes/admin-settings.php:1023
+msgid "Surveille les erreurs critiques et déclenche des notifications ciblées."
+msgstr ""
+
+#: includes/admin-settings.php:1125
+msgid "Administrateur (valeurs par défaut)"
+msgstr ""
+
+#: includes/admin-settings.php:1190
 msgid "Impossible de vider le journal de débogage. Vérifiez les permissions du fichier."
 msgstr ""
 
-#: includes/admin-settings.php:427
+#: includes/admin-settings.php:1192
 msgid "Journal de débogage vidé."
 msgstr ""
 
-#: includes/admin-settings.php:433
+#: includes/admin-settings.php:1199
 msgid "Données stockées effacées."
 msgstr ""
 
-#: includes/admin-settings.php:527
+#: includes/admin-settings.php:1304
 msgid "SitePulse a été réinitialisé."
 msgstr ""
 
-#: includes/admin-settings.php:529
+#: includes/admin-settings.php:1306
 msgid "Impossible de supprimer le journal de débogage. Vérifiez les permissions du fichier."
 msgstr ""
 
-#: includes/admin-settings.php:535
+#: includes/admin-settings.php:1316
 msgid "Réglages de SitePulse"
 msgstr ""
 
-#: includes/admin-settings.php:538
+#: includes/admin-settings.php:1317
+msgid "Activez les modules qui vous intéressent et ajustez les seuils clés pour votre surveillance."
+msgstr ""
+
+#: includes/admin-settings.php:1319
+#: includes/admin-settings.php:1320
+msgid "Sommaire des réglages"
+msgstr ""
+
+#: includes/admin-settings.php:1322
+msgid "Connexion IA"
+msgstr ""
+
+#: includes/admin-settings.php:1323
+msgid "Réglages IA"
+msgstr ""
+
+#: includes/admin-settings.php:1324
+#: includes/admin-settings.php:1335
+msgid "Performances"
+msgstr ""
+
+#: includes/admin-settings.php:1325
+#: includes/admin-settings.php:1336
+#: includes/admin-settings.php:1673
+msgid "Alertes"
+msgstr ""
+
+#: includes/admin-settings.php:1327
+#: includes/admin-settings.php:1338
+msgid "Modules"
+msgstr ""
+
+#: includes/admin-settings.php:1328
+#: includes/admin-settings.php:1339
+#: modules/custom_dashboards.php:1790
+#: modules/maintenance_advisor.php:7
+msgid "Maintenance"
+msgstr ""
+
+#: includes/admin-settings.php:1334
+#: includes/admin-settings.php:1379
+msgid "IA"
+msgstr ""
+
+#: includes/admin-settings.php:1346
 msgid "Paramètres de l'API"
 msgstr ""
 
-#: includes/admin-settings.php:541
+#: includes/admin-settings.php:1350
+msgid "Connexion à Google Gemini"
+msgstr ""
+
+#: includes/admin-settings.php:1353
 msgid "Clé API Google Gemini"
 msgstr ""
 
-#: includes/admin-settings.php:543
+#: includes/admin-settings.php:1354
 msgid "Une clé API est enregistrée"
 msgstr ""
 
-#: includes/admin-settings.php:545
+#: includes/admin-settings.php:1356
+msgid "Cette clé est définie dans wp-config.php via la constante SITEPULSE_GEMINI_API_KEY. Mettez à jour ce fichier pour la modifier."
+msgstr ""
+
+#: includes/admin-settings.php:1358
 msgid "Une clé API est déjà enregistrée. Laissez le champ vide pour la conserver ou cochez la case ci-dessous pour l’effacer."
 msgstr ""
 
-#: includes/admin-settings.php:548
+#: includes/admin-settings.php:1362
 msgid "Effacer la clé API enregistrée"
 msgstr ""
 
 #. translators: %s: URL to Google AI Studio.
-#: includes/admin-settings.php:554
+#: includes/admin-settings.php:1369
 #, php-format
 msgid "Entrez votre clé API pour activer les analyses par IA. Obtenez une clé sur <a href=\"%s\" target=\"_blank\">Google AI Studio</a>."
 msgstr ""
 
-#: includes/admin-settings.php:562
-msgid "IA"
-msgstr ""
-
-#: includes/admin-settings.php:565
+#: includes/admin-settings.php:1383
+#: includes/admin-settings.php:1386
 msgid "Modèle IA"
 msgstr ""
 
-#: includes/admin-settings.php:572
+#: includes/admin-settings.php:1392
 msgid "Choisissez le modèle utilisé pour générer les recommandations. Les modèles diffèrent en termes de profondeur d'analyse, de coût et de temps de réponse."
 msgstr ""
 
-#: includes/admin-settings.php:582
-msgid " (modèle actuel)"
+#: includes/admin-settings.php:1402
+msgid "Modèle actuel"
 msgstr ""
 
-#: includes/admin-settings.php:592
+#: includes/admin-settings.php:1415
+msgid "Fréquence des analyses IA"
+msgstr ""
+
+#: includes/admin-settings.php:1418
 msgid "Fréquence maximale des analyses IA"
 msgstr ""
 
-#: includes/admin-settings.php:599
+#: includes/admin-settings.php:1424
 msgid "Définissez la fréquence maximale des nouvelles recommandations générées automatiquement."
 msgstr ""
 
-#: includes/admin-settings.php:603
+#: includes/admin-settings.php:1432
+msgid "Seuils de performance"
+msgstr ""
+
+#: includes/admin-settings.php:1436
+msgid "Seuil d’avertissement (ms)"
+msgstr ""
+
+#: includes/admin-settings.php:1440
+msgid "Valeur d’avertissement"
+msgstr ""
+
+#: includes/admin-settings.php:1452
+#, php-format
+msgid "Temps de traitement au-delà duquel un statut « attention » est affiché pour la vitesse. Valeur par défaut : %d ms."
+msgstr ""
+
+#: includes/admin-settings.php:1459
+msgid "Seuil critique (ms)"
+msgstr ""
+
+#: includes/admin-settings.php:1463
+msgid "Valeur critique"
+msgstr ""
+
+#: includes/admin-settings.php:1475
+#, php-format
+msgid "Temps de traitement à partir duquel les cartes passent en statut critique. Valeur par défaut : %d ms."
+msgstr ""
+
+#: includes/admin-settings.php:1482
+msgid "Seuils d’impact des plugins"
+msgstr ""
+
+#: includes/admin-settings.php:1485
+msgid "Définissez les seuils d’avertissement et critiques utilisés pour mettre en évidence les plugins selon le rôle de l’utilisateur connecté."
+msgstr ""
+
+#: includes/admin-settings.php:1489
+msgid "Impact – avertissement (%)"
+msgstr ""
+
+#: includes/admin-settings.php:1490
+msgid "Pourcentage d’impact à partir duquel un plugin passe en statut « attention »."
+msgstr ""
+
+#: includes/admin-settings.php:1493
+msgid "Impact – critique (%)"
+msgstr ""
+
+#: includes/admin-settings.php:1494
+msgid "Pourcentage d’impact à partir duquel un plugin est marqué critique."
+msgstr ""
+
+#: includes/admin-settings.php:1497
+msgid "Poids – avertissement (%)"
+msgstr ""
+
+#: includes/admin-settings.php:1498
+msgid "Part du poids total à partir de laquelle un plugin est signalé en attention."
+msgstr ""
+
+#: includes/admin-settings.php:1501
+msgid "Poids – critique (%)"
+msgstr ""
+
+#: includes/admin-settings.php:1502
+msgid "Part du poids total à partir de laquelle un plugin est signalé critique."
+msgstr ""
+
+#: includes/admin-settings.php:1514
+msgid "Ces valeurs servent de référence et s’appliquent à tous les rôles ne disposant pas d’override."
+msgstr ""
+
+#: includes/admin-settings.php:1516
+msgid "Modifiez ces valeurs pour personnaliser les surlignages pour ce rôle. Si elles correspondent aux valeurs par défaut, aucun override n’est conservé."
+msgstr ""
+
+#: includes/admin-settings.php:1560
+msgid "Seuil de disponibilité (%)"
+msgstr ""
+
+#: includes/admin-settings.php:1564
+msgid "Pourcentage minimal"
+msgstr ""
+
+#: includes/admin-settings.php:1577
+#, php-format
+msgid "Pourcentage minimal de disponibilité avant de signaler une alerte. Valeur par défaut : %s %%."
+msgstr ""
+
+#: includes/admin-settings.php:1584
+msgid "Limite de révisions"
+msgstr ""
+
+#: includes/admin-settings.php:1588
+msgid "Nombre recommandé"
+msgstr ""
+
+#: includes/admin-settings.php:1600
+#, php-format
+msgid "Nombre maximal de révisions recommandé avant de proposer un nettoyage. Valeur par défaut : %d."
+msgstr ""
+
+#: includes/admin-settings.php:1610
 msgid "Activer les Modules"
 msgstr ""
 
-#: includes/admin-settings.php:604
+#: includes/admin-settings.php:1611
 msgid "Sélectionnez les modules de surveillance à activer."
 msgstr ""
 
-#: includes/admin-settings.php:613
-msgid "Activer le Mode Debug"
+#: includes/admin-settings.php:1627
+msgid "Activé"
 msgstr ""
 
-#: includes/admin-settings.php:617
+#: includes/admin-settings.php:1627
+msgid "Désactivé"
+msgstr ""
+
+#: includes/admin-settings.php:1641
+msgid "Activer ce module"
+msgstr ""
+
+#: includes/admin-settings.php:1645
+msgid "Ouvrir le module"
+msgstr ""
+
+#: includes/admin-settings.php:1654
+msgid "Mode Debug"
+msgstr ""
+
+#: includes/admin-settings.php:1657
 msgid "Active la journalisation détaillée et le tableau de bord de débogage. À n'utiliser que pour le dépannage."
 msgstr ""
 
-#: includes/admin-settings.php:618
+#: includes/admin-settings.php:1662
+msgid "Activer le Mode Debug"
+msgstr ""
+
+#: includes/admin-settings.php:1665
 #, php-format
 msgid "Sur Nginx (ou tout serveur qui ignore .htaccess / web.config), déplacez le journal via le filtre %s ou bloquez-le côté serveur."
 msgstr ""
 
-#: includes/admin-settings.php:622
-msgid "Alertes"
-msgstr ""
-
-#: includes/admin-settings.php:625
+#: includes/admin-settings.php:1677
 msgid "Destinataires des alertes"
 msgstr ""
 
-#: includes/admin-settings.php:632
+#: includes/admin-settings.php:1684
+msgid "Adresses e-mail"
+msgstr ""
+
+#: includes/admin-settings.php:1686
 msgid "Entrez une adresse par ligne (ou séparées par des virgules). L'adresse e-mail de l'administrateur sera toujours incluse si elle est valide."
 msgstr ""
 
-#: includes/admin-settings.php:636
+#: includes/admin-settings.php:1696
 msgid "Seuil d'alerte de charge CPU"
 msgstr ""
 
-#: includes/admin-settings.php:639
+#: includes/admin-settings.php:1702
+msgid "Activer les alertes de charge CPU"
+msgstr ""
+
+#: includes/admin-settings.php:1704
+msgid "Valeur déclenchant une alerte"
+msgstr ""
+
+#: includes/admin-settings.php:1706
 msgid "Une alerte e-mail est envoyée lorsque la charge moyenne sur 1 minute dépasse ce seuil multiplié par le nombre de cœurs détectés."
 msgstr ""
 
-#: includes/admin-settings.php:643
+#: includes/admin-settings.php:1711
+msgid "Alertes sur les erreurs PHP"
+msgstr ""
+
+#: includes/admin-settings.php:1716
+msgid "Activer les alertes sur les erreurs fatales"
+msgstr ""
+
+#: includes/admin-settings.php:1718
+msgid "Nombre de lignes fatales avant alerte"
+msgstr ""
+
+#: includes/admin-settings.php:1720
+msgid "Déclenche une alerte lorsqu’au moins ce nombre de nouvelles entrées fatales est trouvé dans le journal."
+msgstr ""
+
+#: includes/admin-settings.php:1725
 msgid "Fenêtre anti-spam (minutes)"
 msgstr ""
 
-#: includes/admin-settings.php:646
+#: includes/admin-settings.php:1728
+msgid "Durée minimale entre deux alertes identiques"
+msgstr ""
+
+#: includes/admin-settings.php:1730
 msgid "Empêche l'envoi de plusieurs e-mails identiques pendant la durée spécifiée."
 msgstr ""
 
-#: includes/admin-settings.php:650
+#: includes/admin-settings.php:1735
 msgid "Fréquence des vérifications"
 msgstr ""
 
-#: includes/admin-settings.php:655
-msgid "Toutes les 5 minutes"
+#: includes/admin-settings.php:1747
+msgid "Intervalle choisi"
 msgstr ""
 
-#: includes/admin-settings.php:656
-msgid "Toutes les 10 minutes"
-msgstr ""
-
-#: includes/admin-settings.php:657
-msgid "Toutes les 15 minutes"
-msgstr ""
-
-#: includes/admin-settings.php:658
-msgid "Toutes les 30 minutes"
-msgstr ""
-
-#: includes/admin-settings.php:666
+#: includes/admin-settings.php:1753
 msgid "Détermine la fréquence des vérifications automatisées pour les alertes."
 msgstr ""
 
-#: includes/admin-settings.php:670
-msgid "Disponibilité"
+#: includes/admin-settings.php:1758
+msgid "Tester la configuration"
 msgstr ""
 
-#: includes/admin-settings.php:673
+#: includes/admin-settings.php:1761
+msgid "Envoyez un e-mail de démonstration aux destinataires configurés pour vérifier l’acheminement."
+msgstr ""
+
+#: includes/admin-settings.php:1773
+msgid "Envoyer un test"
+msgstr ""
+
+#: includes/admin-settings.php:1785
 msgid "URL à surveiller"
 msgstr ""
 
-#: includes/admin-settings.php:677
+#: includes/admin-settings.php:1789
+msgid "Adresse du site"
+msgstr ""
+
+#: includes/admin-settings.php:1791
 msgid "Laisser vide pour utiliser automatiquement l’URL principale du site."
 msgstr ""
 
-#: includes/admin-settings.php:681
+#: includes/admin-settings.php:1796
 msgid "Délai d’attente (secondes)"
 msgstr ""
 
-#: includes/admin-settings.php:685
+#: includes/admin-settings.php:1800
+msgid "Temps maximal avant échec"
+msgstr ""
+
+#: includes/admin-settings.php:1802
 msgid "Nombre de secondes avant de considérer la requête comme échouée."
 msgstr ""
 
-#: includes/admin-settings.php:689
+#: includes/admin-settings.php:1807
+msgid "Fréquence des contrôles"
+msgstr ""
+
+#: includes/admin-settings.php:1811
+msgid "Intervalle entre deux vérifications"
+msgstr ""
+
+#: includes/admin-settings.php:1823
+msgid "Sélectionnez la fréquence d’exécution de la tâche de surveillance."
+msgstr ""
+
+#: includes/admin-settings.php:1828
+msgid "Méthode HTTP"
+msgstr ""
+
+#: includes/admin-settings.php:1832
+msgid "Méthode utilisée pour la requête"
+msgstr ""
+
+#: includes/admin-settings.php:1838
+msgid "Choisissez la méthode HTTP employée pour vérifier la disponibilité."
+msgstr ""
+
+#: includes/admin-settings.php:1843
+msgid "En-têtes personnalisés"
+msgstr ""
+
+#: includes/admin-settings.php:1846
+msgid "En-têtes additionnels"
+msgstr ""
+
+#: includes/admin-settings.php:1847
+msgid "Header-Name: valeur"
+msgstr ""
+
+#: includes/admin-settings.php:1848
+msgid "Indiquez un en-tête par ligne au format « Nom: valeur ». Laissez vide pour n’ajouter aucun en-tête."
+msgstr ""
+
+#: includes/admin-settings.php:1853
+msgid "Codes HTTP attendus"
+msgstr ""
+
+#: includes/admin-settings.php:1856
+msgid "Codes considérés comme succès"
+msgstr ""
+
+#: includes/admin-settings.php:1858
+msgid "Liste de codes séparés par des virgules ou plages (ex. 200-204). Laissez vide pour accepter toute réponse 2xx ou 3xx."
+msgstr ""
+
+#: includes/admin-settings.php:1865
 msgid "Enregistrer les modifications"
 msgstr ""
 
-#: includes/admin-settings.php:692
+#: includes/admin-settings.php:1870
 msgid "Nettoyage & Réinitialisation"
 msgstr ""
 
-#: includes/admin-settings.php:693
+#: includes/admin-settings.php:1871
 msgid "Gérez les données du plugin."
 msgstr ""
 
-#: includes/admin-settings.php:698
+#: includes/admin-settings.php:1877
 msgid "Vider le journal de debug"
 msgstr ""
 
-#: includes/admin-settings.php:699
-msgid "Vider le journal"
-msgstr ""
-
-#: includes/admin-settings.php:699
+#: includes/admin-settings.php:1880
 msgid "Supprime le contenu du fichier de log de débogage."
 msgstr ""
 
-#: includes/admin-settings.php:702
+#: includes/admin-settings.php:1882
+msgid "Vider le journal"
+msgstr ""
+
+#: includes/admin-settings.php:1888
 msgid "Vider les données stockées"
 msgstr ""
 
-#: includes/admin-settings.php:703
-msgid "Vider les données"
-msgstr ""
-
-#: includes/admin-settings.php:703
+#: includes/admin-settings.php:1891
 msgid "Supprime les données stockées comme les journaux de disponibilité et les résultats de scan."
 msgstr ""
 
-#: includes/admin-settings.php:706
+#: includes/admin-settings.php:1893
+msgid "Vider les données"
+msgstr ""
+
+#: includes/admin-settings.php:1899
 msgid "Réinitialiser le plugin"
 msgstr ""
 
-#: includes/admin-settings.php:708
-msgid "Tout réinitialiser"
-msgstr ""
-
-#: includes/admin-settings.php:708
-msgid "Êtes-vous sûr ?"
-msgstr ""
-
-#: includes/admin-settings.php:709
+#: includes/admin-settings.php:1902
 msgid "Réinitialise SitePulse à son état d'installation initial."
 msgstr ""
 
+#: includes/admin-settings.php:1904
+msgid "Êtes-vous sûr ?"
+msgstr ""
+
+#: includes/admin-settings.php:1904
+msgid "Tout réinitialiser"
+msgstr ""
+
 #. translators: 1: number of log lines kept, 2: formatted size limit.
-#: includes/admin-settings.php:794
+#: includes/admin-settings.php:2118
 #, php-format
 msgid "Seules les %1$d dernières lignes du journal (limitées à %2$s) sont chargées pour éviter toute surcharge mémoire."
 msgstr ""
 
-#: includes/functions.php:101
+#: includes/functions.php:289
 msgid "Gemini 1.5 Flash"
 msgstr ""
 
-#: includes/functions.php:102
+#: includes/functions.php:290
 msgid "Réponses rapides et économiques, idéales pour obtenir des recommandations synthétiques à fréquence élevée."
 msgstr ""
 
-#: includes/functions.php:103
+#: includes/functions.php:291
 msgid "Fournis une synthèse claire et actionnable en te concentrant sur les gains rapides."
 msgstr ""
 
-#: includes/functions.php:106
+#: includes/functions.php:294
 msgid "Gemini 1.5 Pro"
 msgstr ""
 
-#: includes/functions.php:107
+#: includes/functions.php:295
 msgid "Analyse plus approfondie avec davantage de contexte et de détails, adaptée aux audits complets mais plus lente et coûteuse."
 msgstr ""
 
-#: includes/functions.php:108
+#: includes/functions.php:296
 msgid "Apporte une analyse détaillée et justifie chaque recommandation avec les impacts attendus."
 msgstr ""
 
+#: includes/module-selector.php:43
 #: modules/ai_insights.php:7
 #: modules/ai_insights.php:8
+#: modules/custom_dashboards.php:1795
 msgid "AI Insights"
 msgstr ""
 
+#: includes/module-selector.php:154
+msgid "SitePulse module navigation"
+msgstr ""
+
+#: includes/module-selector.php:157
+msgid "Jump to module"
+msgstr ""
+
+#: includes/module-selector.php:168
+msgid "Select a module"
+msgstr ""
+
+#: includes/module-selector.php:177
+msgid "Open module"
+msgstr ""
+
 #. translators: 1: Status or error code, 2: error details.
-#: modules/ai_insights.php:100
+#: modules/ai_insights.php:455
 #, php-format
 msgid "Code %1$d — %2$s"
 msgstr ""
 
-#: modules/ai_insights.php:328
+#: modules/ai_insights.php:683
 msgid "Veuillez entrer votre clé API Google Gemini dans les réglages de SitePulse."
 msgstr ""
 
-#: modules/ai_insights.php:368
+#: modules/ai_insights.php:723
 msgid "Tu es un expert en optimisation de sites WordPress."
 msgstr ""
 
 #. translators: %1$s: Site name, %2$s: Site URL
-#: modules/ai_insights.php:371
+#: modules/ai_insights.php:726
 #, php-format
 msgid "Analyse les performances du site \"%1$s\" disponible à l'adresse %2$s."
 msgstr ""
 
-#: modules/ai_insights.php:375
+#: modules/ai_insights.php:730
 msgid "Fournis trois recommandations concrètes pour améliorer la vitesse, le référencement et la conversion. Réponds en français."
 msgstr ""
 
 #. translators: %s: site description
-#: modules/ai_insights.php:387
+#: modules/ai_insights.php:742
 #, php-format
 msgid "Description du site : %s."
 msgstr ""
 
-#: modules/ai_insights.php:414
+#: modules/ai_insights.php:769
 msgid "erreur JSON inconnue"
 msgstr ""
 
 #. translators: %s: error detail
-#: modules/ai_insights.php:420
+#: modules/ai_insights.php:775
 #, php-format
 msgid "Impossible de préparer la requête pour Gemini : %s"
 msgstr ""
 
 #. translators: %s: formatted size limit
-#: modules/ai_insights.php:457
+#: modules/ai_insights.php:812
 #, php-format
 msgid "La réponse de Gemini dépasse la taille maximale autorisée (%s). Veuillez réessayer ou augmenter la limite via le filtre sitepulse_ai_response_size_limit."
 msgstr ""
 
 #. translators: %s: error message
-#: modules/ai_insights.php:467
-#: modules/ai_insights.php:497
+#: modules/ai_insights.php:822
+#: modules/ai_insights.php:852
 #, php-format
 msgid "Erreur lors de la génération de l’analyse IA : %s"
 msgstr ""
 
-#: modules/ai_insights.php:491
+#: modules/ai_insights.php:846
 #, php-format
 msgid "HTTP %d"
 msgstr ""
 
-#: modules/ai_insights.php:507
+#: modules/ai_insights.php:862
 msgid "Structure de réponse inattendue reçue depuis Gemini."
 msgstr ""
 
-#: modules/ai_insights.php:523
+#: modules/ai_insights.php:878
+#: modules/ai_insights.php:886
 msgid "La réponse de Gemini ne contient aucun texte exploitable."
 msgstr ""
 
-#: modules/ai_insights.php:575
+#: modules/ai_insights.php:940
 msgid "Impossible de planifier la génération de l’analyse IA. Veuillez réessayer."
 msgstr ""
 
-#: modules/ai_insights.php:583
-msgid "La planification du traitement IA a échoué. Veuillez réessayer ultérieurement."
+#: modules/ai_insights.php:948
+msgid "WP-Cron semble désactivé sur ce site. L’analyse IA sera exécutée immédiatement, mais pensez à réactiver WP-Cron (retirez DISABLE_WP_CRON de wp-config.php ou planifiez une tâche serveur)."
+msgstr ""
+
+#: modules/ai_insights.php:949
+msgid "La planification du traitement IA a échoué. L’analyse est exécutée immédiatement."
 msgstr ""
 
 #. translators: %s: error message
-#: modules/ai_insights.php:663
+#: modules/ai_insights.php:1082
 #, php-format
 msgid "Une erreur inattendue est survenue lors de la génération de l’analyse IA : %s"
 msgstr ""
 
 #. translators: %s: Average TTFB in milliseconds.
-#: modules/ai_insights.php:766
+#: modules/ai_insights.php:1193
 #, php-format
 msgid "TTFB moyen observé : %s ms."
 msgstr ""
 
 #. translators: %s: Uptime percentage.
-#: modules/ai_insights.php:802
+#: modules/ai_insights.php:1229
 #, php-format
 msgid "Disponibilité récemment mesurée : %s%%."
 msgstr ""
 
 #. translators: 1: Plugin name, 2: Average execution time in milliseconds.
-#: modules/ai_insights.php:853
+#: modules/ai_insights.php:1280
 #, php-format
 msgid "Plugin le plus coûteux : %1$s (%2$s ms en moyenne)."
 msgstr ""
 
-#: modules/ai_insights.php:895
+#: modules/ai_insights.php:1343
 msgid "Une erreur inattendue est survenue. Veuillez réessayer."
 msgstr ""
 
-#: modules/ai_insights.php:896
+#: modules/ai_insights.php:1344
 msgid "Dernière mise à jour :"
 msgstr ""
 
-#: modules/ai_insights.php:897
+#: modules/ai_insights.php:1345
 msgid "Résultat issu du cache."
 msgstr ""
 
-#: modules/ai_insights.php:898
+#: modules/ai_insights.php:1346
 msgid "Nouvelle analyse générée."
 msgstr ""
 
-#: modules/ai_insights.php:899
+#: modules/ai_insights.php:1347
 msgid "Génération en cours…"
 msgstr ""
 
-#: modules/ai_insights.php:900
+#: modules/ai_insights.php:1348
 msgid "Analyse en attente de traitement…"
 msgstr ""
 
-#: modules/ai_insights.php:901
+#: modules/ai_insights.php:1349
 msgid "La génération a échoué. Veuillez réessayer."
 msgstr ""
 
-#: modules/ai_insights.php:928
+#: modules/ai_insights.php:1350
+#: modules/ai_insights.php:1478
+#: modules/speed_analyzer.php:341
+#: modules/speed_analyzer.php:483
+msgid "Aucun historique disponible pour le moment."
+msgstr ""
+
+#: modules/ai_insights.php:1387
 msgid "Analyses par IA"
 msgstr ""
 
-#: modules/ai_insights.php:929
+#: modules/ai_insights.php:1388
 msgid "Obtenez des recommandations personnalisées pour votre site en analysant ses données de performance avec l'IA Gemini de Google."
 msgstr ""
 
-#: modules/ai_insights.php:932
+#: modules/ai_insights.php:1392
+msgid "WP-Cron est désactivé. SitePulse exécutera les analyses à la demande, mais réactivez-le pour automatiser les traitements (retirez la constante <code>DISABLE_WP_CRON</code> de wp-config.php ou configurez une tâche cron serveur)."
+msgstr ""
+
+#: modules/ai_insights.php:1399
 msgid "Choix du modèle IA"
 msgstr ""
 
 #. translators: %s: URL to the SitePulse settings page.
-#: modules/ai_insights.php:936
+#: modules/ai_insights.php:1403
 #, php-format
 msgid "Le modèle sélectionné dans les réglages (<a href=\"%s\">Réglages &gt; IA</a>) influence la granularité des recommandations et le temps de génération."
 msgstr ""
 
-#: modules/ai_insights.php:949
+#: modules/ai_insights.php:1416
 msgid " (actuellement utilisé)"
 msgstr ""
 
-#: modules/ai_insights.php:958
+#: modules/ai_insights.php:1425
 #, php-format
 msgid "Veuillez <a href=\"%s\">entrer votre clé API Google Gemini</a> pour utiliser cette fonctionnalité."
 msgstr ""
 
-#: modules/ai_insights.php:961
+#: modules/ai_insights.php:1428
 msgid "Générer une Analyse"
 msgstr ""
 
-#: modules/ai_insights.php:964
+#: modules/ai_insights.php:1431
 msgid "Forcer une nouvelle analyse"
 msgstr ""
 
-#: modules/ai_insights.php:971
+#: modules/ai_insights.php:1438
 msgid "Votre Recommandation par IA"
 msgstr ""
 
-#: modules/ai_insights.php:982
-#: modules/ai_insights.php:1079
+#: modules/ai_insights.php:1444
+msgid "Historique des recommandations"
+msgstr ""
+
+#: modules/ai_insights.php:1447
+msgid "Modèle"
+msgstr ""
+
+#: modules/ai_insights.php:1449
+msgid "Tous les modèles"
+msgstr ""
+
+#: modules/ai_insights.php:1462
+msgid "Limitation"
+msgstr ""
+
+#: modules/ai_insights.php:1464
+msgid "Toutes les limitations"
+msgstr ""
+
+#: modules/ai_insights.php:1530
+#: modules/ai_insights.php:1641
+#: modules/error_alerts.php:801
+#: modules/error_alerts.php:838
 msgid "Vous n'avez pas les permissions nécessaires pour effectuer cette action."
 msgstr ""
 
-#: modules/ai_insights.php:992
-#: modules/ai_insights.php:1089
+#: modules/ai_insights.php:1540
+#: modules/ai_insights.php:1651
 msgid "Échec de la vérification de sécurité. Veuillez recharger la page et réessayer."
 msgstr ""
 
 #. translators: 1: Human readable delay (e.g. "5 minutes"), 2: rate limit label.
-#: modules/ai_insights.php:1040
+#: modules/ai_insights.php:1602
 #, php-format
 msgid "La génération par IA est limitée à %2$s. Réessayez dans %1$s."
 msgstr ""
 
-#: modules/ai_insights.php:1099
+#: modules/ai_insights.php:1661
 msgid "Identifiant de tâche manquant."
 msgstr ""
 
-#: modules/ai_insights.php:1109
+#: modules/ai_insights.php:1671
 msgid "Tâche introuvable ou expirée. Veuillez relancer une génération."
 msgstr ""
 
-#: modules/ai_insights.php:1125
+#: modules/ai_insights.php:1687
 msgid "La génération de l’analyse IA a échoué."
 msgstr ""
 
-#: modules/custom_dashboards.php:264
-#: modules/speed_analyzer.php:83
+#: modules/custom_dashboards.php:443
+msgid "Vous n’avez pas les permissions nécessaires pour modifier ces préférences."
+msgstr ""
+
+#: modules/custom_dashboards.php:449
+msgid "Jeton de sécurité invalide. Merci de recharger la page."
+msgstr ""
+
+#: modules/custom_dashboards.php:463
+msgid "Impossible d’enregistrer les préférences pour le moment."
+msgstr ""
+
+#: modules/custom_dashboards.php:505
+#: modules/custom_dashboards.php:1100
+#: modules/speed_analyzer.php:408
 msgid "Bon"
 msgstr ""
 
-#: modules/custom_dashboards.php:265
-#: modules/speed_analyzer.php:84
+#: modules/custom_dashboards.php:506
+#: modules/custom_dashboards.php:1101
+#: modules/speed_analyzer.php:409
 msgid "Statut : bon"
 msgstr ""
 
-#: modules/custom_dashboards.php:269
-#: modules/speed_analyzer.php:88
+#: modules/custom_dashboards.php:510
+#: modules/custom_dashboards.php:1105
+#: modules/speed_analyzer.php:413
 msgid "Attention"
 msgstr ""
 
-#: modules/custom_dashboards.php:270
-#: modules/speed_analyzer.php:89
+#: modules/custom_dashboards.php:511
+#: modules/custom_dashboards.php:1106
+#: modules/speed_analyzer.php:414
 msgid "Statut : attention"
 msgstr ""
 
-#: modules/custom_dashboards.php:274
-#: modules/speed_analyzer.php:93
+#: modules/custom_dashboards.php:515
+#: modules/custom_dashboards.php:1110
+#: modules/speed_analyzer.php:418
 msgid "Critique"
 msgstr ""
 
-#: modules/custom_dashboards.php:275
-#: modules/speed_analyzer.php:94
+#: modules/custom_dashboards.php:516
+#: modules/custom_dashboards.php:1111
+#: modules/speed_analyzer.php:419
 msgid "Statut : critique"
 msgstr ""
 
-#: modules/custom_dashboards.php:318
-#: modules/custom_dashboards.php:329
+#: modules/custom_dashboards.php:683
+#: modules/custom_dashboards.php:722
+#: modules/custom_dashboards.php:1359
+#: modules/custom_dashboards.php:1398
 msgid "ms"
 msgstr ""
 
-#: modules/custom_dashboards.php:319
-#: modules/resource_monitor.php:41
-#: modules/resource_monitor.php:101
-#: modules/speed_analyzer.php:178
-msgid "N/A"
-msgstr ""
-
-#: modules/custom_dashboards.php:343
-#: modules/custom_dashboards.php:617
-msgid "Measured time"
-msgstr ""
-
-#: modules/custom_dashboards.php:344
-#: modules/custom_dashboards.php:358
-#: modules/custom_dashboards.php:618
-msgid "Performance budget"
-msgstr ""
-
-#: modules/custom_dashboards.php:359
-#: modules/custom_dashboards.php:619
-msgid "Over budget"
-msgstr ""
-
-#: modules/custom_dashboards.php:409
+#: modules/custom_dashboards.php:701
+#: modules/custom_dashboards.php:818
+#: modules/custom_dashboards.php:1377
+#: modules/custom_dashboards.php:1494
 msgid "Unknown"
 msgstr ""
 
-#: modules/custom_dashboards.php:438
-#: modules/custom_dashboards.php:723
-msgid "%"
+#: modules/custom_dashboards.php:735
+#: modules/custom_dashboards.php:1411
+#: modules/custom_dashboards.php:1740
+msgid "Processing time"
 msgstr ""
 
-#: modules/custom_dashboards.php:467
+#: modules/custom_dashboards.php:747
+#: modules/custom_dashboards.php:1423
+#: modules/custom_dashboards.php:1742
+msgid "Performance budget"
+msgstr ""
+
+#: modules/custom_dashboards.php:904
+#: modules/custom_dashboards.php:1584
 msgid "Stored revisions"
 msgstr ""
 
-#: modules/custom_dashboards.php:468
+#: modules/custom_dashboards.php:905
+#: modules/custom_dashboards.php:1585
 msgid "Remaining before cleanup"
 msgstr ""
 
-#: modules/custom_dashboards.php:482
+#: modules/custom_dashboards.php:920
+#: modules/custom_dashboards.php:1600
 msgid "Recommended maximum"
 msgstr ""
 
-#: modules/custom_dashboards.php:483
+#: modules/custom_dashboards.php:921
+#: modules/custom_dashboards.php:1601
 msgid "Excess revisions"
 msgstr ""
 
-#: modules/custom_dashboards.php:510
+#: modules/custom_dashboards.php:948
+#: modules/custom_dashboards.php:1629
 msgid "Log is clean."
 msgstr ""
 
-#: modules/custom_dashboards.php:521
+#: modules/custom_dashboards.php:959
+#: modules/custom_dashboards.php:1640
 msgid "Debug log not configured."
 msgstr ""
 
-#: modules/custom_dashboards.php:524
+#: modules/custom_dashboards.php:962
+#: modules/custom_dashboards.php:1643
 #, php-format
 msgid "Log file not found (%s)."
 msgstr ""
 
-#: modules/custom_dashboards.php:527
-#: modules/custom_dashboards.php:533
+#: modules/custom_dashboards.php:965
+#: modules/custom_dashboards.php:971
+#: modules/custom_dashboards.php:1646
+#: modules/custom_dashboards.php:1652
 #, php-format
 msgid "Unable to read log file (%s)."
 msgstr ""
 
-#: modules/custom_dashboards.php:535
+#: modules/custom_dashboards.php:973
+#: modules/custom_dashboards.php:1654
 msgid "No recent log entries."
 msgstr ""
 
-#: modules/custom_dashboards.php:554
+#: modules/custom_dashboards.php:992
+#: modules/custom_dashboards.php:1673
 msgid "Fatal errors detected in the debug log."
 msgstr ""
 
-#: modules/custom_dashboards.php:557
+#: modules/custom_dashboards.php:995
+#: modules/custom_dashboards.php:1676
 msgid "Warnings present in the debug log."
 msgstr ""
 
-#: modules/custom_dashboards.php:559
+#: modules/custom_dashboards.php:997
+#: modules/custom_dashboards.php:1678
 msgid "No critical events detected."
 msgstr ""
 
-#: modules/custom_dashboards.php:567
-#: modules/custom_dashboards.php:786
+#: modules/custom_dashboards.php:1005
+#: modules/custom_dashboards.php:1686
+#: modules/custom_dashboards.php:1997
 msgid "Fatal errors"
 msgstr ""
 
-#: modules/custom_dashboards.php:568
-#: modules/custom_dashboards.php:790
+#: modules/custom_dashboards.php:1006
+#: modules/custom_dashboards.php:1687
+#: modules/custom_dashboards.php:2001
 msgid "Warnings"
 msgstr ""
 
-#: modules/custom_dashboards.php:569
-#: modules/custom_dashboards.php:794
-#: modules/log_analyzer.php:90
-msgid "Notices"
-msgstr ""
-
-#: modules/custom_dashboards.php:570
-#: modules/custom_dashboards.php:798
+#: modules/custom_dashboards.php:1008
+#: modules/custom_dashboards.php:1689
+#: modules/custom_dashboards.php:2009
 msgid "Deprecated notices"
 msgstr ""
 
-#: modules/custom_dashboards.php:613
+#: modules/custom_dashboards.php:1735
 msgid "Not enough data to render this chart yet."
 msgstr ""
 
-#: modules/custom_dashboards.php:614
+#: modules/custom_dashboards.php:1736
 msgid "Site operational"
 msgstr ""
 
-#: modules/custom_dashboards.php:615
+#: modules/custom_dashboards.php:1737
 msgid "Site unavailable"
 msgstr ""
 
-#: modules/custom_dashboards.php:616
+#: modules/custom_dashboards.php:1738
 msgid "Availability (%)"
 msgstr ""
 
-#: modules/custom_dashboards.php:620
+#: modules/custom_dashboards.php:1739
+msgid "Measured time"
+msgstr ""
+
+#: modules/custom_dashboards.php:1741
+msgid "Processing time (ms)"
+msgstr ""
+
+#: modules/custom_dashboards.php:1743
+msgid "Over budget"
+msgstr ""
+
+#: modules/custom_dashboards.php:1744
 msgid "Revisions"
 msgstr ""
 
-#: modules/custom_dashboards.php:621
+#: modules/custom_dashboards.php:1745
 msgid "Events"
 msgstr ""
 
-#: modules/custom_dashboards.php:660
-msgid "A real-time overview of your site's performance and health."
+#: modules/custom_dashboards.php:1755
+msgid "Dashboard"
 msgstr ""
 
-#: modules/custom_dashboards.php:666
+#: modules/custom_dashboards.php:1760
+#: modules/custom_dashboards.php:1838
+#: modules/custom_dashboards.php:1867
 #: modules/speed_analyzer.php:9
 msgid "Speed"
 msgstr ""
 
-#: modules/custom_dashboards.php:667
-#: modules/custom_dashboards.php:700
-msgid "Details"
-msgstr ""
-
-#: modules/custom_dashboards.php:669
-msgid "Backend PHP processing time captured during the latest scan."
-msgstr ""
-
-#: modules/custom_dashboards.php:692
-msgid "Under 200ms indicates an excellent PHP response. Above 500ms suggests investigating plugins or hosting performance."
-msgstr ""
-
-#: modules/custom_dashboards.php:699
+#: modules/custom_dashboards.php:1765
+#: modules/custom_dashboards.php:1844
+#: modules/custom_dashboards.php:1906
+#: modules/uptime_tracker.php:17
 msgid "Uptime"
 msgstr ""
 
-#: modules/custom_dashboards.php:702
-msgid "Availability for the last 30 hourly checks."
+#: modules/custom_dashboards.php:1770
+#: modules/database_optimizer.php:7
+msgid "Database"
 msgstr ""
 
-#: modules/custom_dashboards.php:725
-msgid "Each bar shows whether the site responded during the scheduled availability probe."
+#: modules/custom_dashboards.php:1775
+#: modules/log_analyzer.php:9
+msgid "Logs"
 msgstr ""
 
-#: modules/custom_dashboards.php:732
+#: modules/custom_dashboards.php:1780
+#: modules/resource_monitor.php:8
+msgid "Resources"
+msgstr ""
+
+#: modules/custom_dashboards.php:1785
+msgid "Plugins"
+msgstr ""
+
+#: modules/custom_dashboards.php:1850
+#: modules/custom_dashboards.php:1941
 msgid "Database Health"
 msgstr ""
 
-#: modules/custom_dashboards.php:733
+#: modules/custom_dashboards.php:1856
+#: modules/custom_dashboards.php:1979
+msgid "Error Log"
+msgstr ""
+
+#: modules/custom_dashboards.php:1868
+#: modules/custom_dashboards.php:1907
+msgid "Details"
+msgstr ""
+
+#: modules/custom_dashboards.php:1870
+msgid "Backend PHP processing time captured during recent scans."
+msgstr ""
+
+#: modules/custom_dashboards.php:1894
+#, php-format
+msgid "Des temps inférieurs à %1$d ms indiquent une excellente réponse PHP. Au-delà de %2$d ms, envisagez d’auditer vos plugins ou votre hébergement."
+msgstr ""
+
+#: modules/custom_dashboards.php:1909
+msgid "Availability for the last 30 hourly checks."
+msgstr ""
+
+#: modules/custom_dashboards.php:1932
+msgid "Each bar shows whether the site responded during the scheduled availability probe."
+msgstr ""
+
+#: modules/custom_dashboards.php:1942
 msgid "Optimize"
 msgstr ""
 
-#: modules/custom_dashboards.php:735
+#: modules/custom_dashboards.php:1944
 msgid "Post revision volume compared to the recommended limit."
 msgstr ""
 
-#: modules/custom_dashboards.php:758
+#: modules/custom_dashboards.php:1967
 msgid "revisions"
 msgstr ""
 
-#: modules/custom_dashboards.php:761
+#: modules/custom_dashboards.php:1970
 #, php-format
 msgid "Keep revisions under %d to avoid bloating the posts table. Cleaning them is safe and reversible with backups."
 msgstr ""
 
-#: modules/custom_dashboards.php:768
-msgid "Error Log"
-msgstr ""
-
-#: modules/custom_dashboards.php:769
+#: modules/custom_dashboards.php:1980
 msgid "Analyze"
 msgstr ""
 
-#: modules/custom_dashboards.php:771
+#: modules/custom_dashboards.php:1982
 msgid "Breakdown of the most recent entries in the WordPress debug log."
 msgstr ""
 
-#: modules/custom_dashboards.php:802
+#: modules/custom_dashboards.php:2013
 msgid "Use the analyzer to inspect full stack traces and silence recurring issues."
 msgstr ""
 
-#: modules/database_optimizer.php:7
-msgid "Database"
+#: modules/custom_dashboards.php:2087
+#: modules/custom_dashboards.php:2211
+msgid "Compacte"
+msgstr ""
+
+#: modules/custom_dashboards.php:2088
+#: modules/custom_dashboards.php:2212
+msgid "Standard"
+msgstr ""
+
+#: modules/custom_dashboards.php:2089
+#: modules/custom_dashboards.php:2213
+msgid "Étendue"
+msgstr ""
+
+#: modules/custom_dashboards.php:2092
+#: modules/custom_dashboards.php:2186
+msgid "Réorganisez les cartes en les faisant glisser et choisissez celles à afficher."
+msgstr ""
+
+#: modules/custom_dashboards.php:2093
+#: modules/custom_dashboards.php:2205
+msgid "Afficher"
+msgstr ""
+
+#: modules/custom_dashboards.php:2094
+#: modules/custom_dashboards.php:2208
+msgid "Taille"
+msgstr ""
+
+#: modules/custom_dashboards.php:2095
+msgid "Préférences enregistrées."
+msgstr ""
+
+#: modules/custom_dashboards.php:2096
+msgid "Impossible d’enregistrer les préférences."
+msgstr ""
+
+#: modules/custom_dashboards.php:2097
+#: modules/custom_dashboards.php:2200
+msgid "Module requis pour afficher cette carte."
+msgstr ""
+
+#: modules/custom_dashboards.php:2098
+msgid "Les préférences du tableau de bord ont été mises à jour."
+msgstr ""
+
+#: modules/custom_dashboards.php:2107
+msgid "A real-time overview of your site's performance and health."
+msgstr ""
+
+#: modules/custom_dashboards.php:2119
+msgid "SitePulse sections"
+msgstr ""
+
+#: modules/custom_dashboards.php:2121
+msgid "Go to section"
+msgstr ""
+
+#: modules/custom_dashboards.php:2133
+msgid "View"
+msgstr ""
+
+#: modules/custom_dashboards.php:2142
+msgid "Scroll navigation left"
+msgstr ""
+
+#: modules/custom_dashboards.php:2172
+msgid "Scroll navigation right"
+msgstr ""
+
+#: modules/custom_dashboards.php:2183
+msgid "Personnaliser l'affichage"
+msgstr ""
+
+#: modules/custom_dashboards.php:2209
+#, php-format
+msgid "Taille de la carte %s"
+msgstr ""
+
+#: modules/custom_dashboards.php:2223
+msgid "Enregistrer"
+msgstr ""
+
+#: modules/custom_dashboards.php:2224
+msgid "Annuler"
+msgstr ""
+
+#: modules/custom_dashboards.php:2256
+msgid "Votre tableau de bord est vide"
+msgstr ""
+
+#: modules/custom_dashboards.php:2257
+msgid "Utilisez le bouton « Personnaliser l’affichage » pour sélectionner des cartes."
 msgstr ""
 
 #: modules/database_optimizer.php:118
@@ -853,210 +1571,250 @@ msgstr ""
 msgid "Les transients expirés ont été supprimés."
 msgstr ""
 
-#: modules/database_optimizer.php:214
+#: modules/database_optimizer.php:219
 msgid "Over time, your database can accumulate data that is no longer necessary. This tool helps you clean it up safely."
 msgstr ""
 
-#: modules/database_optimizer.php:221
+#: modules/database_optimizer.php:226
 #, php-format
 msgid "Clean post revisions (%s found)"
 msgstr ""
 
-#: modules/database_optimizer.php:229
+#: modules/database_optimizer.php:234
 msgid "<strong>What is this?</strong> WordPress stores a copy of your posts every time you edit them. These are revisions. While useful, they can bloat your database."
 msgstr ""
 
-#: modules/database_optimizer.php:236
+#: modules/database_optimizer.php:241
 msgid "<strong>Is it risky?</strong> Generally not. This action removes older versions but keeps the published one. It is a common and safe maintenance task."
 msgstr ""
 
-#: modules/database_optimizer.php:242
+#: modules/database_optimizer.php:247
 msgid "Clean all revisions"
 msgstr ""
 
-#: modules/database_optimizer.php:250
+#: modules/database_optimizer.php:255
 #, php-format
 msgid "Clean transients (%s found)"
 msgstr ""
 
-#: modules/database_optimizer.php:258
+#: modules/database_optimizer.php:263
 msgid "<strong>What is this?</strong> Transients are a form of temporary cache used by plugins and themes. Sometimes expired transients are not cleaned up properly."
 msgstr ""
 
-#: modules/database_optimizer.php:265
+#: modules/database_optimizer.php:270
 msgid "<strong>Is it risky?</strong> No, this operation only removes expired transients. Your site will regenerate them automatically if needed."
 msgstr ""
 
-#: modules/database_optimizer.php:271
+#: modules/database_optimizer.php:276
 msgid "Clean expired transients"
 msgstr ""
 
-#: modules/database_optimizer.php:443
+#: modules/database_optimizer.php:448
 msgid "Aucun transient expiré n'a été supprimé."
 msgstr ""
 
-#: modules/database_optimizer.php:447
+#: modules/database_optimizer.php:452
 #, php-format
 msgid "%s transient expiré a été supprimé."
 msgid_plural "%s transients expirés ont été supprimés."
 msgstr[0] ""
 msgstr[1] ""
 
-#: modules/error_alerts.php:302
+#: modules/error_alerts.php:49
+msgid "Charge CPU"
+msgstr ""
+
+#: modules/error_alerts.php:50
+msgid "Erreurs PHP fatales"
+msgstr ""
+
+#: modules/error_alerts.php:366
+msgid "Aucun destinataire valide pour les alertes."
+msgstr ""
+
+#: modules/error_alerts.php:388
+msgid "aucun canal actif"
+msgstr ""
+
+#. translators: %s: Site title.
+#: modules/error_alerts.php:392
+#, php-format
+msgid "SitePulse : e-mail de test pour %s"
+msgstr ""
+
+#: modules/error_alerts.php:397
+#, php-format
+msgid "Cet e-mail confirme la configuration des alertes SitePulse pour %1$s. Canaux actifs : %2$s."
+msgstr ""
+
+#: modules/error_alerts.php:407
+msgid "Impossible d’envoyer l’e-mail de test."
+msgstr ""
+
+#: modules/error_alerts.php:439
 #, php-format
 msgid "SitePulse Error Alerts (Every %d Minutes)"
 msgstr ""
 
-#: modules/error_alerts.php:355
+#: modules/error_alerts.php:496
 #, php-format
 msgid "SitePulse Alert: High Server Load on %s"
 msgstr ""
 
-#: modules/error_alerts.php:371
+#: modules/error_alerts.php:512
 #, php-format
 msgid "Current server load on %1$s: %2$s (detected cores: %3$d, total threshold: %4$s, load per core: %5$s, threshold per core: %6$s)"
 msgstr ""
 
-#: modules/error_alerts.php:532
+#: modules/error_alerts.php:687
 #, php-format
 msgid "SitePulse Alert: Fatal Error Detected on %s"
 msgstr ""
 
-#: modules/error_alerts.php:540
+#: modules/error_alerts.php:695
 #, php-format
-msgid "Review %1$s for error details affecting %2$s."
+msgid "Au moins %3$d nouvelles erreurs fatales ont été détectées dans %1$s pour %2$s. Consultez ce fichier pour plus de détails."
 msgstr ""
 
-#: modules/error_alerts.php:609
+#: modules/error_alerts.php:765
 msgid "SitePulse n’a pas pu programmer les alertes d’erreurs. Vérifiez la configuration de WP-Cron."
 msgstr ""
 
-#: modules/log_analyzer.php:41
+#: modules/error_alerts.php:807
+#: modules/error_alerts.php:895
+msgid "Échec de la vérification de sécurité pour l’envoi de test."
+msgstr ""
+
+#: modules/error_alerts.php:853
+#: modules/error_alerts.php:908
+msgid "E-mail de test envoyé."
+msgstr ""
+
+#: modules/log_analyzer.php:45
+msgid "Analyseur de Logs"
+msgstr ""
+
+#: modules/log_analyzer.php:46
 #, php-format
 msgid "Cet outil scanne le fichier %s de WordPress pour vous aider à trouver et corriger les problèmes sur votre site."
 msgstr ""
 
-#: modules/log_analyzer.php:52
+#: modules/log_analyzer.php:57
 msgid "Impossible de déterminer le fichier de journal."
 msgstr ""
 
-#: modules/log_analyzer.php:52
+#: modules/log_analyzer.php:57
 msgid "Vérifiez la valeur de la constante WP_DEBUG_LOG."
 msgstr ""
 
-#: modules/log_analyzer.php:72
+#: modules/log_analyzer.php:77
 msgid "Erreurs Fatales"
 msgstr ""
 
-#: modules/log_analyzer.php:73
+#: modules/log_analyzer.php:78
 msgid "Une erreur critique qui casse votre site. Elle empêche votre site de se charger et doit être corrigée immédiatement."
 msgstr ""
 
-#: modules/log_analyzer.php:78
+#: modules/log_analyzer.php:83
 msgid "Erreurs"
 msgstr ""
 
-#: modules/log_analyzer.php:79
+#: modules/log_analyzer.php:84
 msgid "Une erreur significative qui peut empêcher une fonctionnalité de marcher. Doit être traitée en priorité."
 msgstr ""
 
-#: modules/log_analyzer.php:84
-msgid "Avertissements"
-msgstr ""
-
-#: modules/log_analyzer.php:85
+#: modules/log_analyzer.php:90
 msgid "Un problème non-critique. Votre site fonctionnera, mais cela indique un problème potentiel qui devrait être corrigé."
 msgstr ""
 
-#: modules/log_analyzer.php:91
+#: modules/log_analyzer.php:96
 msgid "Un message d'information pour les développeurs. C'est la plus basse priorité et généralement pas un sujet d'inquiétude."
 msgstr ""
 
-#: modules/log_analyzer.php:109
+#: modules/log_analyzer.php:114
 msgid "Ce que c'est :"
 msgstr ""
 
-#: modules/log_analyzer.php:120
+#: modules/log_analyzer.php:125
 msgid "Votre journal de débogage est actif et vide."
 msgstr ""
 
-#: modules/log_analyzer.php:120
+#: modules/log_analyzer.php:125
 msgid "Excellent travail, aucune erreur à signaler !"
 msgstr ""
 
-#: modules/log_analyzer.php:127
+#: modules/log_analyzer.php:132
 msgid "Impossible de lire les dernières lignes du journal."
 msgstr ""
 
-#: modules/log_analyzer.php:127
+#: modules/log_analyzer.php:132
 #, php-format
 msgid "Veuillez vérifier les permissions du fichier %s."
 msgstr ""
 
-#: modules/log_analyzer.php:134
+#: modules/log_analyzer.php:139
 msgid "Le fichier de journal n’est pas lisible."
 msgstr ""
 
-#: modules/log_analyzer.php:134
+#: modules/log_analyzer.php:139
 #, php-format
 msgid "Vérifiez les permissions de %s."
 msgstr ""
 
-#: modules/log_analyzer.php:142
+#: modules/log_analyzer.php:147
 msgid "Votre configuration est correcte !"
 msgstr ""
 
-#: modules/log_analyzer.php:142
+#: modules/log_analyzer.php:147
 msgid "Le journal de débogage est bien activé dans votre fichier wp-config.php."
 msgstr ""
 
-#: modules/log_analyzer.php:143
+#: modules/log_analyzer.php:148
 #, php-format
 msgid "Le fichier %s n’a pas encore été créé car aucune erreur ne s’est produite. Il apparaîtra automatiquement dès que WordPress aura quelque chose à y écrire."
 msgstr ""
 
-#: modules/log_analyzer.php:153
-msgid "Journal de débogage non activé"
-msgstr ""
-
-#: modules/log_analyzer.php:154
-#, php-format
-msgid "Pour que cet outil fonctionne, WordPress doit être configuré pour enregistrer les erreurs dans un fichier. Cela se fait en modifiant votre fichier <code>%s</code>."
-msgstr ""
-
-#: modules/log_analyzer.php:156
-msgid "Comment activer le journal de débogage :"
-msgstr ""
-
 #: modules/log_analyzer.php:158
-msgid "Connectez-vous à votre site via FTP ou le gestionnaire de fichiers de votre hébergeur."
+msgid "Journal de débogage non activé"
 msgstr ""
 
 #: modules/log_analyzer.php:159
 #, php-format
-msgid "Trouvez le fichier <code>%s</code> à la racine de votre installation WordPress."
-msgstr ""
-
-#: modules/log_analyzer.php:160
-#, php-format
-msgid "Ouvrez ce fichier et cherchez la ligne : <br><code>%s</code>"
+msgid "Pour que cet outil fonctionne, WordPress doit être configuré pour enregistrer les erreurs dans un fichier. Cela se fait en modifiant votre fichier <code>%s</code>."
 msgstr ""
 
 #: modules/log_analyzer.php:161
-msgid "<strong>Juste avant</strong> cette ligne, ajoutez le code suivant :"
+msgid "Comment activer le journal de débogage :"
 msgstr ""
 
 #: modules/log_analyzer.php:163
-msgid "define( 'WP_DEBUG', true );\ndefine( 'WP_DEBUG_LOG', true );\ndefine( 'WP_DEBUG_DISPLAY', false );"
+msgid "Connectez-vous à votre site via FTP ou le gestionnaire de fichiers de votre hébergeur."
 msgstr ""
 
 #: modules/log_analyzer.php:164
 #, php-format
-msgid "<strong>Important :</strong> Une fois que vous avez résolu les problèmes, il est recommandé de repasser <code>%1$s</code> à <code>%2$s</code> sur un site en production."
+msgid "Trouvez le fichier <code>%s</code> à la racine de votre installation WordPress."
 msgstr ""
 
-#: modules/maintenance_advisor.php:7
-msgid "Maintenance"
+#: modules/log_analyzer.php:165
+#, php-format
+msgid "Ouvrez ce fichier et cherchez la ligne : <br><code>%s</code>"
+msgstr ""
+
+#: modules/log_analyzer.php:166
+msgid "<strong>Juste avant</strong> cette ligne, ajoutez le code suivant :"
+msgstr ""
+
+#: modules/log_analyzer.php:168
+msgid ""
+"define( 'WP_DEBUG', true );\n"
+"define( 'WP_DEBUG_LOG', true );\n"
+"define( 'WP_DEBUG_DISPLAY', false );"
+msgstr ""
+
+#: modules/log_analyzer.php:169
+#, php-format
+msgid "<strong>Important :</strong> Une fois que vous avez résolu les problèmes, il est recommandé de repasser <code>%1$s</code> à <code>%2$s</code> sur un site en production."
 msgstr ""
 
 #: modules/maintenance_advisor.php:34
@@ -1067,192 +1825,265 @@ msgstr ""
 msgid "À jour"
 msgstr ""
 
-#: modules/maintenance_advisor.php:41
+#: modules/maintenance_advisor.php:46
 msgid "Conseiller de Maintenance"
 msgstr ""
 
-#: modules/maintenance_advisor.php:44
+#: modules/maintenance_advisor.php:49
 msgid "Impossible de récupérer les données de mise à jour de WordPress. Le nombre de mises à jour disponibles est inconnu."
 msgstr ""
 
-#: modules/maintenance_advisor.php:50
+#: modules/maintenance_advisor.php:55
 msgid "Mises à jour du Coeur WP:"
 msgstr ""
 
-#: modules/maintenance_advisor.php:51
+#: modules/maintenance_advisor.php:56
 msgid "Mises à jour des Plugins:"
 msgstr ""
 
-#: modules/maintenance_advisor.php:51
+#: modules/maintenance_advisor.php:56
 msgid "en attente"
 msgstr ""
 
-#: modules/maintenance_advisor.php:53
+#: modules/maintenance_advisor.php:58
 msgid "Recommandations : Faites une sauvegarde avant de mettre à jour, testez sur un site de pré-production."
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:172
+#: modules/plugin_impact_scanner.php:12
+msgid "Plugin Impact"
+msgstr ""
+
+#: modules/plugin_impact_scanner.php:121
+#: modules/plugin_impact_scanner.php:470
+msgid "Tri : impact décroissant"
+msgstr ""
+
+#: modules/plugin_impact_scanner.php:122
+#: modules/plugin_impact_scanner.php:471
+msgid "Tri : impact croissant"
+msgstr ""
+
+#: modules/plugin_impact_scanner.php:123
+#: modules/plugin_impact_scanner.php:473
+msgid "Tri : nom (A → Z)"
+msgstr ""
+
+#: modules/plugin_impact_scanner.php:124
+#: modules/plugin_impact_scanner.php:472
+msgid "Tri : poids décroissant"
+msgstr ""
+
+#: modules/plugin_impact_scanner.php:125
+#: modules/plugin_impact_scanner.php:477
+msgid "Poids min (%)"
+msgstr ""
+
+#: modules/plugin_impact_scanner.php:126
+#: modules/plugin_impact_scanner.php:481
+msgid "Poids max (%)"
+msgstr ""
+
+#: modules/plugin_impact_scanner.php:127
+#: modules/plugin_impact_scanner.php:485
+msgid "Réinitialiser"
+msgstr ""
+
+#: modules/plugin_impact_scanner.php:128
+#: modules/plugin_impact_scanner.php:486
+msgid "Exporter CSV"
+msgstr ""
+
+#: modules/plugin_impact_scanner.php:129
+msgid "Aucun plugin ne correspond aux filtres."
+msgstr ""
+
+#: modules/plugin_impact_scanner.php:130
+msgid "sitepulse-plugin-impact.csv"
+msgstr ""
+
+#: modules/plugin_impact_scanner.php:267
 msgid "Une nouvelle série de mesures sera enregistrée à la fin de cette requête."
 msgstr ""
 
 #. translators: 1: measured plugins count, 2: total active plugins count.
-#: modules/plugin_impact_scanner.php:288
+#: modules/plugin_impact_scanner.php:392
 #, php-format
 msgid "Plugins chronométrés : %1$d sur %2$d."
 msgstr ""
 
 #. translators: %s: human time diff.
 #. translators: %s: human-readable time difference.
-#: modules/plugin_impact_scanner.php:302
-#: modules/resource_monitor.php:405
+#: modules/plugin_impact_scanner.php:406
+#: modules/resource_monitor.php:410
 #, php-format
 msgid "il y a %s"
 msgstr ""
 
 #. translators: 1: formatted datetime, 2: human readable diff.
-#: modules/plugin_impact_scanner.php:308
+#: modules/plugin_impact_scanner.php:412
 #, php-format
 msgid "Dernière actualisation : %1$s (%2$s)."
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:313
+#: modules/plugin_impact_scanner.php:417
 msgid "Dernière actualisation : aucune donnée collectée pour le moment."
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:318
+#: modules/plugin_impact_scanner.php:422
 #, php-format
 msgid "Prochain échantillonnage automatique possible dans %s."
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:322
+#: modules/plugin_impact_scanner.php:426
 msgid "Les mesures seront mises à jour à la fin du prochain chargement de page."
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:326
+#: modules/plugin_impact_scanner.php:430
 #, php-format
 msgid "Intervalle de rafraîchissement : %s maximum."
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:331
+#: modules/plugin_impact_scanner.php:440
 msgid "Analyseur d'Impact des Plugins"
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:335
+#: modules/plugin_impact_scanner.php:444
 msgid "Les temps affichés ci-dessous proviennent du chronométrage réel du chargement de chaque plugin actif."
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:344
+#: modules/plugin_impact_scanner.php:453
 msgid "Limitations connues :"
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:346
+#: modules/plugin_impact_scanner.php:455
 msgid "les mesures correspondent au temps écoulé entre le chargement de deux plugins consécutifs via le hook « plugin_loaded » ; elles reflètent donc l’impact relatif sur la phase de bootstrap."
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:347
+#: modules/plugin_impact_scanner.php:456
 msgid "les plugins chargés avant SitePulse ne peuvent pas être chronométrés directement et apparaissent comme « non mesurés » tant que leur ordre de chargement n’est pas modifié."
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:348
+#: modules/plugin_impact_scanner.php:457
 msgid "les valeurs sont moyennées pour lisser les variations ponctuelles ; les caches d’opcode peuvent réduire artificiellement certaines durées."
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:353
+#: modules/plugin_impact_scanner.php:462
 msgid "Forcer un nouvel échantillon maintenant"
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:360
-#: modules/plugin_impact_scanner.php:415
+#: modules/plugin_impact_scanner.php:468
+msgid "Choisir un tri"
+msgstr ""
+
+#: modules/plugin_impact_scanner.php:492
+#: modules/plugin_impact_scanner.php:605
 msgid "Plugin"
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:361
-#: modules/plugin_impact_scanner.php:416
+#: modules/plugin_impact_scanner.php:493
+#: modules/plugin_impact_scanner.php:606
 msgid "Durée mesurée"
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:362
-#: modules/plugin_impact_scanner.php:417
+#: modules/plugin_impact_scanner.php:494
+#: modules/plugin_impact_scanner.php:607
 msgid "Espace disque"
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:363
-#: modules/plugin_impact_scanner.php:426
+#: modules/plugin_impact_scanner.php:495
+#: modules/plugin_impact_scanner.php:616
 msgid "Poids relatif"
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:368
+#: modules/plugin_impact_scanner.php:496
+#: modules/plugin_impact_scanner.php:627
+msgid "Actions rapides"
+msgstr ""
+
+#: modules/plugin_impact_scanner.php:501
 msgid "Aucun plugin actif à analyser."
 msgstr ""
 
 #. translators: %s: duration in milliseconds
-#: modules/plugin_impact_scanner.php:387
+#: modules/plugin_impact_scanner.php:520
 #, php-format
 msgid "Moyenne glissante : %s ms"
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:393
+#: modules/plugin_impact_scanner.php:526
 #, php-format
 msgid "Dernière mesure : %s ms"
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:399
+#: modules/plugin_impact_scanner.php:532
 #, php-format
 msgid "Enregistré il y a %s"
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:405
+#: modules/plugin_impact_scanner.php:538
 #, php-format
 msgid "Nombre d’échantillons : %d"
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:409
+#: modules/plugin_impact_scanner.php:542
 msgid "Non mesuré pour le moment."
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:420
+#: modules/plugin_impact_scanner.php:560
+msgid "Désactiver sur le réseau"
+msgstr ""
+
+#: modules/plugin_impact_scanner.php:561
+msgid "Désactiver"
+msgstr ""
+
+#: modules/plugin_impact_scanner.php:610
 msgid "en cours…"
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:434
+#: modules/plugin_impact_scanner.php:624
 msgid "n/d"
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:501
+#: modules/plugin_impact_scanner.php:636
+msgid "Fiche plugin"
+msgstr ""
+
+#: modules/plugin_impact_scanner.php:641
+msgid "Documentation"
+msgstr ""
+
+#: modules/plugin_impact_scanner.php:710
 msgid "immédiatement"
 msgstr ""
 
-#: modules/plugin_impact_scanner.php:508
+#: modules/plugin_impact_scanner.php:717
 #, php-format
 msgid "%s seconde"
 msgid_plural "%s secondes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: modules/plugin_impact_scanner.php:517
+#: modules/plugin_impact_scanner.php:726
 #, php-format
 msgid "%s minute"
 msgid_plural "%s minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: modules/plugin_impact_scanner.php:526
+#: modules/plugin_impact_scanner.php:735
 #, php-format
 msgid "%s heure"
 msgid_plural "%s heures"
 msgstr[0] ""
 msgstr[1] ""
 
-#: modules/plugin_impact_scanner.php:534
+#: modules/plugin_impact_scanner.php:743
 #, php-format
 msgid "%s jour"
 msgid_plural "%s jours"
 msgstr[0] ""
 msgstr[1] ""
-
-#: modules/resource_monitor.php:8
-msgid "Resources"
-msgstr ""
 
 #: modules/resource_monitor.php:122
 #: modules/resource_monitor.php:133
@@ -1311,300 +2142,507 @@ msgstr ""
 msgid "Inconnue"
 msgstr ""
 
-#: modules/resource_monitor.php:350
+#: modules/resource_monitor.php:355
 msgid "Moniteur de Ressources"
 msgstr ""
 
-#: modules/resource_monitor.php:370
+#: modules/resource_monitor.php:375
 msgid "Charge CPU (1/5/15 min)"
 msgstr ""
 
-#: modules/resource_monitor.php:379
+#: modules/resource_monitor.php:384
 msgid "Mémoire"
 msgstr ""
 
 #. translators: %s: PHP memory limit value.
-#: modules/resource_monitor.php:383
+#: modules/resource_monitor.php:388
 #, php-format
 msgid "Limite PHP : %s"
 msgstr ""
 
-#: modules/resource_monitor.php:387
+#: modules/resource_monitor.php:392
 msgid "Stockage disque"
 msgstr ""
 
 #. translators: %s: total disk space.
-#: modules/resource_monitor.php:391
+#: modules/resource_monitor.php:396
 #, php-format
 msgid "Total : %s"
 msgstr ""
 
 #. translators: 1: formatted date, 2: relative time.
-#: modules/resource_monitor.php:401
+#: modules/resource_monitor.php:406
 #, php-format
 msgid "Mesures relevées le %1$s (%2$s)."
 msgstr ""
 
 #. translators: %s: formatted date.
-#: modules/resource_monitor.php:412
+#: modules/resource_monitor.php:417
 #, php-format
 msgid "Mesures relevées le %s."
 msgstr ""
 
-#: modules/resource_monitor.php:421
+#: modules/resource_monitor.php:426
 msgid "Actualiser les mesures"
 msgstr ""
 
-#: modules/speed_analyzer.php:109
+#: modules/speed_analyzer.php:173
+msgid "Nous attendons encore suffisamment de données pour formuler des recommandations. Relancez un test pour commencer l'historique."
+msgstr ""
+
+#: modules/speed_analyzer.php:183
+msgid "Les temps de réponse du serveur sont critiques. Contactez votre hébergeur et désactivez temporairement les extensions lourdes pour identifier le goulot d'étranglement."
+msgstr ""
+
+#: modules/speed_analyzer.php:185
+msgid "Vos performances se dégradent. Vérifiez les dernières extensions installées, optimisez la base de données et activez un cache persistant si possible."
+msgstr ""
+
+#: modules/speed_analyzer.php:187
+msgid "Le serveur répond correctement. Continuez à surveiller l'historique pour repérer les écarts ou planifiez des tests réguliers après les mises à jour."
+msgstr ""
+
+#: modules/speed_analyzer.php:191
+msgid "Pensez à réduire les tâches cron simultanées et à surveiller l'utilisation CPU côté hébergeur pendant les pics."
+msgstr ""
+
+#: modules/speed_analyzer.php:193
+msgid "Aucune action urgente n'est requise, mais gardez un œil sur l'évolution après des déploiements importants."
+msgstr ""
+
+#: modules/speed_analyzer.php:205
+msgid "Vous n'avez pas les permissions nécessaires pour réaliser ce test."
+msgstr ""
+
+#. translators: %s: human readable delay before the next scan.
+#: modules/speed_analyzer.php:224
+#, php-format
+msgid "Veuillez patienter encore %s avant de relancer un test pour éviter de surcharger le serveur."
+msgstr ""
+
+#: modules/speed_analyzer.php:253
+msgid "Un nouveau relevé a été ajouté à votre historique."
+msgstr ""
+
+#: modules/speed_analyzer.php:339
+msgid "Analyse en cours…"
+msgstr ""
+
+#: modules/speed_analyzer.php:340
+#: modules/speed_analyzer.php:444
+msgid "Relancer un test"
+msgstr ""
+
+#: modules/speed_analyzer.php:342
+#: modules/speed_analyzer.php:469
+msgid "Horodatage"
+msgstr ""
+
+#: modules/speed_analyzer.php:343
+#: modules/speed_analyzer.php:470
+msgid "Temps serveur (ms)"
+msgstr ""
+
+#: modules/speed_analyzer.php:344
+msgid "Temps de traitement du serveur"
+msgstr ""
+
+#: modules/speed_analyzer.php:345
+msgid "Une erreur est survenue pendant le test. Veuillez réessayer."
+msgstr ""
+
+#: modules/speed_analyzer.php:346
+msgid "Test bloqué temporairement par la limite de fréquence."
+msgstr ""
+
+#: modules/speed_analyzer.php:347
+msgid "Prochain test possible dans"
+msgstr ""
+
+#: modules/speed_analyzer.php:439
 msgid "Analyseur de Vitesse"
 msgstr ""
 
-#: modules/speed_analyzer.php:110
+#: modules/speed_analyzer.php:440
 msgid "Cet outil analyse la performance interne de votre serveur et de votre base de données à chaque chargement de page."
 msgstr ""
 
-#: modules/speed_analyzer.php:115
+#. translators: %s: human readable rate limit duration.
+#: modules/speed_analyzer.php:450
+#, php-format
+msgid "Pour préserver les ressources serveur, un nouveau test manuel est disponible toutes les %s."
+msgstr ""
+
+#: modules/speed_analyzer.php:459
+msgid "Historique des temps de réponse"
+msgstr ""
+
+#: modules/speed_analyzer.php:465
+msgid "Historique des mesures de temps de réponse du serveur."
+msgstr ""
+
+#: modules/speed_analyzer.php:491
+msgid "Recommandations"
+msgstr ""
+
+#: modules/speed_analyzer.php:506
 msgid "Performance du Serveur (Backend)"
 msgstr ""
 
-#: modules/speed_analyzer.php:116
+#: modules/speed_analyzer.php:507
 msgid "Ces métriques mesurent la vitesse à laquelle votre serveur exécute le code PHP et génère la page actuelle."
 msgstr ""
 
-#: modules/speed_analyzer.php:122
+#: modules/speed_analyzer.php:519
 msgid "Temps de Génération de la Page"
 msgstr ""
 
 #. translators: %d: duration in milliseconds.
-#: modules/speed_analyzer.php:132
-#: modules/speed_analyzer.php:161
+#: modules/speed_analyzer.php:529
+#: modules/speed_analyzer.php:567
 #, php-format
 msgid "%d ms"
 msgstr ""
 
-#: modules/speed_analyzer.php:135
-msgid "C'est le temps total que met votre serveur pour préparer cette page. Un temps élevé (>1s) peut indiquer un hébergement lent ou un plugin qui consomme beaucoup de ressources."
+#: modules/speed_analyzer.php:533
+#, php-format
+msgid "C'est le temps total que met votre serveur pour préparer cette page. Un temps élevé (>%d ms) peut indiquer un hébergement lent ou un plugin qui consomme beaucoup de ressources."
 msgstr ""
 
-#: modules/speed_analyzer.php:142
+#: modules/speed_analyzer.php:542
 msgid "Performance de la Base de Données"
 msgstr ""
 
-#: modules/speed_analyzer.php:143
+#: modules/speed_analyzer.php:543
 msgid "Analyse la communication entre WordPress et votre base de données pour cette page."
 msgstr ""
 
-#: modules/speed_analyzer.php:151
-#: modules/speed_analyzer.php:170
+#: modules/speed_analyzer.php:557
+#: modules/speed_analyzer.php:576
 msgid "Temps Total des Requêtes BDD"
 msgstr ""
 
-#: modules/speed_analyzer.php:164
+#: modules/speed_analyzer.php:570
 msgid "Le temps total passé à attendre la base de données. S'il est élevé, cela peut indiquer des requêtes complexes ou une base de données surchargée."
 msgstr ""
 
 #. translators: 1: SAVEQUERIES constant, 2: wp-config.php file name.
-#: modules/speed_analyzer.php:185
+#: modules/speed_analyzer.php:591
 #, php-format
 msgid "Pour activer cette mesure, ajoutez <code>%1$s</code> à votre fichier <code>%2$s</code>. <strong>Note :</strong> N'utilisez ceci que pour le débogage, car cela peut ralentir votre site."
 msgstr ""
 
-#: modules/speed_analyzer.php:204
+#: modules/speed_analyzer.php:610
 msgid "Nombre de Requêtes BDD"
 msgstr ""
 
-#: modules/speed_analyzer.php:214
+#: modules/speed_analyzer.php:620
 msgid "Le nombre de fois que WordPress a interrogé la base de données. Un nombre élevé (>100) peut être le signe d'un plugin ou d'un thème mal optimisé."
 msgstr ""
 
-#: modules/speed_analyzer.php:220
+#: modules/speed_analyzer.php:626
 msgid "Configuration Serveur"
 msgstr ""
 
-#: modules/speed_analyzer.php:221
+#: modules/speed_analyzer.php:627
 msgid "Des réglages serveur optimaux sont essentiels pour la performance."
 msgstr ""
 
-#: modules/speed_analyzer.php:226
+#: modules/speed_analyzer.php:632
 msgid "Actif"
 msgstr ""
 
-#: modules/speed_analyzer.php:226
+#: modules/speed_analyzer.php:632
 msgid "Non détecté"
 msgstr ""
 
-#: modules/speed_analyzer.php:229
+#: modules/speed_analyzer.php:635
 msgid "Object Cache"
 msgstr ""
 
-#: modules/speed_analyzer.php:239
+#: modules/speed_analyzer.php:645
 msgid "Un cache d'objets persistant (ex: Redis, Memcached) accélère énormément les requêtes répétitives. Fortement recommandé."
 msgstr ""
 
-#: modules/speed_analyzer.php:246
+#: modules/speed_analyzer.php:652
 msgid "Version de PHP"
 msgstr ""
 
-#: modules/speed_analyzer.php:256
+#: modules/speed_analyzer.php:662
 msgid "Les versions modernes de PHP (8.0+) sont beaucoup plus rapides et sécurisées. Demandez à votre hébergeur de mettre à jour si nécessaire."
 msgstr ""
 
-#: modules/uptime_tracker.php:70
+#: modules/uptime_tracker.php:157
 msgid "SitePulse n’a pas pu planifier la vérification d’uptime. Vérifiez que WP-Cron est actif ou programmez manuellement la tâche."
 msgstr ""
 
 #. translators: 1: formatted date, 2: uptime percentage, 3: number of checks.
-#: modules/uptime_tracker.php:350
+#: modules/uptime_tracker.php:437
 #, php-format
 msgid "Disponibilité du %1$s : %2$s%% (%3$s contrôles)"
 msgstr ""
 
-#: modules/uptime_tracker.php:368
+#: modules/uptime_tracker.php:455
+msgid "Suivi de Disponibilité"
+msgstr ""
+
+#. translators: %s: number of uptime checks.
+#: modules/uptime_tracker.php:460
+#, php-format
+msgid "Cet outil vérifie la disponibilité de votre site toutes les heures. Voici le statut des %s dernières vérifications."
+msgstr ""
+
+#. translators: 1: number of checks, 2: uptime percentage.
+#: modules/uptime_tracker.php:470
+#, php-format
+msgid "Disponibilité (%1$s dernières heures) : <strong style=\"font-size: 1.4em;\">%2$s%%</strong>"
+msgstr ""
+
+#: modules/uptime_tracker.php:479
 msgid "Disponibilité 7 derniers jours"
 msgstr ""
 
 #. translators: 1: total checks, 2: incidents
-#: modules/uptime_tracker.php:373
-#: modules/uptime_tracker.php:385
+#: modules/uptime_tracker.php:484
+#: modules/uptime_tracker.php:496
 #, php-format
 msgid "Sur %1$s contrôles (%2$s incidents)"
 msgstr ""
 
-#: modules/uptime_tracker.php:380
+#: modules/uptime_tracker.php:491
 msgid "Disponibilité 30 derniers jours"
 msgstr ""
 
-#: modules/uptime_tracker.php:406
+#: modules/uptime_tracker.php:505
+msgid "Aucune donnée de disponibilité. La première vérification aura lieu dans l'heure."
+msgstr ""
+
+#: modules/uptime_tracker.php:519
 msgid "Horodatage inconnu"
 msgstr ""
 
-#: modules/uptime_tracker.php:414
+#: modules/uptime_tracker.php:527
 #, php-format
 msgid "Site OK lors du contrôle du %s."
 msgstr ""
 
-#: modules/uptime_tracker.php:415
+#: modules/uptime_tracker.php:528
 msgid "Statut : site disponible."
 msgstr ""
 
-#: modules/uptime_tracker.php:421
+#: modules/uptime_tracker.php:534
 #, php-format
 msgid "Retour à la normale après un incident débuté le %1$s (durée : %2$s)."
 msgstr ""
 
-#: modules/uptime_tracker.php:422
+#: modules/uptime_tracker.php:535
 #, php-format
 msgid "Durée de l’incident résolu : %s."
 msgstr ""
 
-#: modules/uptime_tracker.php:427
+#: modules/uptime_tracker.php:540
 msgid "Durée : disponibilité confirmée lors de ce contrôle."
 msgstr ""
 
-#: modules/uptime_tracker.php:433
+#: modules/uptime_tracker.php:546
 msgid "horodatage inconnu"
 msgstr ""
 
-#: modules/uptime_tracker.php:434
+#: modules/uptime_tracker.php:547
 #, php-format
 msgid "Site KO lors du contrôle du %1$s. Incident commencé le %2$s."
 msgstr ""
 
-#: modules/uptime_tracker.php:435
+#: modules/uptime_tracker.php:548
 msgid "Statut : site indisponible."
 msgstr ""
 
-#: modules/uptime_tracker.php:441
+#: modules/uptime_tracker.php:554
 #, php-format
 msgid "Détails : %s."
 msgstr ""
 
-#: modules/uptime_tracker.php:448
+#: modules/uptime_tracker.php:561
 #, php-format
 msgid "Incident en cours depuis %s."
 msgstr ""
 
-#: modules/uptime_tracker.php:449
+#: modules/uptime_tracker.php:562
 #, php-format
 msgid "Durée de l’incident en cours : %s."
 msgstr ""
 
-#: modules/uptime_tracker.php:461
+#: modules/uptime_tracker.php:574
 #, php-format
 msgid "Durée estimée : %s."
 msgstr ""
 
-#: modules/uptime_tracker.php:461
+#: modules/uptime_tracker.php:574
 #, php-format
 msgid "Durée cumulée : %s."
 msgstr ""
 
-#: modules/uptime_tracker.php:463
+#: modules/uptime_tracker.php:576
 #, php-format
 msgid "Durée de l’incident : %s."
 msgstr ""
 
-#: modules/uptime_tracker.php:468
+#: modules/uptime_tracker.php:581
 msgid "Durée : incident en cours, durée non déterminée."
 msgstr ""
 
-#: modules/uptime_tracker.php:471
+#: modules/uptime_tracker.php:584
 msgid "Erreur réseau inconnue."
 msgstr ""
 
-#: modules/uptime_tracker.php:472
+#: modules/uptime_tracker.php:585
 #, php-format
 msgid "Statut indéterminé lors du contrôle du %1$s : %2$s"
 msgstr ""
 
-#: modules/uptime_tracker.php:473
+#: modules/uptime_tracker.php:586
 msgid "Statut : indéterminé."
 msgstr ""
 
-#: modules/uptime_tracker.php:474
+#: modules/uptime_tracker.php:587
 msgid "Durée : impossible à déterminer pour ce contrôle."
 msgstr ""
 
-#: modules/uptime_tracker.php:477
+#: modules/uptime_tracker.php:590
 #, php-format
 msgid "Contrôle du %s."
 msgstr ""
 
-#: modules/uptime_tracker.php:492
+#: modules/uptime_tracker.php:601
+#, php-format
+msgid "Il y a %d heures"
+msgstr ""
+
+#: modules/uptime_tracker.php:601
+msgid "Maintenant"
+msgstr ""
+
+#: modules/uptime_tracker.php:605
 msgid "Incident en cours"
 msgstr ""
 
-#: modules/uptime_tracker.php:497
+#: modules/uptime_tracker.php:610
 #, php-format
 msgid "Votre site est signalé comme indisponible depuis le %1$s (%2$s)."
 msgstr ""
 
-#: modules/uptime_tracker.php:507
+#: modules/uptime_tracker.php:620
 msgid "Tendance de disponibilité (30 jours)"
 msgstr ""
 
-#: modules/uptime_tracker.php:508
+#: modules/uptime_tracker.php:621
 #, php-format
 msgid "Disponibilité quotidienne sur %d jours."
 msgstr ""
 
-#: modules/uptime_tracker.php:514
+#: modules/uptime_tracker.php:627
 msgid "≥ 99% de disponibilité"
 msgstr ""
 
-#: modules/uptime_tracker.php:515
+#: modules/uptime_tracker.php:628
 msgid "95 – 98% de disponibilité"
 msgstr ""
 
-#: modules/uptime_tracker.php:516
+#: modules/uptime_tracker.php:629
 msgid "< 95% de disponibilité"
 msgstr ""
 
-#: sitepulse.php:672
+#: modules/uptime_tracker.php:632
+msgid "Comment ça marche :"
+msgstr ""
+
+#: modules/uptime_tracker.php:632
+msgid "Une barre verte indique que votre site était en ligne. Une barre rouge indique un possible incident où votre site était inaccessible."
+msgstr ""
+
+#: sitepulse.php:691
 #, php-format
 msgid "SitePulse n’a pas pu installer le chargeur MU du suivi d’impact (%s). Vérifiez les permissions du dossier mu-plugins."
 msgstr ""
 
-#: sitepulse.php:1040
+#: sitepulse.php:1059
 msgid "SitePulse: the server appears to ignore .htaccess/web.config directives and the debug log could not be moved outside of the web root. Please customize the sitepulse_debug_log_base_dir filter or block HTTP access at the server level."
+msgstr ""
+
+#: sitepulse.php:1235
+msgid "Vitesse"
+msgstr ""
+
+#: sitepulse.php:1236
+msgid "Afficher la carte Vitesse"
+msgstr ""
+
+#: sitepulse.php:1241
+msgid "Afficher la carte Uptime"
+msgstr ""
+
+#: sitepulse.php:1245
+msgid "Base de données"
+msgstr ""
+
+#: sitepulse.php:1246
+msgid "Afficher la carte Base de données"
+msgstr ""
+
+#: sitepulse.php:1251
+msgid "Afficher la carte Journal d’erreurs"
+msgstr ""
+
+#: sitepulse.php:1278
+#: blocks/dashboard-preview/editor.js:62
+#, php-format,js-format
+msgid "Les modules suivants sont désactivés : %s"
+msgstr ""
+
+#: sitepulse.php:1279
+msgid "Activez les modules requis pour afficher toutes les cartes du tableau de bord."
+msgstr ""
+
+#: sitepulse.php:1280
+#: blocks/dashboard-preview/editor.js:161
+msgid "Gérer les modules"
+msgstr ""
+
+#: sitepulse.php:1281
+msgid "Accéder aux réglages"
+msgstr ""
+
+#: sitepulse.php:1282
+#: blocks/dashboard-preview/editor.js:84
+msgid "Ce module est actuellement désactivé. Activez-le depuis les réglages de SitePulse."
+msgstr ""
+
+#: sitepulse.php:1283
+#: blocks/dashboard-preview/editor.js:85
+msgid "Activez ce module pour l’afficher dans le bloc Aperçu du tableau de bord."
+msgstr ""
+
+#: sitepulse.php:1284
+#: blocks/dashboard-preview/editor.js:87
+msgid "Accéder aux réglages des modules"
+msgstr ""
+
+#: sitepulse.php:1285
+msgid "Vous pouvez activer les modules depuis l’écran de réglages de SitePulse."
+msgstr ""
+
+#: blocks/dashboard-preview/editor.js:75
+msgid "Affichage des modules"
+msgstr ""
+
+#: blocks/dashboard-preview/editor.js:122
+msgid "Aide"
+msgstr ""
+
+#: blocks/dashboard-preview/editor.js:126
+msgid "Ce bloc affiche un aperçu des principales métriques suivies par SitePulse."
+msgstr ""
+
+#: blocks/dashboard-preview/editor.js:131
+msgid "Les données proviennent des derniers relevés enregistrés. Utilisez les options ci-dessus pour masquer les cartes non pertinentes."
 msgstr ""

--- a/sitepulse_FR/modules/uptime_tracker.php
+++ b/sitepulse_FR/modules/uptime_tracker.php
@@ -452,9 +452,28 @@ function sitepulse_uptime_tracker_page() {
     }
     ?>
     <div class="wrap">
-        <h1><span class="dashicons-before dashicons-chart-bar"></span> Suivi de Disponibilité</h1>
-        <p>Cet outil vérifie la disponibilité de votre site toutes les heures. Voici le statut des <?php echo esc_html($total_checks); ?> dernières vérifications.</p>
-        <h2>Disponibilité (<?php echo esc_html($total_checks); ?> dernières heures): <strong style="font-size: 1.4em;"><?php echo esc_html(round($uptime_percentage, 2)); ?>%</strong></h2>
+        <h1><span class="dashicons-before dashicons-chart-bar"></span> <?php esc_html_e('Suivi de Disponibilité', 'sitepulse'); ?></h1>
+        <p>
+            <?php
+            printf(
+                /* translators: %s: number of uptime checks. */
+                esc_html__('Cet outil vérifie la disponibilité de votre site toutes les heures. Voici le statut des %s dernières vérifications.', 'sitepulse'),
+                esc_html(number_format_i18n($total_checks))
+            );
+            ?>
+        </p>
+        <h2>
+            <?php
+            echo wp_kses_post(
+                sprintf(
+                    /* translators: 1: number of checks, 2: uptime percentage. */
+                    __('Disponibilité (%1$s dernières heures) : <strong style="font-size: 1.4em;">%2$s%%</strong>', 'sitepulse'),
+                    esc_html(number_format_i18n($total_checks)),
+                    esc_html(number_format_i18n($uptime_percentage, 2))
+                )
+            );
+            ?>
+        </h2>
         <div class="uptime-summary-grid">
             <div class="uptime-summary-card">
                 <h3><?php esc_html_e('Disponibilité 7 derniers jours', 'sitepulse'); ?></h3>
@@ -482,7 +501,9 @@ function sitepulse_uptime_tracker_page() {
             </div>
         </div>
         <div class="uptime-chart">
-            <?php if (empty($uptime_log)): ?><p>Aucune donnée de disponibilité. La première vérification aura lieu dans l'heure.</p><?php else: ?>
+            <?php if (empty($uptime_log)) : ?>
+                <p><?php esc_html_e("Aucune donnée de disponibilité. La première vérification aura lieu dans l'heure.", 'sitepulse'); ?></p>
+            <?php else : ?>
                 <?php foreach ($uptime_log as $index => $entry): ?>
                     <?php
                     $status = $entry['status'] ?? null;


### PR DESCRIPTION
## Summary
- wrap the uptime tracker page titles, messages, and empty-state text in WordPress i18n helpers
- regenerate the translation template so the new strings appear in sitepulse.pot

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0ee531260832e94b3592f8b63541a