### PR TITLE
Improve transient cleanup and document enhancement plan

### DIFF
--- a/sitepulse_FR/IMPROVEMENTS.md
+++ b/sitepulse_FR/IMPROVEMENTS.md
@@ -1,0 +1,39 @@
+# Plan d'amélioration des fonctions
+
+Ce document répertorie les fonctions de SitePulse qui gagneraient à être alignées sur les standards observés dans les solutions professionnelles de monitoring WordPress/SaaS. Les propositions tiennent compte des attentes en matière de résilience, d'observabilité et d'expérience utilisateur premium.
+
+## `sitepulse_delete_transients_by_prefix()`
+
+- **Constat :** la fonction nettoie désormais les entrées `_transient_` et `_transient_timeout_`, ce qui la rapproche des purgeurs distribués utilisés par des suites comme New Relic ou Kinsta MU Manager. Il manque toutefois une prise en charge des caches objets persistants pour éviter les résidus côté Redis/Memcached, ainsi qu'un découpage par lots pour limiter les requêtes longues sur des tables volumineuses.【F:sitepulse_FR/includes/functions.php†L18-L60】
+- **Pistes pro :**
+  - Interroger `wp_using_ext_object_cache()` et purger explicitement les groupes `transient`/`site-transient` dans l'object cache distant.
+  - Segmenter la suppression (pagination SQL ou curseurs) et journaliser le nombre d'entrées supprimées pour suivre l'efficacité des rotations.
+
+## `sitepulse_get_recent_log_lines()`
+
+- **Constat :** la lecture arrière est efficace pour des logs moyens, mais elle ne renvoie pas de métadonnées (horodatage, taille lue) et ne gère pas la contention de fichiers verrouillés, contrairement aux consoles temps réel proposées par des plateformes comme Datadog ou CloudWatch.【F:sitepulse_FR/includes/functions.php†L136-L225】
+- **Pistes pro :**
+  - Ajouter un verrouillage partagé (`flock`) et une tolérance aux logs volumineux (>10 Mo) via `SplFileObject` ou un streaming incrémental.
+  - Retourner un tableau associatif `{ lines, bytes_read, truncated }` pour savoir si le résultat est complet ou tronqué.
+
+## `sitepulse_get_ai_models()`
+
+- **Constat :** la liste est filtrable mais recalculée à chaque appel, sans cache ni validation approfondie des clés, ce qui diffère des catalogues dynamiques gérés par des outils comme Jasper ou Writesonic qui mémorisent les modèles validés pour chaque workspace.【F:sitepulse_FR/includes/functions.php†L92-L135】
+- **Pistes pro :**
+  - Mettre en place un cache transitoire (ou un cache runtime statique) pour éviter des filtrages coûteux sur des listes personnalisées.
+  - Enrichir la validation (longueur des identifiants, disponibilité régionale, coût estimé) et exposer un schéma de compatibilité pour les interfaces React.
+
+## `sitepulse_sanitize_alert_interval()`
+
+- **Constat :** seules quatre valeurs fixes sont acceptées, ce qui limite la personnalisation par rapport aux systèmes d'alerte professionnels (Statuspage, Better Uptime) qui autorisent des fenêtres plus fines (1-120 minutes) et des stratégies progressives.【F:sitepulse_FR/includes/functions.php†L226-L250】
+- **Pistes pro :**
+  - Autoriser des paliers supplémentaires (p. ex. 1, 2, 5, 10, 15, 30, 60) et ajouter un mode « intelligent » qui ajuste l'intervalle selon la gravité des erreurs récentes.
+  - Documenter une API permettant aux intégrations tierces de définir leurs propres contraintes via un filtre.
+
+## `sitepulse_get_speed_thresholds()`
+
+- **Constat :** la fonction force le seuil critique à être strictement supérieur au seuil d'avertissement, mais ne journalise pas ces corrections et n'offre pas de contextes multiples (mobile/desktop) comme le font des suites d'observabilité telles que Calibre ou SpeedCurve.【F:sitepulse_FR/includes/functions.php†L48-L91】
+- **Pistes pro :**
+  - Stocker les ajustements correctifs dans un journal pour faciliter l'audit lors des revues de performance.
+  - Étendre la structure de retour pour inclure des profils (mobile, desktop, LCP, TTFB) et des seuils dépendant des objectifs Core Web Vitals.
+

