### PR TITLE
Add Site Health tests for SitePulse alerts and Gemini configuration

### DIFF
--- a/sitepulse_FR/README.md
+++ b/sitepulse_FR/README.md
@@ -17,6 +17,7 @@ Sitepulse - JLG takes the pulse of your WordPress site, offering modules for:
 - Maintenance checks and AI insights
 - Custom dashboards and multisite support
 - Customisable thresholds for speed alerts, uptime targets and revision cleanup suggestions
+- Site Health integration surfacing SitePulse alerts and AI requirements
 
 ### Key performance defaults
 
@@ -33,6 +34,15 @@ Toggle modules in the admin panel to keep it lightweight. Includes debug mode an
 1. Upload `sitepulse-jlg.zip` to your `/wp-content/plugins/` directory.
 2. Activate the plugin through the 'Plugins' menu in WordPress.
 3. Visit 'SitePulse' in your admin menu to configure the modules.
+
+## Diagnostic « Santé du site »
+
+SitePulse enregistre désormais deux tests visibles dans l’outil « Santé du site » de WordPress :
+
+- **État de SitePulse** récapitule les avertissements WP-Cron et les erreurs critiques générées par l’IA, en les classant selon leur gravité.
+- **Clé API Gemini SitePulse** vérifie que le module AI Insights dispose d’une clé API prête à l’emploi avant de lancer des analyses.
+
+Ces tests facilitent la détection proactive des problèmes susceptibles d’empêcher l’exécution des tâches planifiées ou des analyses IA.
 
 ## Sécuriser la clé API Gemini
 

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -608,6 +608,219 @@ function sitepulse_render_cron_warnings() {
 add_action('admin_notices', 'sitepulse_render_cron_warnings');
 
 /**
+ * Registers Site Health tests exposed by SitePulse.
+ *
+ * @param array $tests Previously registered tests grouped by type.
+ *
+ * @return array
+ */
+function sitepulse_register_site_health_tests($tests) {
+    if (!is_array($tests)) {
+        $tests = [];
+    }
+
+    if (!isset($tests['direct']) || !is_array($tests['direct'])) {
+        $tests['direct'] = [];
+    }
+
+    $tests['direct']['sitepulse_status'] = [
+        'label' => __('État de SitePulse', 'sitepulse'),
+        'test'  => 'sitepulse_site_health_status_test',
+    ];
+
+    $tests['direct']['sitepulse_ai_api_key'] = [
+        'label' => __('Clé API Gemini SitePulse', 'sitepulse'),
+        'test'  => 'sitepulse_site_health_ai_api_key_test',
+    ];
+
+    return $tests;
+}
+add_filter('site_status_tests', 'sitepulse_register_site_health_tests');
+
+/**
+ * Site Health test summarizing SitePulse alerts stored in options.
+ *
+ * @return array
+ */
+function sitepulse_site_health_status_test() {
+    $badge = [
+        'label' => __('SitePulse', 'sitepulse'),
+        'color' => 'blue',
+    ];
+
+    $cron_warnings_option = get_option(SITEPULSE_OPTION_CRON_WARNINGS, []);
+    $cron_messages         = [];
+
+    if (is_array($cron_warnings_option)) {
+        foreach ($cron_warnings_option as $warning) {
+            if (is_array($warning) && isset($warning['message'])) {
+                $message = trim(wp_strip_all_tags((string) $warning['message']));
+
+                if ($message !== '') {
+                    $cron_messages[] = $message;
+                }
+            }
+        }
+    }
+
+    $ai_option_name = defined('SITEPULSE_OPTION_AI_INSIGHT_ERRORS')
+        ? SITEPULSE_OPTION_AI_INSIGHT_ERRORS
+        : 'sitepulse_ai_insight_errors';
+
+    $ai_errors_option = get_option($ai_option_name, []);
+    $ai_messages       = [];
+
+    if (is_array($ai_errors_option)) {
+        foreach ($ai_errors_option as $error) {
+            if (is_array($error) && isset($error['message'])) {
+                $message = trim(wp_strip_all_tags((string) $error['message']));
+
+                if ($message !== '') {
+                    $ai_messages[] = $message;
+                }
+            } elseif (is_string($error)) {
+                $message = trim(wp_strip_all_tags($error));
+
+                if ($message !== '') {
+                    $ai_messages[] = $message;
+                }
+            }
+        }
+    } elseif (is_string($ai_errors_option)) {
+        $message = trim(wp_strip_all_tags($ai_errors_option));
+
+        if ($message !== '') {
+            $ai_messages[] = $message;
+        }
+    }
+
+    $cron_messages = array_values(array_unique($cron_messages));
+    $ai_messages   = array_values(array_unique($ai_messages));
+
+    $status      = 'good';
+    $label       = __('Aucune alerte active signalée par SitePulse.', 'sitepulse');
+    $description = '<p>' . esc_html__('SitePulse ne signale actuellement aucune alerte.', 'sitepulse') . '</p>';
+    $actions     = '';
+
+    $issues_sections = [];
+
+    if (!empty($cron_messages)) {
+        $status = 'recommended';
+        $label  = __('SitePulse a détecté des avertissements de planification.', 'sitepulse');
+
+        $list_items = '';
+
+        foreach ($cron_messages as $message) {
+            $list_items .= '<li>' . esc_html($message) . '</li>';
+        }
+
+        $issues_sections[] = '<p>'
+            . esc_html__('Avertissements WP-Cron enregistrés :', 'sitepulse')
+            . '</p><ul>' . $list_items . '</ul>';
+    }
+
+    if (!empty($ai_messages)) {
+        $status = 'critical';
+        $label  = __('SitePulse a rencontré des erreurs critiques.', 'sitepulse');
+
+        $list_items = '';
+
+        foreach ($ai_messages as $message) {
+            $list_items .= '<li>' . esc_html($message) . '</li>';
+        }
+
+        $issues_sections[] = '<p>'
+            . esc_html__('Erreurs critiques AI Insights :', 'sitepulse')
+            . '</p><ul>' . $list_items . '</ul>';
+    }
+
+    if (!empty($issues_sections)) {
+        $description = implode('', $issues_sections);
+    }
+
+    if (function_exists('admin_url')) {
+        $settings_url = admin_url('admin.php?page=sitepulse-settings');
+
+        if (is_string($settings_url) && $settings_url !== '') {
+            $actions = sprintf(
+                '<p><a class="button button-primary" href="%s">%s</a></p>',
+                esc_url($settings_url),
+                esc_html__('Ouvrir SitePulse', 'sitepulse')
+            );
+        }
+    }
+
+    return [
+        'label'       => $label,
+        'status'      => $status,
+        'badge'       => $badge,
+        'description' => $description,
+        'actions'     => $actions,
+        'test'        => 'sitepulse_status',
+    ];
+}
+
+/**
+ * Site Health test ensuring an API key is available for AI Insights.
+ *
+ * @return array
+ */
+function sitepulse_site_health_ai_api_key_test() {
+    $badge = [
+        'label' => __('SitePulse', 'sitepulse'),
+        'color' => 'blue',
+    ];
+
+    $active_modules_option = get_option(SITEPULSE_OPTION_ACTIVE_MODULES, []);
+    $active_modules        = array_map('strval', (array) $active_modules_option);
+    $ai_module_enabled     = in_array('ai_insights', $active_modules, true);
+
+    $settings_url = function_exists('admin_url') ? admin_url('admin.php?page=sitepulse-settings#sitepulse-section-ai') : '';
+    $actions      = '';
+
+    if (is_string($settings_url) && $settings_url !== '') {
+        $actions = sprintf(
+            '<p><a class="button" href="%s">%s</a></p>',
+            esc_url($settings_url),
+            esc_html__('Configurer SitePulse', 'sitepulse')
+        );
+    }
+
+    if (!$ai_module_enabled) {
+        return [
+            'label'       => __('Le module AI Insights est désactivé.', 'sitepulse'),
+            'status'      => 'good',
+            'badge'       => $badge,
+            'description' => '<p>' . esc_html__('Aucune clé API n’est nécessaire tant que le module AI Insights reste désactivé.', 'sitepulse') . '</p>',
+            'actions'     => $actions,
+            'test'        => 'sitepulse_ai_api_key',
+        ];
+    }
+
+    $api_key = function_exists('sitepulse_get_gemini_api_key') ? sitepulse_get_gemini_api_key() : '';
+
+    if (trim((string) $api_key) === '') {
+        return [
+            'label'       => __('Ajoutez une clé API Gemini pour SitePulse.', 'sitepulse'),
+            'status'      => 'recommended',
+            'badge'       => $badge,
+            'description' => '<p>' . esc_html__('Les analyses IA échoueront sans clé API Gemini valide. Renseignez une clé pour lancer les insights.', 'sitepulse') . '</p>',
+            'actions'     => $actions,
+            'test'        => 'sitepulse_ai_api_key',
+        ];
+    }
+
+    return [
+        'label'       => __('Une clé API Gemini est configurée pour SitePulse.', 'sitepulse'),
+        'status'      => 'good',
+        'badge'       => $badge,
+        'description' => '<p>' . esc_html__('SitePulse dispose d’une clé API Gemini valide pour générer des analyses IA.', 'sitepulse') . '</p>',
+        'actions'     => $actions,
+        'test'        => 'sitepulse_ai_api_key',
+    ];
+}
+
+/**
  * Attempts to bootstrap the WordPress filesystem abstraction layer.
  *
  * @return WP_Filesystem_Base|null


### PR DESCRIPTION
## Summary
- register SitePulse Site Health checks that surface stored cron warnings and AI error logs
- add a Site Health test that tracks Gemini API key availability for the AI Insights module
- document the new Site Health coverage in the French README

## Testing
- php -l sitepulse_FR/sitepulse.php

------
https://chatgpt.com/codex/tasks/task_e_68e12d7cd808832e991d845c911eb12b