### PR TITLE
feat(speed): support multi-profile thresholds in automation

### DIFF
--- a/sitepulse_FR/modules/css/speed-analyzer.css
+++ b/sitepulse_FR/modules/css/speed-analyzer.css
@@ -170,3 +170,38 @@
         border-bottom-width: 2px;
     }
 }
+.speed-history-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+}
+
+.speed-history-profile {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 13px;
+    max-width: 420px;
+}
+
+.speed-history-profile .profile-title {
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+}
+
+.speed-history-profile .profile-description {
+    color: var(--wp-admin-color-gray-700, #50575e);
+}
+
+.is-dark .speed-history-profile .profile-description {
+    color: var(--wp-admin-color-gray-0, #ffffff);
+}
+
+@media (prefers-color-scheme: dark) {
+    .speed-history-profile .profile-description {
+        color: var(--wp-admin-color-gray-0, #ffffff);
+    }
+}
+


### PR DESCRIPTION
## Summary
- extend the speed analyzer thresholds and automation presets to track a normalized profile (desktop/mobile/default) and expose matching metadata through localized/AJAX payloads
- enrich the admin UI with a profile selector, active profile badge, and a profile column in the automation table while styling the new controls
- update the dashboard script to switch threshold overlays per source, refresh manual thresholds from automation payloads, and surface profile descriptions client-side

## Testing
- php -l sitepulse_FR/modules/speed_analyzer.php
- node --check sitepulse_FR/modules/js/speed-analyzer.js

------
https://chatgpt.com/codex/tasks/task_e_68e59b538acc832ea421a13cffb89670