### PR TITLE
Improve AI job secret filter test

### DIFF
--- a/tests/phpunit/test-ai-insights.php
+++ b/tests/phpunit/test-ai-insights.php
@@ -377,8 +377,8 @@ class Sitepulse_AI_Insights_Ajax_Test extends WP_Ajax_UnitTestCase {
         $this->assertIsString($stored_secret);
         $this->assertSame(64, strlen($stored_secret));
 
-        $filter = static function () {
-            return 'filtered-secret-value';
+        $filter = static function ($secret) {
+            return 'filtered-' . $secret;
         };
 
         add_filter('sitepulse_ai_job_secret', $filter);
@@ -387,7 +387,7 @@ class Sitepulse_AI_Insights_Ajax_Test extends WP_Ajax_UnitTestCase {
 
         remove_filter('sitepulse_ai_job_secret', $filter);
 
-        $this->assertSame('filtered-secret-value', $filtered_secret);
+        $this->assertSame('filtered-' . $stored_secret, $filtered_secret);
         $this->assertSame($stored_secret, sitepulse_ai_get_job_secret());
     }
 


### PR DESCRIPTION
## Summary
- update the job secret filter test callback to accept the generated secret and return a derived value
- assert that the filtered secret reflects the original value passed through the filter

## Testing
- not run (phpunit unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e655c5ee70832e9f6ed2e5d048a75b