### PR TITLE
Improve admin settings tab accessibility

### DIFF
--- a/sitepulse_FR/modules/css/admin-settings.css
+++ b/sitepulse_FR/modules/css/admin-settings.css
@@ -18,6 +18,10 @@
     margin-bottom: 0;
 }
 
+.sitepulse-settings-wrap [hidden] {
+    display: none !important;
+}
+
 .sitepulse-settings-tabs .sitepulse-tab-link {
     display: inline-flex;
     align-items: center;
@@ -25,7 +29,8 @@
     transition: background-color 0.2s ease, color 0.2s ease;
 }
 
-.sitepulse-settings-tabs .sitepulse-tab-link.nav-tab-active {
+.sitepulse-settings-tabs .sitepulse-tab-link.nav-tab-active,
+.sitepulse-settings-tabs .sitepulse-tab-link.is-active {
     background: #fff;
     border-bottom-color: #fff;
     box-shadow: 0 1px 0 #fff;
@@ -40,6 +45,10 @@
 
 .sitepulse-settings-tabs-container.is-enhanced .sitepulse-tab-panel[hidden] {
     display: none;
+}
+
+.sitepulse-settings-tabs-container.is-enhanced .sitepulse-tab-panel.is-active {
+    display: block;
 }
 
 .sitepulse-settings-form--secondary {

--- a/sitepulse_FR/modules/js/admin-settings-tabs.js
+++ b/sitepulse_FR/modules/js/admin-settings-tabs.js
@@ -19,6 +19,14 @@
         }
     };
 
+    const normalizeHash = (hashValue) => {
+        if (!hashValue) {
+            return '';
+        }
+
+        return hashValue.charAt(0) === '#' ? hashValue.substring(1) : hashValue;
+    };
+
     onReady(() => {
         const container = document.querySelector('.sitepulse-settings-tabs-container');
 
@@ -27,7 +35,7 @@
         }
 
         const tabLinks = Array.from(container.querySelectorAll('.sitepulse-tab-link[data-tab-target]'));
-        const tabPanels = Array.from(container.querySelectorAll('.sitepulse-tab-panel'));
+        const tabPanels = Array.from(container.querySelectorAll('.sitepulse-tab-panel[id]'));
         const tocLinks = Array.from(document.querySelectorAll('.sitepulse-tab-trigger[data-tab-target]'));
 
         if (!tabLinks.length || !tabPanels.length) {
@@ -36,7 +44,7 @@
 
         container.classList.add('is-enhanced');
 
-        const getLinkForTarget = (targetId) => tabLinks.find((link) => link.dataset.tabTarget === targetId);
+        const getLinkForTarget = (targetId) => tabLinks.find((link) => link.dataset.tabTarget === targetId) || null;
 
         const setTabState = (targetId) => {
             const panel = tabPanels.find((element) => element.id === targetId);
@@ -56,11 +64,9 @@
             tabPanels.forEach((panelElement) => {
                 const isActive = panelElement.id === targetId;
                 panelElement.classList.toggle('is-active', isActive);
-                if (isActive) {
-                    panelElement.removeAttribute('hidden');
-                } else {
-                    panelElement.setAttribute('hidden', 'hidden');
-                }
+                panelElement.toggleAttribute('hidden', !isActive);
+                panelElement.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+                panelElement.setAttribute('tabindex', isActive ? '0' : '-1');
             });
 
             return {
@@ -85,11 +91,13 @@
         };
 
         const findPanelFromHash = (hashValue) => {
-            if (!hashValue) {
+            const normalizedHash = normalizeHash(hashValue);
+
+            if (!normalizedHash) {
                 return null;
             }
 
-            const directTarget = document.getElementById(hashValue);
+            const directTarget = document.getElementById(normalizedHash);
 
             if (!directTarget) {
                 return null;
@@ -182,19 +190,19 @@
                     return;
                 }
 
-                activateTab(targetId);
+                activateTab(targetId, { announce: true });
             });
         });
 
         window.addEventListener('hashchange', () => {
-            const panel = findPanelFromHash(window.location.hash.substring(1));
+            const panel = findPanelFromHash(window.location.hash);
 
             if (panel) {
                 activateTab(panel.id);
             }
         });
 
-        const initialPanel = findPanelFromHash(window.location.hash.substring(1)) || tabPanels[0];
+        const initialPanel = findPanelFromHash(window.location.hash) || tabPanels[0];
 
         if (initialPanel) {
             activateTab(initialPanel.id);


### PR DESCRIPTION
## Summary
- refine the admin settings tab script to manage ARIA attributes, focus handling, and hash navigation when switching tabs
- adjust the admin settings stylesheet to hide inactive panels and visually mark the active tab

## Testing
- not run (WordPress admin UI is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e24e3867f0832ea148e60bf8348533