### PR TITLE
Define default status labels before use

### DIFF
--- a/sitepulse_FR/modules/custom_dashboards.php
+++ b/sitepulse_FR/modules/custom_dashboards.php
@@ -518,6 +518,8 @@ function sitepulse_get_dashboard_preview_context() {
         ],
     ];
 
+    $default_status_labels = $status_labels;
+
     $context = [
         'active_modules' => $active_modules,
         'palette'        => $palette,


### PR DESCRIPTION
## Summary
- initialize the default status labels array in the dashboard preview context so it can be shared with status helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2e301270c832ebb465ef27ce1e4a9