### PR TITLE
Address near-integer boundary in dashboard preview rounding

### DIFF
--- a/sitepulse_FR/blocks/dashboard-preview/render.php
+++ b/sitepulse_FR/blocks/dashboard-preview/render.php
@@ -57,7 +57,7 @@ if (!function_exists('sitepulse_render_dashboard_preview_block')) {
                 if (is_numeric($value)) {
                     $numeric_value = (float) $value;
                     $rounded_integer = round($numeric_value);
-                    $is_near_integer = abs($numeric_value - $rounded_integer) < 0.001;
+                    $is_near_integer = abs($numeric_value - $rounded_integer) <= 0.001;
 
                     if ($is_near_integer) {
                         $values[] = number_format_i18n($rounded_integer, 0);


### PR DESCRIPTION
## Summary
- ensure values within the tolerance threshold, including exact 0.001 offsets, are rendered without decimals in the dashboard preview summary

## Testing
- not run (phpunit unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e57af414e0832e8a5c526062cbf5fb