--- a/sitepulse_FR/includes/functions.php
+++ b/sitepulse_FR/includes/functions.php
@@ -26,8 +26,9 @@ if (!function_exists('sitepulse_delete_transients_by_prefix')) {
         $like = $wpdb->esc_like($prefix) . '%';
         $option_names = $wpdb->get_col(
             $wpdb->prepare(
-                "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s",
-                '_transient_' . $like
+                "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s",
+                '_transient_' . $like,
+                '_transient_timeout_' . $like
             )
         );
 
@@ -35,14 +36,24 @@ if (!function_exists('sitepulse_delete_transients_by_prefix')) {
             return;
         }
 
-        $transient_prefix = strlen('_transient_');
+        $transient_keys = [];
+        $value_prefix   = strlen('_transient_');
+        $timeout_prefix = strlen('_transient_timeout_');
 
         foreach ($option_names as $option_name) {
-            $transient_key = substr($option_name, $transient_prefix);
+            if (strpos($option_name, '_transient_timeout_') === 0) {
+                $transient_key = substr($option_name, $timeout_prefix);
+            } else {
+                $transient_key = substr($option_name, $value_prefix);
+            }
 
             if ($transient_key !== '') {
-                delete_transient($transient_key);
+                $transient_keys[$transient_key] = true;
             }
+        }
+
+        foreach (array_keys($transient_keys) as $transient_key) {
+            delete_transient($transient_key);
         }
     }
 }
@@ -256,8 +267,9 @@ if (!function_exists('sitepulse_delete_site_transients_by_prefix')) {
         $like = $wpdb->esc_like($prefix) . '%';
         $meta_keys = $wpdb->get_col(
             $wpdb->prepare(
-                "SELECT meta_key FROM {$wpdb->sitemeta} WHERE meta_key LIKE %s",
-                '_site_transient_' . $like
+                "SELECT meta_key FROM {$wpdb->sitemeta} WHERE meta_key LIKE %s OR meta_key LIKE %s",
+                '_site_transient_' . $like,
+                '_site_transient_timeout_' . $like
             )
         );
 
@@ -265,14 +277,24 @@ if (!function_exists('sitepulse_delete_site_transients_by_prefix')) {
             return;
         }
 
-        $site_transient_prefix = strlen('_site_transient_');
+        $transient_keys = [];
+        $value_prefix   = strlen('_site_transient_');
+        $timeout_prefix = strlen('_site_transient_timeout_');
 
         foreach ($meta_keys as $meta_key) {
-            $transient_key = substr($meta_key, $site_transient_prefix);
+            if (strpos($meta_key, '_site_transient_timeout_') === 0) {
+                $transient_key = substr($meta_key, $timeout_prefix);
+            } else {
+                $transient_key = substr($meta_key, $value_prefix);
+            }
 
             if ($transient_key !== '') {
-                delete_site_transient($transient_key);
+                $transient_keys[$transient_key] = true;
             }
+        }
+
+        foreach (array_keys($transient_keys) as $transient_key) {
+            delete_site_transient($transient_key);
         }
     }
 }

