### PR TITLE
Update docs for new uptime tracker capabilities

### DIFF
--- a/sitepulse_FR/ASSESSMENT.md
+++ b/sitepulse_FR/ASSESSMENT.md
@@ -9,8 +9,8 @@
 ### État actuel
 - Les réglages centralisent l’activation des modules, la clé Gemini, les destinataires d’alertes, les seuils vitesse/uptime et quelques fenêtres de maintenance.【F:sitepulse_FR/includes/admin-settings.php†L1745-L2056】
 - Les seuils de performance ne gèrent que deux niveaux (avertissement/critique) par profil, ce qui limite la granularité par rapport aux suites qui surveillent LCP, INP ou CLS séparément.【F:sitepulse_FR/includes/functions.php†L210-L275】
-- L’historique d’uptime se limite aux 30 derniers événements, ce qui empêche tout calcul d’indicateurs SLA sur 90 jours ou 12 mois.【F:sitepulse_FR/modules/uptime_tracker.php†L2183-L2207】
-- Un seul agent « global » est provisionné par défaut et il n’existe pas d’interface pour déclarer plusieurs sondes régionales avec leurs URL dédiées.【F:sitepulse_FR/modules/uptime_tracker.php†L254-L293】
+- La rétention d’uptime est désormais configurable entre 30 et 365 jours (`sitepulse_get_uptime_history_retention_days()`), mais aucun rapport SLA consolidé n’est généré automatiquement pour capitaliser sur ces fenêtres étendues.【F:sitepulse_FR/modules/uptime_tracker.php†L1004-L1028】
+- Le plugin sait charger plusieurs agents (`SITEPULSE_OPTION_UPTIME_AGENTS`) et orchestrer une file d’attente de jobs distants, toutefois l’interface d’administration ne propose pas encore de gestion CRUD avancée (ajout/suspension d’agents, pondération) ni de métriques associées.【F:sitepulse_FR/modules/uptime_tracker.php†L277-L346】【F:sitepulse_FR/modules/uptime_tracker.php†L696-L820】
 - Les analyses IA sont planifiées via un unique événement WP-Cron et, en cas d’échec de planification, exécutées immédiatement sans file d’attente priorisée ni reprise automatique des erreurs.【F:sitepulse_FR/modules/ai_insights.php†L1769-L1890】
 
 ### Pistes d’alignement « pro »
@@ -62,7 +62,7 @@
 ## 6. Intégrations & API
 ### État actuel
 - Les routes REST existantes orchestrent surtout les process internes (queue uptime, tests d’alertes) et reposent sur l’authentification WordPress classique.【F:sitepulse_FR/modules/uptime_tracker.php†L112-L168】【F:sitepulse_FR/modules/error_alerts.php†L1430-L1458】
-- Le suivi uptime conserve un log local limité à 30 entrées, malgré une archive optionnelle, ce qui freine la diffusion vers des tableaux de bord externes.【F:sitepulse_FR/modules/uptime_tracker.php†L2183-L2207】
+- Le suivi uptime persiste désormais jusqu’à 365 jours d’historique selon la configuration, mais aucune API REST n’expose encore ces séries longues pour alimenter des dashboards externes (Grafana, Better Uptime).【F:sitepulse_FR/modules/uptime_tracker.php†L1004-L1028】
 - Le module Resource Monitor stocke des snapshots sur une fenêtre d’environ 24 h (TTL `DAY_IN_SECONDS`) et 288 points maximum, sans mécanisme d’export ni de normalisation vers des standards type OpenTelemetry.【F:sitepulse_FR/modules/resource_monitor.php†L827-L845】【F:sitepulse_FR/modules/resource_monitor.php†L998-L1023】
 
 ### Recommandations « pro »

--- a/sitepulse_FR/IMPROVEMENTS.md
+++ b/sitepulse_FR/IMPROVEMENTS.md
@@ -38,11 +38,11 @@ Ce document répertorie les fonctions de SitePulse qui gagneraient à être alig
 
 ## Module « Uptime Tracker »
 
