### PR TITLE
feat: display module summaries on module cards

### DIFF
--- a/sitepulse_FR/includes/admin-settings.php
+++ b/sitepulse_FR/includes/admin-settings.php
@@ -1989,7 +1989,12 @@ function sitepulse_settings_page() {
                             $raw_metrics = isset($module_summaries[$module_key]) && is_array($module_summaries[$module_key])
                                 ? $module_summaries[$module_key]
                                 : [];
-                            $module_metrics = [];
+                            ?>
+                            <?php if ($module_description !== '') : ?>
+                                <p class="sitepulse-card-description" id="<?php echo esc_attr($description_id); ?>"><?php echo esc_html($module_description); ?></p>
+                            <?php endif; ?>
+                            <?php
+                            $prepared_metrics = [];
 
                             foreach ($raw_metrics as $metric) {
                                 if (!is_array($metric)) {
@@ -2008,26 +2013,23 @@ function sitepulse_settings_page() {
                                     $metric_status = 'is-success';
                                 }
 
-                                $module_metrics[] = [
+                                $prepared_metrics[] = [
                                     'label'  => $metric_label,
                                     'value'  => $metric_value,
                                     'status' => $metric_status,
                                 ];
                             }
                             ?>
-                            <?php if ($module_description !== '') : ?>
-                                <p class="sitepulse-card-description" id="<?php echo esc_attr($description_id); ?>"><?php echo esc_html($module_description); ?></p>
-                            <?php endif; ?>
-                            <?php if (!empty($module_metrics)) : ?>
+                            <?php if (!empty($prepared_metrics)) : ?>
                                 <ul class="sitepulse-module-metrics">
-                                    <?php foreach ($module_metrics as $metric) : ?>
+                                    <?php foreach ($prepared_metrics as $metric) : ?>
                                         <li class="sitepulse-module-metric">
                                             <?php if ($metric['label'] !== '') : ?>
-                                                <span class="sitepulse-status <?php echo esc_attr($metric['status']); ?>"><?php echo esc_html($metric['label']); ?></span>
+                                                <span class="sitepulse-module-metric-label"><?php echo esc_html($metric['label']); ?></span>
                                             <?php endif; ?>
-                                            <?php if ($metric['value'] !== '') : ?>
-                                                <span class="sitepulse-module-metric-value"><?php echo esc_html($metric['value']); ?></span>
-                                            <?php endif; ?>
+                                            <span class="sitepulse-status <?php echo esc_attr($metric['status']); ?>">
+                                                <?php echo esc_html($metric['value'] !== '' ? $metric['value'] : __('Aucun relevé', 'sitepulse')); ?>
+                                            </span>
                                         </li>
                                     <?php endforeach; ?>
                                 </ul>

--- a/sitepulse_FR/modules/css/admin-settings.css
+++ b/sitepulse_FR/modules/css/admin-settings.css
@@ -152,6 +152,13 @@
     color: #2d3748;
 }
 
+.sitepulse-module-metric-label {
+    font-weight: 600;
+    font-size: 12px;
+    color: #4a5568;
+    text-transform: uppercase;
+}
+
 .sitepulse-module-metric-value {
     font-weight: 600;
 }

--- a/tests/phpunit/test-module-changes.php
+++ b/tests/phpunit/test-module-changes.php
@@ -140,13 +140,13 @@ class Sitepulse_Module_Changes_Test extends WP_UnitTestCase {
         $output = ob_get_clean();
 
         $this->assertStringContainsString('Alertes', $output);
-        $this->assertStringContainsString('1 en attente', $output);
+        $this->assertMatchesRegularExpression('/sitepulse-status\s+is-critical[^>]*>[^<]*en attente/i', $output);
         $this->assertStringContainsString('Temps de réponse', $output);
-        $this->assertStringContainsString('150', $output);
+        $this->assertMatchesRegularExpression('/Temps de réponse[\s\S]*sitepulse-status\s+is-success[^>]*>[^<]*150/', $output);
         $this->assertStringContainsString('Statut actuel', $output);
-        $this->assertStringContainsString('En ligne', $output);
+        $this->assertMatchesRegularExpression('/Statut actuel[\s\S]*sitepulse-status\s+is-success[^>]*>[^<]*En ligne/', $output);
         $this->assertStringContainsString('Dernière analyse', $output);
-        $this->assertStringContainsString('Il y a', $output);
+        $this->assertMatchesRegularExpression('/Dernière analyse[\s\S]*sitepulse-status\s+is-success[^>]*>[^<]*Il y a/', $output);
         $this->assertStringContainsString('Aucun relevé', $output);
     }
 }


### PR DESCRIPTION
## Summary
- show the latest stored metrics on module cards using status badges
- add styling for metric labels and keep a fallback when no measurements are found
- extend the module change test to cover the new badge output

## Testing
- phpunit --configuration phpunit.xml.dist *(fails: phpunit binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e24e442b74832ea4f98d8ad0fbdc67