### PR TITLE
Fix dashboard preview summary rounding

### DIFF
--- a/sitepulse_FR/blocks/dashboard-preview/render.php
+++ b/sitepulse_FR/blocks/dashboard-preview/render.php
@@ -56,8 +56,14 @@ if (!function_exists('sitepulse_render_dashboard_preview_block')) {
 
                 if (is_numeric($value)) {
                     $numeric_value = (float) $value;
-                    $precision = (floor($numeric_value) === $numeric_value) ? 0 : 2;
-                    $values[] = number_format_i18n($numeric_value, $precision);
+                    $rounded_integer = round($numeric_value);
+                    $is_near_integer = abs($numeric_value - $rounded_integer) < 0.001;
+
+                    if ($is_near_integer) {
+                        $values[] = number_format_i18n($rounded_integer, 0);
+                    } else {
+                        $values[] = number_format_i18n(round($numeric_value, 2), 2);
+                    }
                 } elseif (is_scalar($value)) {
                     $values[] = (string) $value;
                 }

--- a/tests/phpunit/test-dashboard-preview-summary.php
+++ b/tests/phpunit/test-dashboard-preview-summary.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Tests for the dashboard preview block summaries.
+ */
+
+require_once dirname(__DIR__, 2) . '/sitepulse_FR/blocks/dashboard-preview/render.php';
+
+class Sitepulse_Dashboard_Preview_Summary_Test extends WP_UnitTestCase {
+    public function test_near_integer_values_are_rendered_without_decimals(): void {
+        $chart = [
+            'labels'   => ['Disponibilité'],
+            'datasets' => [
+                [
+                    'data' => [99.999],
+                ],
+            ],
+        ];
+
+        $summary = sitepulse_dashboard_preview_render_dataset_summary($chart);
+
+        $this->assertIsArray($summary);
+        $this->assertArrayHasKey('html', $summary);
+        $this->assertMatchesRegularExpression(
+            '/<span class="sitepulse-preview-list__value">100<\/span>/',
+            $summary['html']
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/<span class="sitepulse-preview-list__value">100(?:\.|,)00<\/span>/',
+            $summary['html']
+        );
+    }
+
+    public function test_decimal_values_keep_two_decimals(): void {
+        $chart = [
+            'labels'   => ['Temps de réponse'],
+            'datasets' => [
+                [
+                    'data' => [54.125],
+                ],
+            ],
+        ];
+
+        $summary = sitepulse_dashboard_preview_render_dataset_summary($chart);
+
+        $this->assertIsArray($summary);
+        $this->assertArrayHasKey('html', $summary);
+        $this->assertMatchesRegularExpression(
+            '/<span class="sitepulse-preview-list__value">54(?:\.|,)13<\/span>/',
+            $summary['html']
+        );
+    }
+}
+


### PR DESCRIPTION
## Summary
- adjust the dashboard preview summary formatter to treat near-integer datapoints as whole numbers and stabilise decimal rounding
- add PHPUnit coverage ensuring the summary output omits spurious .00 suffixes and keeps two decimals when required

## Testing
- phpunit *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5762685d8832e9c0eb2b779cc8554