### PR TITLE
Improve Gutenberg dashboard preview block editor presentation

### DIFF
--- a/sitepulse_FR/blocks/dashboard-preview/editor.css
+++ b/sitepulse_FR/blocks/dashboard-preview/editor.css
@@ -1,0 +1,35 @@
+.editor-styles-wrapper .wp-block-sitepulse-dashboard-preview {
+    border: 1px solid var(--wp-admin-color-gray-200, #c3c4c7);
+    border-radius: 8px;
+    padding: clamp(16px, 3vw, 24px);
+    background: var(--wp-admin-color-gray-0, #ffffff);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.editor-styles-wrapper .wp-block-sitepulse-dashboard-preview .sitepulse-dashboard-preview__header {
+    margin-bottom: var(--sitepulse-dashboard-header-spacing, 24px);
+}
+
+.editor-styles-wrapper .wp-block-sitepulse-dashboard-preview .sitepulse-dashboard-preview__header h3 {
+    font-size: 18px;
+}
+
+.editor-styles-wrapper .wp-block-sitepulse-dashboard-preview .sitepulse-dashboard-preview__header p {
+    color: var(--wp-admin-color-gray-700, #50575e);
+}
+
+.editor-styles-wrapper .wp-block-sitepulse-dashboard-preview .sitepulse-grid {
+    margin-top: 0;
+}
+
+.editor-styles-wrapper .wp-block-sitepulse-dashboard-preview .sitepulse-card {
+    box-shadow: none;
+}
+
+.editor-styles-wrapper .wp-block-sitepulse-dashboard-preview .sitepulse-card .description {
+    color: var(--wp-admin-color-gray-600, #646970);
+}
+
+.editor-styles-wrapper .wp-block-sitepulse-dashboard-preview .sitepulse-chart-container {
+    min-height: 200px;
+}

--- a/sitepulse_FR/blocks/dashboard-preview/editor.js
+++ b/sitepulse_FR/blocks/dashboard-preview/editor.js
@@ -113,7 +113,8 @@
                                     setAttributes(next);
                                 },
                                 disabled: moduleDisabled,
-                                help: toggleHelp
+                                help: toggleHelp,
+                                __nextHasNoMarginBottom: true
                             });
                         })
                     ),

--- a/sitepulse_FR/blocks/dashboard-preview/style.css
+++ b/sitepulse_FR/blocks/dashboard-preview/style.css
@@ -2,7 +2,7 @@
     --sitepulse-dashboard-gap: 20px;
     --sitepulse-dashboard-card-padding: 20px;
     --sitepulse-dashboard-header-spacing: 24px;
-    margin-block: 0;
+    margin-block: var(--wp--style--block-gap, 0);
 }
 
 .wp-block-sitepulse-dashboard-preview:not(.alignwide):not(.alignfull) {
@@ -58,6 +58,28 @@
 
 .sitepulse-dashboard-preview-block__notice {
     margin-bottom: 16px;
+}
+
+.sitepulse-dashboard-preview-block__notice p {
+    margin-top: 0;
+    margin-bottom: 8px;
+}
+
+.sitepulse-dashboard-preview-block__notice p:last-child {
+    margin-bottom: 0;
+}
+
+.sitepulse-dashboard-preview-block__notice-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.sitepulse-dashboard-preview-block__notice-actions .components-button,
+.sitepulse-dashboard-preview-block__notice-actions .components-button.is-secondary,
+.sitepulse-dashboard-preview-block__notice-actions .components-button.is-tertiary {
+    margin: 0;
 }
 
 .wp-block-sitepulse-dashboard-preview .sitepulse-chart-container {

--- a/sitepulse_FR/sitepulse.php
+++ b/sitepulse_FR/sitepulse.php
@@ -1648,6 +1648,7 @@ function sitepulse_register_dashboard_preview_block() {
     $block_dir = SITEPULSE_PATH . 'blocks/dashboard-preview';
     $style_base_handle = 'sitepulse-dashboard-preview-base';
     $style_handle = 'sitepulse-dashboard-preview-style';
+    $editor_style_handle = 'sitepulse-dashboard-preview-editor-style';
     $editor_handle = 'sitepulse-dashboard-preview-editor';
 
     wp_register_style(
@@ -1661,6 +1662,13 @@ function sitepulse_register_dashboard_preview_block() {
         $style_handle,
         SITEPULSE_URL . 'blocks/dashboard-preview/style.css',
         [$style_base_handle],
+        SITEPULSE_VERSION
+    );
+
+    wp_register_style(
+        $editor_style_handle,
+        SITEPULSE_URL . 'blocks/dashboard-preview/editor.css',
+        [$style_handle],
         SITEPULSE_VERSION
     );
 
@@ -1680,6 +1688,7 @@ function sitepulse_register_dashboard_preview_block() {
         $block_dir,
         [
             'style'           => $style_handle,
+            'editor_style'    => $editor_style_handle,
             'editor_script'   => $editor_handle,
             'render_callback' => 'sitepulse_render_dashboard_preview_block',
         ]


### PR DESCRIPTION
## Summary
- add an editor-only stylesheet so the dashboard preview block renders with padded cards and consistent colors inside Gutenberg
- tune the shared block styles to use the global block gap and clean up notice spacing/actions
- silence the ToggleControl margin deprecation notice by opting into the new marginless behaviour

## Testing
- php -l sitepulse_FR/sitepulse.php

------
https://chatgpt.com/codex/tasks/task_e_68e44414e774832e89df7f536e7ff563