### PR TITLE
docs: ajouter revue du bloc dashboard et debug visuel

### DIFF
--- a/sitepulse_FR/blocks/dashboard-preview/style.css
+++ b/sitepulse_FR/blocks/dashboard-preview/style.css
@@ -2,6 +2,7 @@
     --sitepulse-dashboard-gap: 20px;
     --sitepulse-dashboard-card-padding: 20px;
     --sitepulse-dashboard-header-spacing: 24px;
+    --sitepulse-dashboard-card-min-width: clamp(220px, 22vw, 320px);
     margin-block: var(--wp--style--block-gap, 0);
 }
 
@@ -25,23 +26,23 @@
     display: grid;
     margin-top: 0;
     gap: var(--wp--style--block-gap, var(--sitepulse-dashboard-gap, 20px));
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    grid-template-columns: repeat(
+        auto-fit,
+        minmax(var(--sitepulse-dashboard-card-min-width, 260px), 1fr)
+    );
 }
 
 .wp-block-sitepulse-dashboard-preview .sitepulse-grid--cols-1 {
     grid-template-columns: repeat(1, minmax(0, 1fr));
 }
 
-.wp-block-sitepulse-dashboard-preview .sitepulse-grid--cols-2 {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.wp-block-sitepulse-dashboard-preview .sitepulse-grid--cols-3 {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
+.wp-block-sitepulse-dashboard-preview .sitepulse-grid--cols-2,
+.wp-block-sitepulse-dashboard-preview .sitepulse-grid--cols-3,
 .wp-block-sitepulse-dashboard-preview .sitepulse-grid--cols-4 {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(
+        auto-fit,
+        minmax(var(--sitepulse-dashboard-card-min-width, 260px), 1fr)
+    );
 }
 
 .wp-block-sitepulse-dashboard-preview .sitepulse-grid--variant-list {
@@ -49,6 +50,34 @@
     flex-direction: column;
     grid-template-columns: none;
     gap: var(--wp--style--block-gap, var(--sitepulse-dashboard-gap, 20px));
+}
+
+@media (min-width: 48rem) {
+    .wp-block-sitepulse-dashboard-preview .sitepulse-grid--cols-2 {
+        grid-template-columns: repeat(
+            2,
+            minmax(var(--sitepulse-dashboard-card-min-width, 260px), 1fr)
+        );
+    }
+}
+
+@media (min-width: 60rem) {
+    .wp-block-sitepulse-dashboard-preview .sitepulse-grid--cols-3,
+    .wp-block-sitepulse-dashboard-preview .sitepulse-grid--cols-4 {
+        grid-template-columns: repeat(
+            3,
+            minmax(var(--sitepulse-dashboard-card-min-width, 260px), 1fr)
+        );
+    }
+}
+
+@media (min-width: 75rem) {
+    .wp-block-sitepulse-dashboard-preview .sitepulse-grid--cols-4 {
+        grid-template-columns: repeat(
+            4,
+            minmax(var(--sitepulse-dashboard-card-min-width, 260px), 1fr)
+        );
+    }
 }
 
 .wp-block-sitepulse-dashboard-preview .sitepulse-card {

--- a/sitepulse_FR/docs/revue-2024-07.md
+++ b/sitepulse_FR/docs/revue-2024-07.md
@@ -1,0 +1,44 @@
+# Revue technique – juillet 2024
+
+## Synthèse
+
+- Périmètre audité : bloc Gutenberg « Aperçu SitePulse », helpers PHP communs (`sitepulse.php`) et feuilles de style associées.
+- Priorités dégagées : fiabiliser l’analyse des séries temporelles dans le bloc, réduire la duplication de gabarits PHP et consolider la configuration globale du plugin.
+- Correctif visuel livré : nouvelles largeurs minimales et points de rupture pour éviter l’écrasement des cartes dans les grilles multi-colonnes.
+
+## Analyse du code
+
+### 1. Stabiliser la détection des valeurs numériques dans les résumés
+
+- **Constat** : `sitepulse_dashboard_preview_render_dataset_summary()` détecte les entiers avec `floor($numeric_value) === $numeric_value`, ce qui échoue sur des floats proches d’un entier (ex. 99.999) et produit alors deux décimales fantômes dans le résumé.【F:sitepulse_FR/blocks/dashboard-preview/render.php†L23-L97】
+- **Impact** : les utilisateurs peuvent voir des valeurs incohérentes dans les listes textuelles (ex. `100.00` au lieu de `100`), ce qui décrédibilise les exports et l’accessibilité.
+- **Piste** : comparer avec une marge d’erreur (`abs($value - round($value)) < 0.0005`) ou réutiliser `wp_is_numeric_array` + `wp_is_integer()` pour garantir un rendu constant.
+
+### 2. Factoriser la génération des cartes du bloc
+
+- **Constat** : chaque carte du bloc (`speed`, `uptime`, `database`, `logs`) est rendue via un `sprintf()` quasi identique, seules les chaînes et métriques changent.【F:sitepulse_FR/blocks/dashboard-preview/render.php†L293-L415】
+- **Impact** : l’ajout d’un nouveau module ou la modification d’un motif (ex. ajout d’un badge) oblige à répéter les modifications sur quatre sections, augmentant le risque d’oublis.
+- **Piste** : encapsuler la configuration des cartes dans un tableau (label, description, métriques, callbacks de formatage) et itérer dessus pour alimenter un gabarit unique (`wp_kses_post( sitepulse_render_dashboard_card( $definition ) )`).
+
+### 3. Centraliser la déclaration des constantes globales
+
+- **Constat** : `sitepulse.php` définit plusieurs dizaines de constantes en appelant manuellement `sitepulse_define_constant()` à répétition.【F:sitepulse_FR/sitepulse.php†L33-L113】
+- **Impact** : maintenir ou renommer une option nécessite de retrouver chaque ligne, sans validation croisée ; la lisibilité en pâtit et les tests d’intégration ne disposent pas d’une source unique de vérité.
+- **Piste** : déplacer ces définitions dans un tableau associatif (`$option_constants = ['SITEPULSE_OPTION_ACTIVE_MODULES' => 'sitepulse_active_modules', …]`) parcouru dans une boucle, ou exposer un filtre (`sitepulse_register_constants`) pour laisser les modules étendre la configuration proprement.
+
+## Débogage visuel & CSS
+
+- **Symptôme observé** : les classes `sitepulse-grid--cols-3/4` forçaient des colonnes en `minmax(0, 1fr)`, ce qui compressait les cartes à moins de 200 px sur tablette/mobile malgré le choix d’un affichage « spacieux ».
+- **Correctifs appliqués** :
+  - ajout d’une variable `--sitepulse-dashboard-card-min-width` et d’un gabarit `auto-fit` commun pour préserver la largeur minimale des cartes ;
+  - définition de points de rupture progressifs (48 rem, 60 rem, 75 rem) pour n’autoriser respectivement 2, 3 puis 4 colonnes maximales.【F:sitepulse_FR/blocks/dashboard-preview/style.css†L1-L81】
+- **Recette visuelle** :
+  1. Ouvrir `sitepulse_FR/docs/visual-debug/dashboard-preview.html` dans un navigateur ;
+  2. Redimensionner entre 360 px et 1400 px de large ;
+  3. Vérifier que la grille passe de 1 → 2 → 3 → 4 colonnes sans que les cartes soient écrasées.【F:sitepulse_FR/docs/visual-debug/dashboard-preview.html†L1-L112】
+
+## Suivi recommandé
+
+1. Prioriser un ticket « refactor bloc dashboard » pour capitaliser sur la factorisation proposée avant d’ajouter de nouveaux modules.
+2. Couvrir `sitepulse_dashboard_preview_render_dataset_summary()` par des tests PHPUnit additionnels (cas limites décimaux) afin de sécuriser le formatage.
+3. Documenter la convention des constantes dans le README technique pour faciliter l’onboarding et les revues futures.

--- a/sitepulse_FR/docs/visual-debug/dashboard-preview.html
+++ b/sitepulse_FR/docs/visual-debug/dashboard-preview.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="utf-8" />
+    <title>Debug visuel – Aperçu SitePulse</title>
+    <link rel="stylesheet" href="../../blocks/dashboard-preview/style.css" />
+    <link rel="stylesheet" href="../../modules/css/custom-dashboard.css" />
+    <style>
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            background: #f6f7f7;
+            color: #1d2327;
+            padding: 32px;
+        }
+
+        .debug-wrapper {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .debug-wrapper h1 {
+            font-size: 24px;
+            margin-bottom: 16px;
+        }
+
+        .debug-note {
+            margin-bottom: 24px;
+            color: #3c434a;
+        }
+
+        .sitepulse-card {
+            background: #fff;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        }
+
+        .sitepulse-card .sitepulse-card-header h3 {
+            margin: 0 0 8px;
+        }
+
+        .sitepulse-card .sitepulse-card-subtitle {
+            margin: 0 0 16px;
+            color: #50575e;
+        }
+
+        .sitepulse-card .sitepulse-metric {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            font-size: 18px;
+            margin: 0 0 16px;
+        }
+
+        .sitepulse-legend {
+            list-style: none;
+            margin: 0 0 16px;
+            padding: 0;
+            display: grid;
+            gap: 8px;
+        }
+
+        .sitepulse-legend .label {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .sitepulse-legend .badge {
+            display: inline-block;
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+        }
+    </style>
+</head>
+<body>
+    <div class="debug-wrapper">
+        <h1>Débogage visuel – Bloc « Aperçu SitePulse »</h1>
+        <p class="debug-note">
+            Redimensionnez la fenêtre pour vérifier le comportement des colonnes après l'ajout des points de rupture responsives.
+        </p>
+        <div class="wp-block-sitepulse-dashboard-preview sitepulse-dashboard-preview--layout-grid sitepulse-dashboard-preview--density-comfortable sitepulse-dashboard-preview--columns-4">
+            <div class="sitepulse-dashboard-preview__header">
+                <h3>Aperçu SitePulse</h3>
+                <p>Dernières mesures agrégées par vos modules actifs.</p>
+            </div>
+            <div class="sitepulse-grid sitepulse-grid--cols-4 sitepulse-grid--density-comfortable sitepulse-grid--variant-grid">
+                <section class="sitepulse-card sitepulse-card--speed">
+                    <div class="sitepulse-card-header"><h3>Performance PHP</h3></div>
+                    <p class="sitepulse-card-subtitle">Dernier temps de traitement mesuré lors d’un scan récent.</p>
+                    <div class="sitepulse-chart-container">
+                        <div class="sitepulse-chart-placeholder">Graphique simulé</div>
+                    </div>
+                    <p class="sitepulse-metric">
+                        <span class="status-badge status-ok" aria-hidden="true"><span class="status-icon">✅</span><span class="status-text">OK</span></span>
+                        <span class="sitepulse-metric-value">215&nbsp;ms</span>
+                    </p>
+                    <p class="description">En dessous de 200&nbsp;ms, tout va bien. Au-delà de 500&nbsp;ms, investiguez.</p>
+                </section>
+                <section class="sitepulse-card sitepulse-card--uptime">
+                    <div class="sitepulse-card-header"><h3>Disponibilité</h3></div>
+                    <p class="sitepulse-card-subtitle">Taux de réussite des 30 dernières vérifications horaires.</p>
+                    <div class="sitepulse-chart-container">
+                        <div class="sitepulse-chart-placeholder">Graphique simulé</div>
+                    </div>
+                    <p class="sitepulse-metric">
+                        <span class="status-badge status-ok" aria-hidden="true"><span class="status-icon">📈</span><span class="status-text">OK</span></span>
+                        <span class="sitepulse-metric-value">99,4<span class="sitepulse-metric-unit">%</span></span>
+                    </p>
+                    <p class="description">Chaque barre représente une vérification de disponibilité programmée.</p>
+                </section>
+                <section class="sitepulse-card sitepulse-card--database">
+                    <div class="sitepulse-card-header"><h3>Santé de la base</h3></div>
+                    <p class="sitepulse-card-subtitle">Volume des révisions par rapport au budget défini.</p>
+                    <div class="sitepulse-chart-container">
+                        <div class="sitepulse-chart-placeholder">Graphique simulé</div>
+                    </div>
+                    <p class="sitepulse-metric">
+                        <span class="status-badge status-warn" aria-hidden="true"><span class="status-icon">⚠️</span><span class="status-text">Attention</span></span>
+                        <span class="sitepulse-metric-value">340<span class="sitepulse-metric-unit">révisions</span></span>
+                    </p>
+                    <p class="description">Essayez de rester sous la barre des 250 révisions pour éviter les gonflements.</p>
+                </section>
+                <section class="sitepulse-card sitepulse-card--logs">
+                    <div class="sitepulse-card-header"><h3>Journal d’erreurs</h3></div>
+                    <p class="sitepulse-card-subtitle">Répartition des évènements récents.</p>
+                    <div class="sitepulse-chart-container">
+                        <div class="sitepulse-chart-placeholder">Graphique simulé</div>
+                    </div>
+                    <p class="sitepulse-metric">
+                        <span class="status-badge status-warn" aria-hidden="true"><span class="status-icon">⚠️</span><span class="status-text">Surveillance</span></span>
+                        <span class="sitepulse-metric-value">56 alertes</span>
+                    </p>
+                    <ul class="sitepulse-legend">
+                        <li><span class="label"><span class="badge" style="background-color:#a0141e"></span>Erreurs fatales</span><span class="value">3</span></li>
+                        <li><span class="label"><span class="badge" style="background-color:#8a6100"></span>Avertissements</span><span class="value">18</span></li>
+                        <li><span class="label"><span class="badge" style="background-color:#2196F3"></span>Notices</span><span class="value">22</span></li>
+                        <li><span class="label"><span class="badge" style="background-color:#9C27B0"></span>Obsolescences</span><span class="value">13</span></li>
+                    </ul>
+                    <p class="description">Analysez le journal complet depuis l’interface SitePulse pour plus de détails.</p>
+                </section>
+            </div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- documente les constats et pistes d’amélioration pour le bloc « Aperçu SitePulse » et la configuration globale
- ajoute un scénario de débogage visuel reproductible pour vérifier la grille du bloc
- ajuste les variables CSS et les points de rupture afin d’éviter la compression des cartes en affichage multi-colonnes

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68e563583044832e80287f23b8b23ea3