### PR TITLE
Fix sortable initialization error in dashboard preferences panel

### DIFF
--- a/sitepulse_FR/modules/js/sitepulse-dashboard-preferences.js
+++ b/sitepulse_FR/modules/js/sitepulse-dashboard-preferences.js
@@ -30,9 +30,9 @@
     initialise();
 
     function initialise() {
+        bindEvents();
         setControlsFromState(savedState);
         applyStateToGrid(savedState);
-        bindEvents();
         updateEmptyState();
     }
 
@@ -188,7 +188,7 @@
 
         list.appendChild(fragment);
 
-        if ($list && typeof $list.sortable === 'function') {
+        if ($list && typeof $list.sortable === 'function' && $list.hasClass('ui-sortable')) {
             $list.sortable('refresh');
         }
     }


### PR DESCRIPTION
## Summary
- bind dashboard preference events before applying the saved state so sortable is initialised
- guard sortable refresh calls until the sortable instance exists

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e443373038832e8981afc864f28723