### PR TITLE
Add SitePulse admin overview and tab updates

### DIFF
--- a/sitepulse_FR/modules/css/admin-settings.css
+++ b/sitepulse_FR/modules/css/admin-settings.css
@@ -10,6 +10,140 @@
     margin: 0 0 16px;
 }
 
+.sitepulse-overview-card {
+    align-items: flex-start;
+    background: #fff;
+    border: 1px solid #dcdcde;
+    border-left: 4px solid #2271b1;
+    border-radius: 6px;
+    display: flex;
+    gap: 20px;
+    margin-bottom: 32px;
+    padding: 24px;
+}
+
+.sitepulse-overview-card__icon {
+    align-items: center;
+    background: #2271b1;
+    border-radius: 50%;
+    color: #fff;
+    display: flex;
+    justify-content: center;
+    flex-shrink: 0;
+    height: 48px;
+    width: 48px;
+}
+
+.sitepulse-overview-card__icon .dashicons {
+    font-size: 24px;
+    line-height: 1;
+}
+
+.sitepulse-overview-card__content {
+    flex: 1;
+}
+
+.sitepulse-overview-card__header {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+
+.sitepulse-overview-card__header h2 {
+    font-size: 20px;
+    margin: 0;
+}
+
+.sitepulse-overview-card__intro {
+    color: #50575e;
+    font-size: 14px;
+    margin: 0 0 16px;
+}
+
+.sitepulse-overview-card__items {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.sitepulse-overview-card__item {
+    background: #f6f7f7;
+    border-radius: 6px;
+    padding: 16px;
+}
+
+.sitepulse-overview-card__item-heading {
+    align-items: center;
+    display: flex;
+    gap: 12px;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+
+.sitepulse-overview-card__item-title {
+    color: #1d2327;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.sitepulse-overview-card__item-description {
+    color: #50575e;
+    font-size: 13px;
+    margin: 0 0 12px;
+}
+
+.sitepulse-overview-card__item-action {
+    align-items: center;
+    color: #2271b1;
+    display: inline-flex;
+    font-weight: 600;
+    gap: 4px;
+    text-decoration: none;
+}
+
+.sitepulse-overview-card__item-action:hover,
+.sitepulse-overview-card__item-action:focus {
+    color: #135e96;
+}
+
+.sitepulse-status-badge {
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    padding: 4px 10px;
+    text-transform: uppercase;
+}
+
+.sitepulse-status-badge.is-complete {
+    background: #e7f5ea;
+    color: #0a6a1f;
+}
+
+.sitepulse-status-badge.is-partial {
+    background: #fff4e5;
+    color: #924400;
+}
+
+.sitepulse-status-badge.is-missing {
+    background: #fbeaea;
+    color: #8a2424;
+}
+
+.sitepulse-overview-grid .sitepulse-module-card {
+    border-color: #dcdcde;
+}
+
+.sitepulse-overview-grid .sitepulse-card-header {
+    align-items: center;
+    gap: 12px;
+}
+
 .sitepulse-settings-form {
     margin-top: 24px;
 }
@@ -185,6 +319,20 @@
 
 @media (max-width: 782px) {
     .sitepulse-settings-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .sitepulse-overview-card {
+        flex-direction: column;
+        padding: 20px;
+    }
+
+    .sitepulse-overview-card__icon {
+        height: 40px;
+        width: 40px;
+    }
+
+    .sitepulse-overview-card__items {
         grid-template-columns: 1fr;
     }
 

--- a/tests/phpunit/test-admin-settings-cleanup.php
+++ b/tests/phpunit/test-admin-settings-cleanup.php
@@ -228,4 +228,15 @@ class Sitepulse_Admin_Settings_Cleanup_Test extends WP_UnitTestCase {
 
         $this->assertSame('stored-value', $sanitized);
     }
+
+    public function test_settings_page_displays_overview_tab_by_default(): void {
+        ob_start();
+        sitepulse_settings_page();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('sitepulse-tab-overview-label', $output);
+        $this->assertStringContainsString('data-tab-target="sitepulse-tab-overview"', $output);
+        $this->assertStringContainsString('id="sitepulse-tab-overview"', $output);
+        $this->assertStringContainsString('id="sitepulse-tab-overview-label" class="nav-tab nav-tab-active"', $output);
+    }
 }


### PR DESCRIPTION
## Summary
- add computed overview data for essential modules, alerts and AI key on the SitePulse settings screen
- insert a quick overview card, reorder the table of contents, and add a dedicated "Vue d’ensemble" tab to the navigation
- style the overview card to match WordPress UI and cover the new tab with a PHPUnit assertion

## Testing
- php -l sitepulse_FR/includes/admin-settings.php
- php -l tests/phpunit/test-admin-settings-cleanup.php
- (fails: command not found) phpunit -c phpunit.xml.dist


------
https://chatgpt.com/codex/tasks/task_e_68e1a422587c832eb89e6ede55bf4ac1