### PR TITLE
Fix job secret filter callback in tests

### DIFF
--- a/tests/phpunit/test-ai-insights.php
+++ b/tests/phpunit/test-ai-insights.php
@@ -377,7 +377,7 @@ class Sitepulse_AI_Insights_Ajax_Test extends WP_Ajax_UnitTestCase {
         $this->assertIsString($stored_secret);
         $this->assertSame(64, strlen($stored_secret));
 
-        $filter = static function () {
+        $filter = static function ($secret) {
             return 'filtered-secret-value';
         };
 


### PR DESCRIPTION
## Summary
- add regression coverage for AI insight variant sanitization, including HTML fallbacks
- ensure AI insight job secrets remain stable while still honoring filters
- fix the AI job secret filter test callback to accept the secret argument so PHP 8 can invoke it safely

## Testing
- not run (phpunit unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e655c5ee70832e9f6ed2e5d048a75b