### PR TITLE
Fix dashboard preview fallback status badge class

### DIFF
--- a/sitepulse_FR/blocks/dashboard-preview/render.php
+++ b/sitepulse_FR/blocks/dashboard-preview/render.php
@@ -265,7 +265,13 @@ if (!function_exists('sitepulse_render_dashboard_preview_block')) {
         $chart_html = sitepulse_dashboard_preview_render_chart_area($chart_id, $chart_payload);
 
         $status_meta = sitepulse_dashboard_preview_get_status_meta($status, $status_labels);
-        $status_badge_class = sanitize_html_class($status);
+        $status_badge_class = '';
+
+        if (is_string($status) && $status !== '' && isset($status_labels[$status])) {
+            $status_badge_class = sanitize_html_class($status);
+        } elseif (isset($status_labels['status-warn'])) {
+            $status_badge_class = 'status-warn';
+        }
 
         return sprintf(
             '<section class="%1$s"><div class="sitepulse-card-header"><h3>%2$s</h3></div><p class="sitepulse-card-subtitle">%3$s</p>%4$s<p class="sitepulse-metric"><span class="status-badge %5$s" aria-hidden="true"><span class="status-icon">%6$s</span><span class="status-text">%7$s</span></span><span class="screen-reader-text">%8$s</span>%9$s</p>%10$s<p class="description">%11$s</p></section>',

--- a/tests/phpunit/test-dashboard-preview-summary.php
+++ b/tests/phpunit/test-dashboard-preview-summary.php
@@ -49,5 +49,33 @@ class Sitepulse_Dashboard_Preview_Summary_Test extends WP_UnitTestCase {
             $summary['html']
         );
     }
+
+    public function test_status_badge_falls_back_to_warning_when_status_missing(): void {
+        $definition = [
+            'title'       => 'Test card',
+            'subtitle'    => 'Subtitle',
+            'description' => 'Description',
+            'chart'       => [
+                'labels'   => ['foo'],
+                'datasets' => [
+                    [
+                        'data' => [1],
+                    ],
+                ],
+            ],
+        ];
+
+        $status_labels = [
+            'status-warn' => [
+                'label' => 'Warning',
+                'sr'    => 'Statut avertissement',
+                'icon'  => '!',
+            ],
+        ];
+
+        $markup = sitepulse_dashboard_preview_render_card_section($definition, $status_labels);
+
+        $this->assertStringContainsString('class="status-badge status-warn"', $markup);
+    }
 }
 


### PR DESCRIPTION
## Summary
- ensure the dashboard preview card falls back to the warning badge class when no status is provided
- cover the fallback behaviour with a regression test in the dashboard preview PHPUnit suite

## Testing
- phpunit *(fails: WordPress tests not installed in /tmp/wordpress-tests-lib)*

------
https://chatgpt.com/codex/tasks/task_e_68e67000fa60832e8b2814dc0cdf8069