--- a/sitepulse_FR/tests/sitepulse_transient_cleanup_test.php
+++ b/sitepulse_FR/tests/sitepulse_transient_cleanup_test.php
@@ -1,0 +1,261 @@
+<?php
+declare(strict_types=1);
+
+define('ABSPATH', __DIR__);
+
+if (!class_exists('wpdb')) {
+    class wpdb {}
+}
+
+$GLOBALS['sitepulse_is_multisite'] = false;
+$GLOBALS['sitepulse_deleted_transients'] = [];
+$GLOBALS['sitepulse_deleted_site_transients'] = [];
+
+class Sitepulse_Test_WPDB extends wpdb
+{
+    public $options = 'wp_options';
+    public $sitemeta = 'wp_sitemeta';
+
+    private $queries = [];
+
+    public $data = [
+        'options'  => [],
+        'sitemeta' => [],
+    ];
+
+    public function esc_like($text)
+    {
+        return addcslashes((string) $text, '_%\\');
+    }
+
+    public function prepare($query, ...$args)
+    {
+        if (count($args) === 1 && is_array($args[0])) {
+            $args = $args[0];
+        }
+
+        $token = 'stmt_' . count($this->queries);
+
+        $this->queries[$token] = [
+            'query' => (string) $query,
+            'args'  => $args,
+        ];
+
+        return $token;
+    }
+
+    public function get_col($token)
+    {
+        if (!isset($this->queries[$token])) {
+            return [];
+        }
+
+        $statement = $this->queries[$token];
+        unset($this->queries[$token]);
+
+        $table = (strpos($statement['query'], $this->sitemeta) !== false) ? 'sitemeta' : 'options';
+        $column = ($table === 'options') ? 'option_name' : 'meta_key';
+        $like_1 = $this->normalize_like($statement['args'][0] ?? '');
+        $like_2 = $this->normalize_like($statement['args'][1] ?? '');
+
+        $results = [];
+
+        foreach ($this->data[$table] as $row) {
+            $value = $row[$column] ?? '';
+
+            if ($like_1 !== '' && strpos($value, $like_1) === 0) {
+                $results[] = $value;
+                continue;
+            }
+
+            if ($like_2 !== '' && strpos($value, $like_2) === 0) {
+                $results[] = $value;
+            }
+        }
+
+        return $results;
+    }
+
+    public function set_option_rows(array $rows)
+    {
+        $this->data['options'] = array_values($rows);
+    }
+
+    public function set_sitemeta_rows(array $rows)
+    {
+        $this->data['sitemeta'] = array_values($rows);
+    }
+
+    public function has_option($name)
+    {
+        foreach ($this->data['options'] as $row) {
+            if (($row['option_name'] ?? null) === $name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function has_meta($key)
+    {
+        foreach ($this->data['sitemeta'] as $row) {
+            if (($row['meta_key'] ?? null) === $key) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function delete_transient_rows($key)
+    {
+        $targets = [
+            '_transient_' . $key,
+            '_transient_timeout_' . $key,
+        ];
+
+        $this->data['options'] = array_values(array_filter(
+            $this->data['options'],
+            function ($row) use ($targets) {
+                return !in_array($row['option_name'] ?? '', $targets, true);
+            }
+        ));
+    }
+
+    public function delete_site_transient_rows($key)
+    {
+        $targets = [
+            '_site_transient_' . $key,
+            '_site_transient_timeout_' . $key,
+        ];
+
+        $this->data['sitemeta'] = array_values(array_filter(
+            $this->data['sitemeta'],
+            function ($row) use ($targets) {
+                return !in_array($row['meta_key'] ?? '', $targets, true);
+            }
+        ));
+    }
+
+    private function normalize_like($pattern)
+    {
+        $pattern = (string) $pattern;
+
+        if ($pattern === '') {
+            return '';
+        }
+
+        if (substr($pattern, -1) === '%') {
+            $pattern = substr($pattern, 0, -1);
+        }
+
+        return str_replace('\\', '', $pattern);
+    }
+}
+
+if (!function_exists('is_multisite')) {
+    function is_multisite()
+    {
+        return !empty($GLOBALS['sitepulse_is_multisite']);
+    }
+}
+
+if (!function_exists('delete_transient')) {
+    function delete_transient($key)
+    {
+        global $wpdb;
+
+        $GLOBALS['sitepulse_deleted_transients'][] = $key;
+
+        if ($wpdb instanceof Sitepulse_Test_WPDB) {
+            $wpdb->delete_transient_rows($key);
+        }
+
+        return true;
+    }
+}
+
+if (!function_exists('delete_site_transient')) {
+    function delete_site_transient($key)
+    {
+        global $wpdb;
+
+        $GLOBALS['sitepulse_deleted_site_transients'][] = $key;
+
+        if ($wpdb instanceof Sitepulse_Test_WPDB) {
+            $wpdb->delete_site_transient_rows($key);
+        }
+
+        return true;
+    }
+}
+
+if (!function_exists('apply_filters')) {
+    function apply_filters($hook, $value)
+    {
+        return $value;
+    }
+}
+
+require_once dirname(__DIR__) . '/includes/functions.php';
+
+function sitepulse_assert($condition, $message)
+{
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+$wpdb = new Sitepulse_Test_WPDB();
+$GLOBALS['wpdb'] = $wpdb;
+
+$wpdb->set_option_rows([
+    ['option_name' => '_transient_sitepulse_speed', 'option_value' => 'ok'],
+    ['option_name' => '_transient_timeout_sitepulse_speed', 'option_value' => time() + 60],
+    ['option_name' => '_transient_sitepulse_error', 'option_value' => 'ok'],
+    ['option_name' => '_transient_timeout_sitepulse_error', 'option_value' => time() + 60],
+    ['option_name' => '_transient_other_metric', 'option_value' => 'ok'],
+    ['option_name' => '_transient_timeout_other_metric', 'option_value' => time() + 60],
+]);
+
+sitepulse_delete_transients_by_prefix('sitepulse_');
+
+sitepulse_assert(!$wpdb->has_option('_transient_sitepulse_speed'), 'Les valeurs ciblées doivent être supprimées.');
+sitepulse_assert(!$wpdb->has_option('_transient_timeout_sitepulse_speed'), 'Les timeouts ciblés doivent être supprimés.');
+sitepulse_assert(!$wpdb->has_option('_transient_sitepulse_error'), 'Toutes les valeurs correspondant au préfixe doivent être supprimées.');
+sitepulse_assert(!$wpdb->has_option('_transient_timeout_sitepulse_error'), 'Tous les timeouts correspondant au préfixe doivent être supprimés.');
+sitepulse_assert($wpdb->has_option('_transient_other_metric'), 'Les transients non ciblés doivent être préservés.');
+sitepulse_assert($wpdb->has_option('_transient_timeout_other_metric'), 'Les timeouts non ciblés doivent être préservés.');
+
+$deleted_transients = $GLOBALS['sitepulse_deleted_transients'];
+sort($deleted_transients);
+sitepulse_assert($deleted_transients === ['sitepulse_error', 'sitepulse_speed'], 'Seules les clés ciblées doivent être supprimées.');
+
+$GLOBALS['sitepulse_deleted_transients'] = [];
+
+$wpdb->set_sitemeta_rows([
+    ['meta_key' => '_site_transient_sitepulse_queue', 'meta_value' => '1'],
+    ['meta_key' => '_site_transient_timeout_sitepulse_queue', 'meta_value' => time() + 60],
+    ['meta_key' => '_site_transient_sitepulse_digest', 'meta_value' => '1'],
+    ['meta_key' => '_site_transient_timeout_sitepulse_digest', 'meta_value' => time() + 60],
+    ['meta_key' => '_site_transient_other_queue', 'meta_value' => '1'],
+    ['meta_key' => '_site_transient_timeout_other_queue', 'meta_value' => time() + 60],
+]);
+
+$GLOBALS['sitepulse_is_multisite'] = true;
+
+sitepulse_delete_site_transients_by_prefix('sitepulse_');
+
+sitepulse_assert(!$wpdb->has_meta('_site_transient_sitepulse_queue'), 'Les transients réseau ciblés doivent être supprimés.');
+sitepulse_assert(!$wpdb->has_meta('_site_transient_timeout_sitepulse_queue'), 'Les timeouts réseau ciblés doivent être supprimés.');
+sitepulse_assert(!$wpdb->has_meta('_site_transient_sitepulse_digest'), 'Toutes les valeurs réseau correspondant au préfixe doivent être supprimées.');
+sitepulse_assert(!$wpdb->has_meta('_site_transient_timeout_sitepulse_digest'), 'Tous les timeouts réseau correspondant au préfixe doivent être supprimés.');
+sitepulse_assert($wpdb->has_meta('_site_transient_other_queue'), 'Les transients réseau non ciblés doivent être préservés.');
+sitepulse_assert($wpdb->has_meta('_site_transient_timeout_other_queue'), 'Les timeouts réseau non ciblés doivent être préservés.');
+
+$deleted_site_transients = $GLOBALS['sitepulse_deleted_site_transients'];
+sort($deleted_site_transients);
+sitepulse_assert($deleted_site_transients === ['sitepulse_digest', 'sitepulse_queue'], 'Seules les clés réseau ciblées doivent être supprimées.');
+
+echo "Tous les tests de nettoyage de transients sont passés." . PHP_EOL;


### PR DESCRIPTION
## Summary
- extend transient cleanup helpers to remove timeout rows and deduplicate keys
- add coverage ensuring both single-site and network transient cleanup paths purge consistently
- document remaining high-priority function enhancements compared to professional monitoring suites

## Testing
- php sitepulse_FR/tests/sitepulse_transient_cleanup_test.php

------
https://chatgpt.com/codex/tasks/task_e_68e2cb797d50832eb3b662d21eb25cde