-- **Constat :** l'historique conserve uniquement les 30 derniers points et un seul agent actif, ce qui limite la profondeur d'analyse et la corrélation multi-région par rapport à des outils comme Pingdom ou Better Uptime qui agrègent plusieurs sondes et publient des SLA détaillés.【F:sitepulse_FR/modules/uptime_tracker.php†L2203-L2288】【F:sitepulse_FR/modules/uptime_tracker.php†L258-L320】
+- **Constat :** le module gère désormais plusieurs agents (`SITEPULSE_OPTION_UPTIME_AGENTS`), une file d’attente de jobs distants et une rétention configurable entre 30 et 365 jours, mais il manque encore un reporting SLA consolidé et des garde-fous sur la taille de la queue distante pour s’aligner sur les consoles pro.【F:sitepulse_FR/modules/uptime_tracker.php†L277-L346】【F:sitepulse_FR/modules/uptime_tracker.php†L696-L820】【F:sitepulse_FR/modules/uptime_tracker.php†L1004-L1028】
 - **Pistes pro :**
-  - Permettre la configuration de multiples agents géographiques avec pondération et tests parallèles, puis générer des rapports SLA mensuels exportables.
-  - Étendre la fenêtre d'historique (via options et stockage personnalisé) pour autoriser des rétrospectives de 90 jours/12 mois et la corrélation avec les annotations de maintenance.
-  - Ajouter des canaux d'alerte temps réel (webhooks dédiés, SMS) et une page de statut publique afin de se rapprocher des offres premium.
+  - Générer des rapports SLA mensuels (CSV/PDF) agrégeant tous les agents et intégrant les fenêtres de maintenance (`sitepulse_uptime_get_agents()` + annotations) pour rivaliser avec Pingdom/Better Uptime.
+  - Introduire une politique de rétention spécifique à la file distante (taille max, purge automatique des jobs échoués) et des métriques de supervision (compteur de jobs en attente) pour prévenir les dérives en cas de Cron inactif.
+  - Ajouter des canaux d’alerte temps réel (webhooks dédiés, SMS) et une page de statut publique afin de se rapprocher des offres premium.
 
 ## Module « Resource Monitor »
 

--- a/sitepulse_FR/README.md
+++ b/sitepulse_FR/README.md
@@ -52,7 +52,7 @@ Toggle modules in the admin panel to keep it lightweight. Includes debug mode an
 | --- | --- | --- |
 | **Speed Analyzer** | Mesurer la performance front-end | Scans manuels et planifiés, agrégation mobile/desktop, recommandations contextualisées, budgets de vitesse personnalisables |
 | **Database Optimizer** | Nettoyer et optimiser la base | Purge des révisions/transients, historique des opérations, seuils ajustables et notifications de nettoyage |
-| **Uptime Tracker** | Surveiller la disponibilité | Agents programmables, historique 30 points, export CSV, intégration Site Health, maintenance windows configurables |
+| **Uptime Tracker** | Surveiller la disponibilité | Agents multiples avec file d’attente distants, rétention 30-365 jours, export CSV, intégration Site Health, fenêtres de maintenance ciblées par agent |
 | **Resource Monitor** | Suivre CPU/RAM/Disque | Snapshots réguliers, historique 24 h, export JSON/CSV, alertes visuelles basées sur les seuils |
 | **Error Alerts** | Détecter les erreurs PHP/JS | Lecture sécurisée de `debug.log`, webhooks Slack/Teams/Discord, filtrage par gravité, journal d’alertes |
 | **AI Insights** | Générer des recommandations | Orchestrateur Gemini avec cache, historique commentable, export CSV/clipboard, module de notes collaboratif |

--- a/sitepulse_FR/docs/revue-2024-07.md
+++ b/sitepulse_FR/docs/revue-2024-07.md
@@ -10,21 +10,18 @@
 
 ### 1. Stabiliser la détection des valeurs numériques dans les résumés
 
