### PR TITLE
Load translations on init

### DIFF
--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -292,7 +292,9 @@ sitepulse_update_plugin_basename_option();
 $debug_mode = get_option(SITEPULSE_OPTION_DEBUG_MODE, false);
 define('SITEPULSE_DEBUG', (bool) $debug_mode);
 
-add_action('plugins_loaded', 'sitepulse_load_textdomain');
+// Load translations once WordPress has completed initialization to avoid
+// triggering the _load_textdomain_just_in_time notice introduced in WP 6.7.
+add_action('init', 'sitepulse_load_textdomain');
 
 function sitepulse_load_textdomain() {
     load_plugin_textdomain('sitepulse', false, dirname(plugin_basename(__FILE__)) . '/languages');


### PR DESCRIPTION
## Summary
- load the SitePulse text domain on the `init` hook so translations are initialized after WordPress boots
- document the change to clarify the link with the `_load_textdomain_just_in_time` notice introduced in WP 6.7

## Testing
- not run (phpunit not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2ce8bb3fc832eb233f40649121629