### PR TITLE
Add Site Health helper for SitePulse alerts

### DIFF
--- a/sitepulse_FR/readme.txt
+++ b/sitepulse_FR/readme.txt
@@ -26,6 +26,15 @@ Sitepulse - JLG takes the pulse of your WordPress site, offering modules for:
 
 Toggle modules in the admin panel to keep it lightweight. Includes debug mode and cleanup options.
 
+== Site Health diagnostics ==
+
+SitePulse registers additional checks within the WordPress "Site Health" tool:
+
+* **SitePulse status** summarises WP-Cron warnings and critical AI Insight errors, raising the severity when alerts are pending.
+* **SitePulse Gemini API key** warns administrators when the AI module is active without a configured Gemini API key.
+
+These checks surface potential cron failures or missing credentials directly inside the core diagnostics dashboard.
+
 == Installation ==
 
 1.  Upload `sitepulse-jlg.zip` to your `/wp-content/plugins/` directory.

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -650,16 +650,14 @@ function sitepulse_register_site_health_tests($tests) {
 add_filter('site_status_tests', 'sitepulse_register_site_health_tests');
 
 /**
- * Site Health test summarizing SitePulse alerts stored in options.
+ * Retrieves SitePulse alerts stored in the WordPress options table.
  *
- * @return array
+ * @return array{
+ *     cron: string[],
+ *     ai: string[],
+ * }
  */
-function sitepulse_site_health_status_test() {
-    $badge = [
-        'label' => __('SitePulse', 'sitepulse'),
-        'color' => 'blue',
-    ];
-
+function sitepulse_get_site_health_alert_messages() {
     $cron_warnings_option = get_option(SITEPULSE_OPTION_CRON_WARNINGS, []);
     $cron_messages         = [];
 
@@ -706,8 +704,26 @@ function sitepulse_site_health_status_test() {
         }
     }
 
-    $cron_messages = array_values(array_unique($cron_messages));
-    $ai_messages   = array_values(array_unique($ai_messages));
+    return [
+        'cron' => array_values(array_unique($cron_messages)),
+        'ai'   => array_values(array_unique($ai_messages)),
+    ];
+}
+
+/**
+ * Site Health test summarizing SitePulse alerts stored in options.
+ *
+ * @return array
+ */
+function sitepulse_site_health_status_test() {
+    $badge = [
+        'label' => __('SitePulse', 'sitepulse'),
+        'color' => 'blue',
+    ];
+
+    $alerts = sitepulse_get_site_health_alert_messages();
+    $cron_messages = $alerts['cron'];
+    $ai_messages   = $alerts['ai'];
 
     $status      = 'good';
     $label       = __('Aucune alerte active signalée par SitePulse.', 'sitepulse');


### PR DESCRIPTION
## Summary
- add a helper that aggregates SitePulse cron warnings and AI insight errors for the Site Health test
- keep the Site Health status test focused on rendering while reusing the shared helper
- document the Site Health diagnostics exposed by SitePulse in the plugin readme

## Testing
- phpunit --configuration phpunit.xml.dist *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e1490ddc3c832ebf8b3fea5f304791