### PR TITLE
Enhance plugin impact disk usage telemetry

### DIFF
--- a/sitepulse_FR/modules/js/plugin-impact-scanner.js
+++ b/sitepulse_FR/modules/js/plugin-impact-scanner.js
@@ -73,6 +73,8 @@
                 weight: parseNumber(row.dataset.weight),
                 samples: parseNumber(row.dataset.samples),
                 diskSpace: parseNumber(row.dataset.diskSpace),
+                diskFiles: parseNumber(row.dataset.diskFiles),
+                diskRecorded: parseNumber(row.dataset.diskRecorded),
                 lastRecorded: parseNumber(row.dataset.lastRecorded),
                 isMeasured: row.dataset.isMeasured === '1',
             };


### PR DESCRIPTION
## Summary
- capture plugin directory file counts and timestamps when caching disk usage metrics
- expose the additional metadata on the Plugin Impact admin table so operators can assess freshness and file counts

## Testing
- php -l sitepulse_FR/modules/plugin_impact_scanner.php

------
https://chatgpt.com/codex/tasks/task_e_68e639e378bc832eabaffb374e837b33