-- **Constat** : `sitepulse_dashboard_preview_render_dataset_summary()` détecte les entiers avec `floor($numeric_value) === $numeric_value`, ce qui échoue sur des floats proches d’un entier (ex. 99.999) et produit alors deux décimales fantômes dans le résumé.【F:sitepulse_FR/blocks/dashboard-preview/render.php†L23-L97】
-- **Impact** : les utilisateurs peuvent voir des valeurs incohérentes dans les listes textuelles (ex. `100.00` au lieu de `100`), ce qui décrédibilise les exports et l’accessibilité.
-- **Piste** : comparer avec une marge d’erreur (`abs($value - round($value)) < 0.0005`) ou réutiliser `wp_is_numeric_array` + `wp_is_integer()` pour garantir un rendu constant.
+- ✅ **Résolu** : `sitepulse_dashboard_preview_render_dataset_summary()` compare désormais la valeur arrondie à l’entier le plus proche avec une marge de 0.0005 et formate dynamiquement en entier ou deux décimales selon le résultat. Les résumés textuels n’affichent plus de `100.00` spurieux sur des données quasi entières.【F:sitepulse_FR/blocks/dashboard-preview/render.php†L57-L69】
+- **Suivi** : conserver un test unitaire futur autour de cette tolérance pour éviter les régressions lors d’une refonte des presets.
 
 ### 2. Factoriser la génération des cartes du bloc
 
-- **Constat** : chaque carte du bloc (`speed`, `uptime`, `database`, `logs`) est rendue via un `sprintf()` quasi identique, seules les chaînes et métriques changent.【F:sitepulse_FR/blocks/dashboard-preview/render.php†L293-L415】
-- **Impact** : l’ajout d’un nouveau module ou la modification d’un motif (ex. ajout d’un badge) oblige à répéter les modifications sur quatre sections, augmentant le risque d’oublis.
-- **Piste** : encapsuler la configuration des cartes dans un tableau (label, description, métriques, callbacks de formatage) et itérer dessus pour alimenter un gabarit unique (`wp_kses_post( sitepulse_render_dashboard_card( $definition ) )`).
+- ✅ **Résolu** : la fonction `sitepulse_render_dashboard_preview_block()` construit désormais un tableau `$card_configs` et applique une unique routine de rendu pour chaque carte. Les titres, métriques et sous-titres sont injectés via des callbacks dédiés, ce qui simplifie l’ajout de nouveaux modules et garantit l’uniformité visuelle.【F:sitepulse_FR/blocks/dashboard-preview/render.php†L320-L420】【F:sitepulse_FR/blocks/dashboard-preview/render.php†L260-L319】
+- **Suivi** : prévoir une couverture de tests de snapshot HTML pour sécuriser les prochaines variations de cartes (icônes, badges).
 
 ### 3. Centraliser la déclaration des constantes globales
 
-- **Constat** : `sitepulse.php` définit plusieurs dizaines de constantes en appelant manuellement `sitepulse_define_constant()` à répétition.【F:sitepulse_FR/sitepulse.php†L33-L113】
-- **Impact** : maintenir ou renommer une option nécessite de retrouver chaque ligne, sans validation croisée ; la lisibilité en pâtit et les tests d’intégration ne disposent pas d’une source unique de vérité.
-- **Piste** : déplacer ces définitions dans un tableau associatif (`$option_constants = ['SITEPULSE_OPTION_ACTIVE_MODULES' => 'sitepulse_active_modules', …]`) parcouru dans une boucle, ou exposer un filtre (`sitepulse_register_constants`) pour laisser les modules étendre la configuration proprement.
+- ✅ **Résolu** : `sitepulse.php` délègue maintenant la déclaration des constantes à `includes/bootstrap/constants.php`, lequel renvoie un tableau exhaustif parcouru dans une boucle. L’onboarding est facilité et les extensions peuvent auditer l’inventaire des constantes depuis un endroit unique.【F:sitepulse_FR/sitepulse.php†L19-L35】【F:sitepulse_FR/includes/bootstrap/constants.php†L6-L86】
+- **Suivi** : documenter cette source de vérité dans le wiki interne et envisager un test qui vérifie que les options critiques sont bien déclarées (ex. `SITEPULSE_OPTION_UPTIME_AGENTS`).
 
 ## Débogage visuel & CSS
 


### PR DESCRIPTION
## Summary
- refresh the code review status note to mark previous blockers as fixed and highlight the new queue sizing risk
- mark the July 2024 technical review items as resolved and update the improvement/assessment docs for the multi-agent uptime tracker
- update the French README module table to document the extended retention and agent orchestration features

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e68e61db0c832eb0df6e4aec66d875